### PR TITLE
[Annotation plugin] Add bitmap API for Symbol

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
@@ -86,16 +86,24 @@ class SymbolActivity : AppCompatActivity() {
             .withDraggable(true)
           symbol = create(symbolOptions)
         }
-        // create nearby symbols
-        val nearbyOptions: SymbolOptions = SymbolOptions()
-          .withPoint(Point.fromLngLat(NEARBY_LONGITUDE, NEARBY_LATITUDE))
-          .withIconImage(MAKI_ICON_CIRCLE)
-          .withIconColor(ColorUtils.colorToRgbaString(Color.YELLOW))
-          .withIconSize(2.5)
-          .withSymbolSortKey(5.0)
-          .withDraggable(true)
-        create(nearbyOptions)
 
+        BitmapUtils.getBitmapFromDrawable(
+          ResourcesCompat.getDrawable(
+            resources,
+            R.drawable.custom_user_arrow,
+            this@SymbolActivity.theme
+          )
+        )?.let {
+          // create nearby symbols
+          val nearbyOptions: SymbolOptions = SymbolOptions()
+            .withPoint(Point.fromLngLat(NEARBY_LONGITUDE, NEARBY_LATITUDE))
+            .withIconImage(it)
+            .withIconColor(ColorUtils.colorToRgbaString(Color.YELLOW))
+            .withIconSize(2.5)
+            .withSymbolSortKey(5.0)
+            .withDraggable(true)
+          create(nearbyOptions)
+        }
         // random add symbols across the globe
         val symbolOptionsList: MutableList<SymbolOptions> = ArrayList()
         for (i in 0..20) {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
@@ -1,7 +1,6 @@
 package com.mapbox.maps.testapp.examples.annotation
 
 import android.animation.ValueAnimator
-import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
@@ -37,7 +36,6 @@ class SymbolActivity : AppCompatActivity() {
   private var symbolManager: SymbolManager? = null
   private var symbol: Symbol? = null
   private val animators: MutableList<ValueAnimator> = mutableListOf()
-  private var airportImage: Bitmap? = null
   private var index: Int = 0
   private val nextStyle: String
     get() {
@@ -47,19 +45,7 @@ class SymbolActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_annotation)
-    airportImage = BitmapUtils.getBitmapFromDrawable(
-      ResourcesCompat.getDrawable(
-        resources,
-        R.drawable.ic_airplanemode_active_black_24dp,
-        this@SymbolActivity.theme
-      )
-    )
-
-    mapView.getMapboxMap().loadStyleUri(nextStyle) { style ->
-      airportImage?.let {
-        style.addImage(ID_ICON_AIRPORT, it, true)
-      }
-
+    mapView.getMapboxMap().loadStyleUri(nextStyle) {
       val annotationPlugin = mapView.getAnnotationPlugin()
       symbolManager = annotationPlugin.getSymbolManager(mapView).apply {
         addClickListener(
@@ -80,19 +66,26 @@ class SymbolActivity : AppCompatActivity() {
         iconAllowOverlap = true
         textAllowOverlap = true
 
-        // create a symbol
-        val symbolOptions: SymbolOptions = SymbolOptions()
-          .withPoint(Point.fromLngLat(AIRPORT_LONGITUDE, AIRPORT_LATITUDE))
-          .withIconImage(ID_ICON_AIRPORT)
-          .withTextField(ID_ICON_AIRPORT)
-          .withTextOffset(listOf(0.0, -1.0))
-          .withTextColor(ColorUtils.colorToRgbaString(Color.RED))
-          .withIconSize(1.3)
-          .withIconOffset(listOf(5.0, 10.0))
-          .withSymbolSortKey(10.0)
-          .withDraggable(true)
-        symbol = create(symbolOptions)
-
+        BitmapUtils.getBitmapFromDrawable(
+          ResourcesCompat.getDrawable(
+            resources,
+            R.drawable.ic_airplanemode_active_black_24dp,
+            this@SymbolActivity.theme
+          )
+        )?.let {
+          // create a symbol
+          val symbolOptions: SymbolOptions = SymbolOptions()
+            .withPoint(Point.fromLngLat(AIRPORT_LONGITUDE, AIRPORT_LATITUDE))
+            .withIconImage(it)
+            .withTextField(ID_ICON_AIRPORT)
+            .withTextOffset(listOf(0.0, -1.0))
+            .withTextColor(ColorUtils.colorToRgbaString(Color.RED))
+            .withIconSize(1.3)
+            .withIconOffset(listOf(5.0, 10.0))
+            .withSymbolSortKey(10.0)
+            .withDraggable(true)
+          symbol = create(symbolOptions)
+        }
         // create nearby symbols
         val nearbyOptions: SymbolOptions = SymbolOptions()
           .withPoint(Point.fromLngLat(NEARBY_LONGITUDE, NEARBY_LATITUDE))
@@ -126,11 +119,7 @@ class SymbolActivity : AppCompatActivity() {
 
     deleteAll.setOnClickListener { symbolManager?.deleteAll() }
     changeStyle.setOnClickListener {
-      mapView.getMapboxMap().loadStyleUri(nextStyle) { style ->
-        airportImage?.let { bitMap ->
-          style.addImage(ID_ICON_AIRPORT, bitMap, true)
-        }
-      }
+      mapView.getMapboxMap().loadStyleUri(nextStyle)
     }
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -13,6 +13,8 @@ import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
 import com.mapbox.maps.extension.style.expressions.generated.Expression
+import com.mapbox.maps.extension.style.image.addImage
+import com.mapbox.maps.extension.style.image.image
 import com.mapbox.maps.extension.style.layers.Layer
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.addLayerBelow
@@ -21,6 +23,7 @@ import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.plugin.InvalidPluginConfigurationException
 import com.mapbox.maps.plugin.PLUGIN_GESTURE_CLASS_NAME
+import com.mapbox.maps.plugin.annotation.generated.Symbol
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapFeatureQueryDelegate
 import com.mapbox.maps.plugin.delegates.MapProjectionDelegate
@@ -215,18 +218,28 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
       Logger.e(TAG, "Can't update source: style is not fully loaded.")
       return
     }
-    source?.let {
-      if (!style.styleSourceExists(it.sourceId)) {
+    source?.let { geoJsonSource ->
+      if (!style.styleSourceExists(geoJsonSource.sourceId)) {
         Logger.e(TAG, "Can't update source: source has not been added to style.")
         return
       }
+      annotations
+        .filter { it.value.getType() == AnnotationType.Symbol }
+        .forEach {
+          (it.value as Symbol).iconImageBitmap?.let {
+            val imagePlugin = image(Symbol.ICON_DEFAULT_NAME) {
+              bitmap(it)
+            }
+            style.addImage(imagePlugin)
+          }
+        }
       val features = annotations.map {
         val annotation = Feature.fromGeometry(it.value.geometry, it.value.jsonObject)
         it.value.setUsedDataDrivenProperties()
         annotation
       }
 
-      it.featureCollection(FeatureCollection.fromFeatures(features))
+      geoJsonSource.featureCollection(FeatureCollection.fromFeatures(features))
     }
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -226,11 +226,17 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
       annotations
         .filter { it.value.getType() == AnnotationType.Symbol }
         .forEach {
-          (it.value as Symbol).iconImageBitmap?.let {
-            val imagePlugin = image(Symbol.ICON_DEFAULT_NAME) {
-              bitmap(it)
+          val symbol = it.value as Symbol
+          symbol.iconImage?.let { image ->
+            if (image.startsWith(Symbol.ICON_DEFAULT_NAME_PREFIX)) {
+              // User set the bitmap icon, add the icon to style
+              symbol.iconImageBitmap?.let { bitmap ->
+                val imagePlugin = image(image) {
+                  bitmap(bitmap)
+                }
+                style.addImage(imagePlugin)
+              }
             }
-            style.addImage(imagePlugin)
           }
         }
       val features = annotations.map {

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Circle.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Circle.kt
@@ -20,7 +20,7 @@ import com.mapbox.maps.plugin.delegates.MapProjectionDelegate
 class Circle(
   id: Long,
   /** The annotation manger that manipulate this annotation */
-  val annotationManager: AnnotationManager<Point, Circle, *, *, *, *>,
+  private val annotationManager: AnnotationManager<Point, Circle, *, *, *, *>,
   jsonObject: JsonObject,
   geometry: Point
 ) : Annotation<Point>(id, jsonObject, geometry) {
@@ -182,7 +182,7 @@ class Circle(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty("circle-color", value)
+      jsonObject.addProperty(CircleOptions.PROPERTY_CIRCLE_COLOR, value)
     }
 
   /**
@@ -315,7 +315,7 @@ class Circle(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty("circle-stroke-color", value)
+      jsonObject.addProperty(CircleOptions.PROPERTY_CIRCLE_STROKE_COLOR, value)
     }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleManager.kt
@@ -33,8 +33,8 @@ class CircleManager(
 
   init {
     val id = ID_GENERATOR.incrementAndGet()
-    layerId = annotationConfig?.layerId ?: "mapbox-android-fill-layer-$id"
-    sourceId = annotationConfig?.sourceId ?: "mapbox-android-fill-source-$id"
+    layerId = annotationConfig?.layerId ?: "mapbox-android-circle-layer-$id"
+    sourceId = annotationConfig?.sourceId ?: "mapbox-android-circle-source-$id"
     delegateProvider.getStyle {
       style = it
       initLayerAndSource()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Fill.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Fill.kt
@@ -20,7 +20,7 @@ import com.mapbox.maps.plugin.delegates.MapProjectionDelegate
 class Fill(
   id: Long,
   /** The annotation manger that manipulate this annotation */
-  val annotationManager: AnnotationManager<Polygon, Fill, *, *, *, *>,
+  private val annotationManager: AnnotationManager<Polygon, Fill, *, *, *, *>,
   jsonObject: JsonObject,
   geometry: Polygon
 ) : Annotation<Polygon>(id, jsonObject, geometry) {
@@ -149,7 +149,7 @@ class Fill(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty("fill-color", value)
+      jsonObject.addProperty(FillOptions.PROPERTY_FILL_COLOR, value)
     }
 
   /**
@@ -249,7 +249,7 @@ class Fill(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty("fill-outline-color", value)
+      jsonObject.addProperty(FillOptions.PROPERTY_FILL_OUTLINE_COLOR, value)
     }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Line.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Line.kt
@@ -20,7 +20,7 @@ import com.mapbox.maps.plugin.delegates.MapProjectionDelegate
 class Line(
   id: Long,
   /** The annotation manger that manipulate this annotation */
-  val annotationManager: AnnotationManager<LineString, Line, *, *, *, *>,
+  private val annotationManager: AnnotationManager<LineString, Line, *, *, *, *>,
   jsonObject: JsonObject,
   geometry: LineString
 ) : Annotation<LineString>(id, jsonObject, geometry) {
@@ -215,7 +215,7 @@ class Line(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty("line-color", value)
+      jsonObject.addProperty(LineOptions.PROPERTY_LINE_COLOR, value)
     }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/LineManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/LineManager.kt
@@ -33,8 +33,8 @@ class LineManager(
 
   init {
     val id = ID_GENERATOR.incrementAndGet()
-    layerId = annotationConfig?.layerId ?: "mapbox-android-fill-layer-$id"
-    sourceId = annotationConfig?.sourceId ?: "mapbox-android-fill-source-$id"
+    layerId = annotationConfig?.layerId ?: "mapbox-android-line-layer-$id"
+    sourceId = annotationConfig?.sourceId ?: "mapbox-android-line-source-$id"
     delegateProvider.getStyle {
       style = it
       initLayerAndSource()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.maps.plugin.annotation.generated
 
+import android.graphics.Bitmap
 import androidx.annotation.ColorInt
 import com.google.gson.*
 import com.mapbox.android.gestures.MoveDistancesObject
@@ -22,7 +23,7 @@ import com.mapbox.maps.plugin.delegates.MapProjectionDelegate
 class Symbol(
   id: Long,
   /** The annotation manger that manipulate this annotation */
-  val annotationManager: AnnotationManager<Point, Symbol, *, *, *, *>,
+  private val annotationManager: AnnotationManager<Point, Symbol, *, *, *, *>,
   jsonObject: JsonObject,
   geometry: Point
 ) : Annotation<Point>(id, jsonObject, geometry) {
@@ -53,6 +54,25 @@ class Symbol(
       geometry = value
     }
 
+  /**
+   * The bitmap image for this Symbol
+   *
+   * Will not take effect if [iconImage] has been set.
+   */
+  var iconImageBitmap: Bitmap? = null
+    /**
+     * Set the iconImageBitmap property
+     *
+     * @param value the iconBitmap
+     */
+    set(value) {
+      value?.let {
+        field = it
+        if (iconImage == null) {
+          iconImage = ICON_DEFAULT_NAME
+        }
+      }
+    }
   // Property accessors
   /**
    * The iconAnchor property
@@ -680,7 +700,7 @@ class Symbol(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty("icon-color", value)
+      jsonObject.addProperty(SymbolOptions.PROPERTY_ICON_COLOR, value)
     }
 
   /**
@@ -780,7 +800,7 @@ class Symbol(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty("icon-halo-color", value)
+      jsonObject.addProperty(SymbolOptions.PROPERTY_ICON_HALO_COLOR, value)
     }
 
   /**
@@ -913,7 +933,7 @@ class Symbol(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty("text-color", value)
+      jsonObject.addProperty(SymbolOptions.PROPERTY_TEXT_COLOR, value)
     }
 
   /**
@@ -1013,7 +1033,7 @@ class Symbol(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty("text-halo-color", value)
+      jsonObject.addProperty(SymbolOptions.PROPERTY_TEXT_HALO_COLOR, value)
     }
 
   /**
@@ -1196,5 +1216,7 @@ class Symbol(
   companion object {
     /** the Id key for annotation */
     const val ID_KEY: String = "Symbol"
+    /** the default name for icon */
+    internal const val ICON_DEFAULT_NAME = "icon_default_name"
   }
 }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
@@ -69,7 +69,7 @@ class Symbol(
       value?.let {
         field = it
         if (iconImage == null) {
-          iconImage = ICON_DEFAULT_NAME
+          iconImage = ICON_DEFAULT_NAME_PREFIX + id
         }
       }
     }
@@ -1217,6 +1217,6 @@ class Symbol(
     /** the Id key for annotation */
     const val ID_KEY: String = "Symbol"
     /** the default name for icon */
-    internal const val ICON_DEFAULT_NAME = "icon_default_name"
+    const val ICON_DEFAULT_NAME_PREFIX = "icon_default_name_"
   }
 }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolManager.kt
@@ -33,8 +33,8 @@ class SymbolManager(
 
   init {
     val id = ID_GENERATOR.incrementAndGet()
-    layerId = annotationConfig?.layerId ?: "mapbox-android-fill-layer-$id"
-    sourceId = annotationConfig?.sourceId ?: "mapbox-android-fill-source-$id"
+    layerId = annotationConfig?.layerId ?: "mapbox-android-symbol-layer-$id"
+    sourceId = annotationConfig?.sourceId ?: "mapbox-android-symbol-source-$id"
     delegateProvider.getStyle {
       style = it
       initLayerAndSource()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.maps.plugin.annotation.generated
 
+import android.graphics.Bitmap
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.mapbox.geojson.Feature
@@ -24,6 +25,20 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   private var isDraggable: Boolean = false
   private var data: JsonElement? = null
   private var geometry: Point? = null
+  private var iconImageBitmap: Bitmap? = null
+
+  /**
+   * Set bitmap icon-image to initialise the symbol.
+   *
+   * Will not take effect if a String iconImage name has been set.
+   *
+   * @param iconImage the bitmap image
+   * @return this
+   */
+  fun withIconImage(iconImageBitmap: Bitmap): SymbolOptions {
+    this.iconImageBitmap = iconImageBitmap
+    return this
+  }
 
   /**
    * Part of the icon placed closest to the anchor.
@@ -634,6 +649,9 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
     jsonObject.addProperty(PROPERTY_TEXT_HALO_WIDTH, textHaloWidth)
     jsonObject.addProperty(PROPERTY_TEXT_OPACITY, textOpacity)
     val symbol = Symbol(id, annotationManager, jsonObject, geometry!!)
+    iconImageBitmap?.let {
+      symbol.iconImageBitmap = iconImageBitmap
+    }
     symbol.isDraggable = isDraggable
     symbol.setData(data)
     return symbol

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.maps.plugin.annotation.generated
 
+import android.graphics.Bitmap
 import android.graphics.PointF
 import android.view.View
 import com.mapbox.android.gestures.MoveDistancesObject
@@ -56,6 +57,7 @@ class SymbolManagerTest {
   private val source: GeoJsonSource = mockk()
   private val mapView: View = mockk()
   private lateinit var manager: SymbolManager
+  val bitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
   @Before
   fun setUp() {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
@@ -97,6 +99,9 @@ class SymbolManagerTest {
     manager = SymbolManager(mapView, delegateProvider)
     manager.layer = layer
     manager.source = source
+    val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
+    every { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) } returns expected
+    every { expected.error } returns null
     every { layer.iconAnchor(any<Expression>()) } answers { layer }
     every { layer.iconImage(any<Expression>()) } answers { layer }
     every { layer.iconOffset(any<Expression>()) } answers { layer }
@@ -151,6 +156,44 @@ class SymbolManagerTest {
     assertTrue(manager.longClickListeners.isEmpty())
   }
 
+  @Test
+  fun iconImageBitmapWithIconImage() {
+    every { style.styleSourceExists(any()) } returns true
+    val annotation = manager.create(
+      SymbolOptions()
+        .withIconImage("car-15")
+        .withIconImage(bitmap)
+        .withPoint(Point.fromLngLat(0.0, 0.0))
+    )
+    assertEquals("car-15", annotation.iconImage)
+    verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun iconImageBitmapWithoutIconImage() {
+    every { style.styleSourceExists(any()) } returns true
+    val annotation = manager.create(
+      SymbolOptions()
+        .withIconImage(bitmap)
+        .withPoint(Point.fromLngLat(0.0, 0.0))
+    )
+    assertEquals(Symbol.ICON_DEFAULT_NAME, annotation.iconImage)
+
+    verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun updateIconImageBitmap() {
+    every { style.styleSourceExists(any()) } returns true
+    val annotation = manager.create(
+      SymbolOptions()
+        .withPoint(Point.fromLngLat(0.0, 0.0))
+    )
+    verify(exactly = 0) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+    annotation.iconImageBitmap = bitmap
+    manager.update(annotation)
+    verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+  }
   @Test
   fun create() {
     val annotation = manager.create(

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
@@ -166,7 +166,7 @@ class SymbolManagerTest {
         .withPoint(Point.fromLngLat(0.0, 0.0))
     )
     assertEquals("car-15", annotation.iconImage)
-    verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+    verify(exactly = 0) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
   }
 
   @Test
@@ -177,7 +177,7 @@ class SymbolManagerTest {
         .withIconImage(bitmap)
         .withPoint(Point.fromLngLat(0.0, 0.0))
     )
-    assertEquals(Symbol.ICON_DEFAULT_NAME, annotation.iconImage)
+    assertEquals(Symbol.ICON_DEFAULT_NAME_PREFIX + annotation.id, annotation.iconImage)
 
     verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[Annotation plugin] Add bitmap API for Symbol</changelog>`.

### Summary of changes
This pr add the bitmap API for Symbol to enable users to add a bitmap to Symbol directly instead of adding it to style.
![QQ20210203-144935](https://user-images.githubusercontent.com/8577318/106709191-195db600-662f-11eb-8867-4b5d9fb52a2f.gif)

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->