### PR TITLE
[location-component] Add OnIndicatorPositionChangedListener and OnIndicatorBearingChangedListener.

### DIFF
--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
@@ -3,13 +3,18 @@ package com.mapbox.maps.plugin.locationcomponent.animators
 import android.animation.ValueAnimator
 import com.mapbox.geojson.Point
 import com.mapbox.maps.plugin.locationcomponent.LocationLayerRenderer
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorBearingChangedListener
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings
 import com.mapbox.maps.plugin.locationcomponent.utils.MathUtils
 
-internal class PuckAnimatorManager {
+internal class PuckAnimatorManager(
+  indicatorPositionChangedListener: OnIndicatorPositionChangedListener,
+  indicatorBearingChangedListener: OnIndicatorBearingChangedListener
+) {
 
-  private var bearingAnimator = PuckBearingAnimator()
-  private var pointAnimator = PuckPositionAnimator()
+  private var bearingAnimator = PuckBearingAnimator(indicatorBearingChangedListener)
+  private var pointAnimator = PuckPositionAnimator(indicatorPositionChangedListener)
   private var pulsingAnimator = PuckPulsingAnimator()
 
   fun setLocationLayerRenderer(renderer: LocationLayerRenderer) {

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckBearingAnimator.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckBearingAnimator.kt
@@ -1,8 +1,11 @@
 package com.mapbox.maps.plugin.locationcomponent.animators
 
-internal class PuckBearingAnimator : PuckAnimator<Double>(Evaluators.DOUBLE) {
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorBearingChangedListener
+
+internal class PuckBearingAnimator(private val indicatorBearingChangedListener: OnIndicatorBearingChangedListener) : PuckAnimator<Double>(Evaluators.DOUBLE) {
 
   override fun updateLayer(fraction: Float, value: Double) {
     locationRenderer?.setBearing(value)
+    indicatorBearingChangedListener.onIndicatorBearingChanged(value)
   }
 }

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckPositionAnimator.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckPositionAnimator.kt
@@ -1,10 +1,12 @@
 package com.mapbox.maps.plugin.locationcomponent.animators
 
 import com.mapbox.geojson.Point
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 
-internal class PuckPositionAnimator : PuckAnimator<Point>(Evaluators.POINT) {
+internal class PuckPositionAnimator(private val indicatorPositionChangedListener: OnIndicatorPositionChangedListener) : PuckAnimator<Point>(Evaluators.POINT) {
 
   override fun updateLayer(fraction: Float, value: Point) {
     locationRenderer?.setLatLng(value)
+    indicatorPositionChangedListener.onIndicatorPositionChanged(value)
   }
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPlugin.kt
@@ -23,4 +23,32 @@ interface LocationComponentPlugin :
    * @return The location provider currently under usage, and will return null if the location component plugin is not enabled and not initialised.
    */
   fun getLocationProvider(): LocationProvider?
+
+  /**
+   * Adds a listener that gets invoked when indicator position changes.
+   *
+   * @param listener Listener that gets invoked when indicator position changes
+   */
+  fun addOnIndicatorPositionChangedListener(listener: OnIndicatorPositionChangedListener)
+
+  /**
+   * Removes a listener that gets invoked when indicator position changes.
+   *
+   * @param listener Listener that gets invoked when indicator position changes.
+   */
+  fun removeOnIndicatorPositionChangedListener(listener: OnIndicatorPositionChangedListener)
+
+  /**
+   * Adds a listener that gets invoked when indicator bearing changes.
+   *
+   * @param listener Listener that gets invoked when indicator bearing changes
+   */
+  fun addOnIndicatorBearingChangedListener(listener: OnIndicatorBearingChangedListener)
+
+  /**
+   * Removes a listener that gets invoked when indicator bearing changes.
+   *
+   * @param listener Listener that gets invoked when indicator bearing changes.
+   */
+  fun removeOnIndicatorBearingChangedListener(listener: OnIndicatorBearingChangedListener)
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/OnIndicatorBearingChangedListener.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/OnIndicatorBearingChangedListener.kt
@@ -1,0 +1,13 @@
+package com.mapbox.maps.plugin.locationcomponent
+
+/**
+ * Listener that gets invoked when indicator bearing changes.
+ */
+fun interface OnIndicatorBearingChangedListener {
+  /**
+   * This method is called on each bearing change of the location indicator, including each animation frame.
+   *
+   * @param bearing indicator's bearing
+   */
+  fun onIndicatorBearingChanged(bearing: Double)
+}

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/OnIndicatorPositionChangedListener.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/OnIndicatorPositionChangedListener.kt
@@ -1,0 +1,15 @@
+package com.mapbox.maps.plugin.locationcomponent
+
+import com.mapbox.geojson.Point
+
+/**
+ * Listener that gets invoked when indicator position changes.
+ */
+fun interface OnIndicatorPositionChangedListener {
+  /**
+   * This method is called on each position change of the location indicator, including each animation frame.
+   *
+   * @param point indicator's position
+   */
+  fun onIndicatorPositionChanged(point: Point)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Add OnIndicatorPositionChangedListener and OnIndicatorBearingChangedListener.</changelog>`.

### Summary of changes

This PR adds the OnIndicatorPositionChangedListener and OnIndicatorBearingChangedListener to the location component plugin, these two callbacks will be called on each position and bearing change of the location indicator, including each animation frame.

This PR also updates the LocationComponentActivity to utilise the OnIndicatorPositionChangedListener and always have the location indicator centered.  And LocationTrackingActivity is updated to use LocationComponentPlugin instead of deprecated LocationPlugin.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->