### PR TITLE
[location-component] Improve model scaling using expression.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/LocationComponentActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/LocationComponentActivity.kt
@@ -67,7 +67,8 @@ class LocationComponentActivity : AppCompatActivity() {
     mapView.getLocationComponentPlugin().let {
       if (it.locationPuck == null) {
         it.locationPuck = ThreeDLocationPuck(
-          modelUri = "asset://race_car_model.gltf"
+          modelUri = "asset://race_car_model.gltf",
+          modelScale = listOf(0.1f, 0.1f, 0.1f)
         )
       } else {
         it.locationPuck = null

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
@@ -98,21 +98,6 @@ class LocationComponentPluginImpl : LocationComponentPlugin, LocationComponentSe
   }
 
   /**
-   * Called whenever camera position changes.
-   */
-  override fun onCameraMove(
-    lat: Double,
-    lon: Double,
-    zoom: Double,
-    pitch: Double,
-    bearing: Double,
-    padding: Array<Double>?,
-    anchor: Pair<Double, Double>?
-  ) {
-    locationPuckManager?.updateCurrentZoomLevel(zoom)
-  }
-
-  /**
    * Bind the ViewPlugin with current map context. This will create a View that
    * will be added to the MapView.
    *

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerRenderer.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerRenderer.kt
@@ -63,10 +63,6 @@ internal class LocationIndicatorLayerRenderer(
     setLayerLocation(latLng)
   }
 
-  override fun setZoomLevel(zoomLevel: Double) {
-    // not supported
-  }
-
   override fun setBearing(bearing: Float) {
     setLayerBearing(bearing.toDouble())
   }

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationLayerRenderer.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationLayerRenderer.kt
@@ -22,8 +22,6 @@ internal interface LocationLayerRenderer {
 
   fun setLatLng(latLng: Point)
 
-  fun setZoomLevel(zoomLevel: Double)
-
   fun setBearing(bearing: Float)
 
   fun setAccuracyRadius(accuracy: Float)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -16,6 +16,4 @@ internal interface LocationPuckManager {
   fun updateCurrentPosition(point: Point)
 
   fun updateCurrentBearing(bearing: Float)
-
-  fun updateCurrentZoomLevel(zoomLevel: Double)
 }

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRenderer.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRenderer.kt
@@ -6,7 +6,6 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.plugin.ThreeDLocationPuck
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.MODEL_SOURCE
-import kotlin.math.pow
 
 internal class ModelLayerRenderer(
   layerSourceProvider: LayerSourceProvider,
@@ -50,11 +49,6 @@ internal class ModelLayerRenderer(
     setLayerLocation(latLng)
   }
 
-  override fun setZoomLevel(zoomLevel: Double) {
-    val scale = 2.0.pow(MAX_ZOOM_LEVEL - zoomLevel)
-    modelLayer.modelScale(locationModelLayerOptions.modelScale.map { it * scale })
-  }
-
   override fun setBearing(bearing: Float) {
     setLayerBearing(bearing.toDouble())
   }
@@ -63,6 +57,7 @@ internal class ModelLayerRenderer(
   }
 
   override fun styleScaling(scaleExpression: List<Value>) {
+    modelLayer.modelScaleExpression(scaleExpression)
   }
 
   override fun setLocationStale(isStale: Boolean) {
@@ -109,9 +104,5 @@ internal class ModelLayerRenderer(
   }
 
   override fun clearBitmaps() {
-  }
-
-  companion object {
-    internal const val MAX_ZOOM_LEVEL = 19
   }
 }

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapper.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapper.kt
@@ -18,5 +18,7 @@ internal class ModelLayerWrapper(
 
   fun modelScale(scale: List<Double>) = updateProperty("model-scale", Value(scale.map { Value(it) }))
 
+  fun modelScaleExpression(scaleExpression: List<Value>) = updateProperty("model-scale", Value(scaleExpression))
+
   fun modelRotation(rotation: List<Double>) = updateProperty("model-rotation", Value(rotation.map { Value(it) }))
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPlugin.kt
@@ -1,18 +1,15 @@
 package com.mapbox.maps.plugin.locationcomponent
 
-import com.mapbox.maps.plugin.ContextBinder
-import com.mapbox.maps.plugin.LifecyclePlugin
-import com.mapbox.maps.plugin.MapCameraPlugin
-import com.mapbox.maps.plugin.MapStyleObserverPlugin
+import com.mapbox.maps.plugin.*
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettingsInterface
 
 /**
  * Define the interfaces for the Location plugin.
  */
 interface LocationComponentPlugin :
+  MapPlugin,
   MapStyleObserverPlugin,
   LifecyclePlugin,
-  MapCameraPlugin,
   ContextBinder,
   LocationConsumer,
   LocationComponentSettingsInterface {


### PR DESCRIPTION
This PR improves the 3d model scaling using expression.

![3d_model_scaling_expression](https://user-images.githubusercontent.com/2764714/105012552-f0420080-5a46-11eb-9771-df63d2247967.gif)

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


