### PR TITLE
OnCameraChangeListener is called only on actual camera update

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/InsetMapActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/InsetMapActivity.kt
@@ -100,22 +100,20 @@ class InsetMapActivity : AppCompatActivity(), OnCameraChangeListener {
     }
   }
 
-  override fun onCameraChange(changeEvent: CameraChange, mode: CameraChangeMode) {
-    if (changeEvent != CameraChange.CAMERA_WILL_CHANGE) {
-      val mainCameraPosition = mainMapboxMap.getCameraOptions(null)
-      val insetCameraPosition = CameraOptions.Builder()
-        .zoom(mainCameraPosition.zoom?.minus(ZOOM_DISTANCE_BETWEEN_MAIN_AND_INSET_MAPS))
-        .bearing(mainCameraPosition.bearing)
-        .center(mainCameraPosition.center)
-        .build()
-      mainMapboxMap.flyTo(
-        insetCameraPosition,
-        mapAnimationOptions {
-          duration = DURATION_MS
-        }
-      )
-      insetMapboxMap.getStyle { style -> updateInsetMapLineLayerBounds(style) }
-    }
+  override fun onCameraChanged() {
+    val mainCameraPosition = mainMapboxMap.getCameraOptions(null)
+    val insetCameraPosition = CameraOptions.Builder()
+      .zoom(mainCameraPosition.zoom?.minus(ZOOM_DISTANCE_BETWEEN_MAIN_AND_INSET_MAPS))
+      .bearing(mainCameraPosition.bearing)
+      .center(mainCameraPosition.center)
+      .build()
+    mainMapboxMap.flyTo(
+      insetCameraPosition,
+      mapAnimationOptions {
+        duration = DURATION_MS
+      }
+    )
+    insetMapboxMap.getStyle { style -> updateInsetMapLineLayerBounds(style) }
   }
 
   private fun updateInsetMapLineLayerBounds(fullyLoadedStyle: Style) {

--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
@@ -5,7 +5,6 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import com.mapbox.maps.CameraChange
 import com.mapbox.maps.Projection.getMetersPerPixelAtLatitude
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.delegates.listeners.OnCameraChangeListener
@@ -27,10 +26,8 @@ open class ScaleBarPluginImpl(
 
   override var internalSettings: ScaleBarSettings = ScaleBarSettings()
 
-  private val cameraChangeListener = OnCameraChangeListener { changeEvent, _ ->
-    if (changeEvent != CameraChange.CAMERA_WILL_CHANGE) {
-      invalidateScaleBar()
-    }
+  private val cameraChangeListener = OnCameraChangeListener {
+    invalidateScaleBar()
   }
 
   override fun applySettings() {

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/listeners/OnCameraChangeListener.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/listeners/OnCameraChangeListener.kt
@@ -1,19 +1,19 @@
 package com.mapbox.maps.plugin.delegates.listeners
 
-import com.mapbox.maps.CameraChange
-import com.mapbox.maps.CameraChangeMode
+import com.mapbox.maps.plugin.animation.CameraAnimationsLifecycleListener
+import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.CameraAnimatorChangeListener
 
 /**
  * Definition for listener invoked whenever the camera position changes.
- * See [CameraChange] and [CameraChangeMode].
  */
 fun interface OnCameraChangeListener {
 
   /**
    * Invoked whenever camera position changes.
    *
-   * @param changeEvent the [CameraChange] event
-   * @param mode the [CameraChangeMode] mode
+   * For more precise information about actual map camera animations
+   * please check [CameraAnimationsPlugin], [CameraAnimationsLifecycleListener] and [CameraAnimatorChangeListener]
    */
-  fun onCameraChange(changeEvent: CameraChange, mode: CameraChangeMode)
+  fun onCameraChanged()
 }

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -56,7 +56,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       this,
       dispatchTelemetryTurnstileEvent()
     )
-    this.cameraChangeListener = OnCameraChangeListener { _, _ ->
+    this.cameraChangeListener = OnCameraChangeListener {
       pluginRegistry.onCameraMove(nativeMap.getCameraOptions(null))
     }
     this.mapChangeListener = OnMapChangedListener {
@@ -91,7 +91,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     this.nativeMap = nativeMap
     this.mapboxMap = mapboxMap
     this.pluginRegistry = pluginRegistry
-    this.cameraChangeListener = OnCameraChangeListener { _, _ ->
+    this.cameraChangeListener = OnCameraChangeListener {
       pluginRegistry.onCameraMove(nativeMap.getCameraOptions(null))
     }
     this.mapChangeListener = mapChangeListener

--- a/sdk/src/main/java/com/mapbox/maps/NativeMapObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/NativeMapObserver.kt
@@ -60,7 +60,9 @@ internal class NativeMapObserver(private val mainHandler: Handler) : MapObserver
       return
     }
     mainHandler.post {
-      onCameraChangeListeners.forEach { it.onCameraChange(changeEvent, mode) }
+      if (changeEvent == CameraChange.CAMERA_DID_CHANGE) {
+        onCameraChangeListeners.forEach { it.onCameraChanged() }
+      }
     }
   }
 

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -135,7 +135,7 @@ class MapControllerTest {
     mapController.onStart()
     val onCameraChangeListener = onCameraChangeListenerSlot.captured
 
-    onCameraChangeListener.onCameraChange(mockk(), mockk())
+    onCameraChangeListener.onCameraChanged()
     verify { nativeMap.getCameraOptions(null) }
     verify { pluginRegistry.onCameraMove(cameraOptions) }
   }

--- a/sdk/src/test/java/com/mapbox/maps/NativeMapObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeMapObserverTest.kt
@@ -128,12 +128,21 @@ class NativeMapObserverTest {
   }
 
   @Test
-  fun addOnCameraChangeListener() {
+  fun addOnCameraChangeListenerDidChange() {
     val listener = mockk<OnCameraChangeListener>(relaxUnitFun = true)
     mapObserver.addOnCameraChangeListener(listener)
     mapObserver.onCameraChange(CameraChange.CAMERA_DID_CHANGE, CameraChangeMode.IMMEDIATE)
     runnableSlot.captured.run()
-    verify { listener.onCameraChange(CameraChange.CAMERA_DID_CHANGE, CameraChangeMode.IMMEDIATE) }
+    verify { listener.onCameraChanged() }
+  }
+
+  @Test
+  fun addOnCameraChangeListenerWillChange() {
+    val listener = mockk<OnCameraChangeListener>(relaxUnitFun = true)
+    mapObserver.addOnCameraChangeListener(listener)
+    mapObserver.onCameraChange(CameraChange.CAMERA_WILL_CHANGE, CameraChangeMode.IMMEDIATE)
+    runnableSlot.captured.run()
+    verify(exactly = 0) { listener.onCameraChanged() }
   }
 
   @Test
@@ -144,10 +153,7 @@ class NativeMapObserverTest {
     mapObserver.removeOnCameraChangeListener(listener)
     mapObserver.onCameraChange(CameraChange.CAMERA_DID_CHANGE, CameraChangeMode.IMMEDIATE)
     verify(exactly = 0) {
-      listener.onCameraChange(
-        CameraChange.CAMERA_DID_CHANGE,
-        CameraChangeMode.IMMEDIATE
-      )
+      listener.onCameraChanged()
     }
   }
 
@@ -160,10 +166,7 @@ class NativeMapObserverTest {
     mapObserver.onCameraChange(CameraChange.CAMERA_DID_CHANGE, CameraChangeMode.IMMEDIATE)
     runnableSlot.captured.run()
     verify(exactly = 0) {
-      listener.onCameraChange(
-        CameraChange.CAMERA_DID_CHANGE,
-        CameraChangeMode.IMMEDIATE
-      )
+      listener.onCameraChanged()
     }
   }
 


### PR DESCRIPTION
`<changelog>OnCameraChangeListener is called only on actual camera update</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


