### PR TITLE
Expose cameraForCoordinates for Snapshotter

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
@@ -12,6 +12,7 @@ import androidx.core.content.res.ResourcesCompat
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.common.Logger
+import com.mapbox.geojson.Point
 import com.mapbox.maps.attribution.AttributionLayout
 import com.mapbox.maps.attribution.AttributionMeasure
 import com.mapbox.maps.attribution.AttributionParser
@@ -136,6 +137,20 @@ class Snapshotter : MapSnapshotterObserver {
    */
   fun getRegion(): CoordinateBounds {
     return coreSnapshotter.region
+  }
+
+  /**
+   * Convenience method that returns the camera options object for given arguments
+   *
+   * @param coordinates The coordinates representing the bounds of the map
+   * @param padding The edge padding of the map
+   * @param bearing The bearing of the map
+   * @param pitch The pitch of the map
+   *
+   * @return Returns the camera options object representing the provided params
+   */
+  fun cameraForCoordinates(coordinates: List<Point>, padding: EdgeInsets, bearing: Double, pitch: Double): CameraOptions {
+    return coreSnapshotter.cameraForCoordinates(coordinates, padding, bearing, pitch)
   }
 
   /**

--- a/sdk/src/test/java/com/mapbox/maps/SnapshotterDelegateTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/SnapshotterDelegateTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps
 
 import com.mapbox.common.ShadowLogger
+import com.mapbox.geojson.Point
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -94,6 +95,14 @@ class SnapshotterDelegateTest {
   fun getRegion() {
     snapshotter.getRegion()
     verify { coreSnapshotter.region }
+  }
+
+  @Test
+  fun cameraForCoordinates() {
+    val coordinate = mockk<Point>()
+    val padding = mockk<EdgeInsets>()
+    snapshotter.cameraForCoordinates(listOf(coordinate), padding, 0.0, 0.0)
+    verify { coreSnapshotter.cameraForCoordinates(listOf(coordinate), padding, 0.0, 0.0) }
   }
 
   @Test


### PR DESCRIPTION
`<changelog>Expose cameraForCoordinates for Snapshotter</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


