### PR TITLE
Allow getCameraOptions with no padding parameter

### DIFF
--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapTransformDelegate.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapTransformDelegate.kt
@@ -18,7 +18,7 @@ interface MapTransformDelegate {
    *
    * @param edgeInsets The optional padding
    */
-  fun getCameraOptions(edgeInsets: EdgeInsets?): CameraOptions
+  fun getCameraOptions(edgeInsets: EdgeInsets? = null): CameraOptions
 
   /**
    * Notify map about gesture being in progress.


### PR DESCRIPTION
`<changelog>Allow getCameraOptions with no padding parameter</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


