### PR TITLE
[doc] Bump the dependency version number to v10.0.0-beta.12 in READMEs.

### DIFF
--- a/extension-observable/README.md
+++ b/extension-observable/README.md
@@ -53,7 +53,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.extension:maps-observable:10.0.0-beta.11'
+  implementation 'com.mapbox.extension:maps-observable:10.0.0-beta.12'
 }
 ```
 

--- a/extension-style/README.md
+++ b/extension-style/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.extension:maps-style:10.0.0-beta.11'
+  implementation 'com.mapbox.extension:maps-style:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-animation/README.md
+++ b/plugin-animation/README.md
@@ -34,7 +34,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-animation:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-animation:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -30,7 +30,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-annotation:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-annotation:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-attribution/README.md
+++ b/plugin-attribution/README.md
@@ -33,7 +33,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-attribution:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-attribution:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-compass/README.md
+++ b/plugin-compass/README.md
@@ -32,9 +32,9 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-compass:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-compass:10.0.0-beta.12'
   // Mapbox Maps Compass Plugin depends on the Mapbox Maps Animation Plugin
-  implementation 'com.mapbox.plugin:maps-animation:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-animation:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-gestures/README.md
+++ b/plugin-gestures/README.md
@@ -30,7 +30,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-gestures:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-gestures:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-location/README.md
+++ b/plugin-location/README.md
@@ -29,7 +29,7 @@ allprojects {
 }
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-location:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-location:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-locationcomponent/README.md
+++ b/plugin-locationcomponent/README.md
@@ -29,7 +29,7 @@ allprojects {
 }
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-locationcomponent:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-locationcomponent:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-logo/README.md
+++ b/plugin-logo/README.md
@@ -30,7 +30,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-logo:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-logo:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-overlay/README.md
+++ b/plugin-overlay/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-overlay:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-overlay:10.0.0-beta.12'
 }
 ```
 

--- a/plugin-scalebar/README.md
+++ b/plugin-scalebar/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-scalebar:10.0.0-beta.11'
+  implementation 'com.mapbox.plugin:maps-scalebar:10.0.0-beta.12'
 }
 ```
 


### PR DESCRIPTION
This PR bumps the dependency version number to v10.0.0-beta.12 in READMEs.

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


