### PR TITLE
[Annotation plugin] Add colorInt API for annotation options

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/CircleActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/CircleActivity.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
-import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.testapp.R
@@ -42,7 +41,7 @@ class CircleActivity : AppCompatActivity() {
 
         val circleOptions: CircleOptions = CircleOptions()
           .withPoint(Point.fromLngLat(CIRCLE_LONGITUDE, CIRCLE_LATITUDE))
-          .withCircleColor(ColorUtils.colorToRgbaString(Color.YELLOW))
+          .withCircleColor(Color.YELLOW)
           .withCircleRadius(12.0)
           .withDraggable(true)
         create(circleOptions)
@@ -54,7 +53,7 @@ class CircleActivity : AppCompatActivity() {
           circleOptionsList.add(
             CircleOptions()
               .withPoint(AnnotationUtils.createRandomPoint())
-              .withCircleColor(ColorUtils.colorToRgbaString(color))
+              .withCircleColor(color)
               .withCircleRadius(8.0)
               .withDraggable(true)
           )

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/FillActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/FillActivity.kt
@@ -7,7 +7,6 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.gson.JsonPrimitive
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
-import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.testapp.R
@@ -52,7 +51,7 @@ class FillActivity : AppCompatActivity() {
         val fillOptions: FillOptions = FillOptions()
           .withPoints(points)
           .withData(JsonPrimitive("Foobar"))
-          .withFillColor(ColorUtils.colorToRgbaString(Color.RED))
+          .withFillColor(Color.RED)
         create(fillOptions)
 
         // random add fills across the globe
@@ -62,7 +61,7 @@ class FillActivity : AppCompatActivity() {
           fillOptionsList.add(
             FillOptions()
               .withPoints(AnnotationUtils.createRandomPointsList())
-              .withFillColor(ColorUtils.colorToRgbaString(color))
+              .withFillColor(color)
           )
         }
         create(fillOptionsList)

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/LineActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/LineActivity.kt
@@ -7,7 +7,6 @@ import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.style.layers.getLayer
-import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
@@ -60,7 +59,7 @@ class LineActivity : AppCompatActivity() {
 
         val lineOptions: LineOptions = LineOptions()
           .withPoints(points)
-          .withLineColor(ColorUtils.colorToRgbaString(Color.RED))
+          .withLineColor(Color.RED)
           .withLineWidth(5.0)
         create(lineOptions)
 
@@ -73,7 +72,7 @@ class LineActivity : AppCompatActivity() {
           val color = Color.argb(255, random.nextInt(256), random.nextInt(256), random.nextInt(256))
           LineOptions()
             .withPoints(it)
-            .withLineColor(ColorUtils.colorToRgbaString(color))
+            .withLineColor(color)
         }
 
         create(lineOptionsList)

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
@@ -19,7 +19,6 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression.Companio
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.toNumber
 import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.mapbox.maps.extension.style.layers.properties.generated.TextAnchor
-import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.plugin.location.utils.BitmapUtils
@@ -79,7 +78,7 @@ class SymbolActivity : AppCompatActivity() {
             .withIconImage(it)
             .withTextField(ID_ICON_AIRPORT)
             .withTextOffset(listOf(0.0, -1.0))
-            .withTextColor(ColorUtils.colorToRgbaString(Color.RED))
+            .withTextColor(Color.RED)
             .withIconSize(1.3)
             .withIconOffset(listOf(5.0, 10.0))
             .withSymbolSortKey(10.0)
@@ -98,7 +97,7 @@ class SymbolActivity : AppCompatActivity() {
           val nearbyOptions: SymbolOptions = SymbolOptions()
             .withPoint(Point.fromLngLat(NEARBY_LONGITUDE, NEARBY_LATITUDE))
             .withIconImage(it)
-            .withIconColor(ColorUtils.colorToRgbaString(Color.YELLOW))
+            .withIconColor(Color.YELLOW)
             .withIconSize(2.5)
             .withSymbolSortKey(5.0)
             .withDraggable(true)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleOptions.kt
@@ -2,10 +2,12 @@
 
 package com.mapbox.maps.plugin.annotation.generated
 
+import androidx.annotation.ColorInt
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Point
+import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.AnnotationManager
 import com.mapbox.maps.plugin.annotation.AnnotationOptions
 
@@ -72,6 +74,19 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
   }
 
   /**
+   * Set circle-color to initialise the circle with.
+   * <p>
+   * The fill color of the circle.
+   * </p>
+   * @param circleColor the circle-color value with ColorInt format
+   * @return this
+   */
+  fun withCircleColor(@ColorInt circleColor: Int): CircleOptions {
+    this.circleColor = ColorUtils.colorToRgbaString(circleColor)
+    return this
+  }
+
+  /**
    * The opacity at which the circle will be drawn.
    */
   var circleOpacity: Double = 1.0
@@ -122,6 +137,19 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
    */
   fun withCircleStrokeColor(circleStrokeColor: String): CircleOptions {
     this.circleStrokeColor = circleStrokeColor
+    return this
+  }
+
+  /**
+   * Set circle-stroke-color to initialise the circle with.
+   * <p>
+   * The stroke color of the circle.
+   * </p>
+   * @param circleStrokeColor the circle-stroke-color value with ColorInt format
+   * @return this
+   */
+  fun withCircleStrokeColor(@ColorInt circleStrokeColor: Int): CircleOptions {
+    this.circleStrokeColor = ColorUtils.colorToRgbaString(circleStrokeColor)
     return this
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/FillOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/FillOptions.kt
@@ -2,11 +2,13 @@
 
 package com.mapbox.maps.plugin.annotation.generated
 
+import androidx.annotation.ColorInt
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.Polygon
+import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.AnnotationManager
 import com.mapbox.maps.plugin.annotation.AnnotationOptions
 
@@ -55,6 +57,19 @@ class FillOptions : AnnotationOptions<Polygon, Fill> {
   }
 
   /**
+   * Set fill-color to initialise the fill with.
+   * <p>
+   * The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1px stroke, if it is used.
+   * </p>
+   * @param fillColor the fill-color value with ColorInt format
+   * @return this
+   */
+  fun withFillColor(@ColorInt fillColor: Int): FillOptions {
+    this.fillColor = ColorUtils.colorToRgbaString(fillColor)
+    return this
+  }
+
+  /**
    * The opacity of the entire fill layer. In contrast to the `fill-color`, this value will also affect the 1px stroke around the fill, if the stroke is used.
    */
   var fillOpacity: Double = 1.0
@@ -87,6 +102,19 @@ class FillOptions : AnnotationOptions<Polygon, Fill> {
    */
   fun withFillOutlineColor(fillOutlineColor: String): FillOptions {
     this.fillOutlineColor = fillOutlineColor
+    return this
+  }
+
+  /**
+   * Set fill-outline-color to initialise the fill with.
+   * <p>
+   * The outline color of the fill. Matches the value of {@link PropertyFactory#fillColor} if unspecified.
+   * </p>
+   * @param fillOutlineColor the fill-outline-color value with ColorInt format
+   * @return this
+   */
+  fun withFillOutlineColor(@ColorInt fillOutlineColor: Int): FillOptions {
+    this.fillOutlineColor = ColorUtils.colorToRgbaString(fillOutlineColor)
     return this
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/LineOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/LineOptions.kt
@@ -2,12 +2,14 @@
 
 package com.mapbox.maps.plugin.annotation.generated
 
+import androidx.annotation.ColorInt
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.style.layers.properties.generated.LineJoin
+import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.AnnotationManager
 import com.mapbox.maps.plugin.annotation.AnnotationOptions
 
@@ -88,6 +90,19 @@ class LineOptions : AnnotationOptions<LineString, Line> {
    */
   fun withLineColor(lineColor: String): LineOptions {
     this.lineColor = lineColor
+    return this
+  }
+
+  /**
+   * Set line-color to initialise the line with.
+   * <p>
+   * The color with which the line will be drawn.
+   * </p>
+   * @param lineColor the line-color value with ColorInt format
+   * @return this
+   */
+  fun withLineColor(@ColorInt lineColor: Int): LineOptions {
+    this.lineColor = ColorUtils.colorToRgbaString(lineColor)
     return this
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
@@ -3,6 +3,7 @@
 package com.mapbox.maps.plugin.annotation.generated
 
 import android.graphics.Bitmap
+import androidx.annotation.ColorInt
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.mapbox.geojson.Feature
@@ -11,6 +12,7 @@ import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.mapbox.maps.extension.style.layers.properties.generated.TextAnchor
 import com.mapbox.maps.extension.style.layers.properties.generated.TextJustify
 import com.mapbox.maps.extension.style.layers.properties.generated.TextTransform
+import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.AnnotationManager
 import com.mapbox.maps.plugin.annotation.AnnotationOptions
 import com.mapbox.maps.plugin.annotation.ConvertUtils.convertDoubleArray
@@ -365,6 +367,19 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   }
 
   /**
+   * Set icon-color to initialise the symbol with.
+   * <p>
+   * The color of the icon. This can only be used with sdf icons.
+   * </p>
+   * @param iconColor the icon-color value with ColorInt format
+   * @return this
+   */
+  fun withIconColor(@ColorInt iconColor: Int): SymbolOptions {
+    this.iconColor = ColorUtils.colorToRgbaString(iconColor)
+    return this
+  }
+
+  /**
    * Fade out the halo towards the outside.
    */
   var iconHaloBlur: Double = 0.0
@@ -397,6 +412,19 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
    */
   fun withIconHaloColor(iconHaloColor: String): SymbolOptions {
     this.iconHaloColor = iconHaloColor
+    return this
+  }
+
+  /**
+   * Set icon-halo-color to initialise the symbol with.
+   * <p>
+   * The color of the icon's halo. Icon halos can only be used with SDF icons.
+   * </p>
+   * @param iconHaloColor the icon-halo-color value with ColorInt format
+   * @return this
+   */
+  fun withIconHaloColor(@ColorInt iconHaloColor: Int): SymbolOptions {
+    this.iconHaloColor = ColorUtils.colorToRgbaString(iconHaloColor)
     return this
   }
 
@@ -455,6 +483,19 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   }
 
   /**
+   * Set text-color to initialise the symbol with.
+   * <p>
+   * The color with which the text will be drawn.
+   * </p>
+   * @param textColor the text-color value with ColorInt format
+   * @return this
+   */
+  fun withTextColor(@ColorInt textColor: Int): SymbolOptions {
+    this.textColor = ColorUtils.colorToRgbaString(textColor)
+    return this
+  }
+
+  /**
    * The halo's fadeout distance towards the outside.
    */
   var textHaloBlur: Double = 0.0
@@ -487,6 +528,19 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
    */
   fun withTextHaloColor(textHaloColor: String): SymbolOptions {
     this.textHaloColor = textHaloColor
+    return this
+  }
+
+  /**
+   * Set text-halo-color to initialise the symbol with.
+   * <p>
+   * The color of the text's halo, which helps it stand out from backgrounds.
+   * </p>
+   * @param textHaloColor the text-halo-color value with ColorInt format
+   * @return this
+   */
+  fun withTextHaloColor(@ColorInt textHaloColor: Int): SymbolOptions {
+    this.textHaloColor = ColorUtils.colorToRgbaString(textHaloColor)
     return this
   }
 

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleManagerTest.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.maps.plugin.annotation.generated
 
+import android.graphics.Color
 import android.graphics.PointF
 import android.view.View
 import com.mapbox.android.gestures.MoveDistancesObject
@@ -392,6 +393,19 @@ class CircleManagerTest {
   }
 
   @Test
+  fun testCircleColorIntLayerProperty() {
+    every { style.styleSourceExists(any()) } returns true
+    verify(exactly = 0) { manager.layer?.circleColor(Expression.get(CircleOptions.PROPERTY_CIRCLE_COLOR)) }
+    val options = CircleOptions()
+      .withPoint(Point.fromLngLat(0.0, 0.0))
+      .withCircleColor(Color.YELLOW)
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.circleColor(Expression.get(CircleOptions.PROPERTY_CIRCLE_COLOR)) }
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.circleColor(Expression.get(CircleOptions.PROPERTY_CIRCLE_COLOR)) }
+  }
+
+  @Test
   fun testCircleColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleColor(Expression.get(CircleOptions.PROPERTY_CIRCLE_COLOR)) }
@@ -428,6 +442,19 @@ class CircleManagerTest {
     verify(exactly = 1) { manager.layer?.circleRadius(Expression.get(CircleOptions.PROPERTY_CIRCLE_RADIUS)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleRadius(Expression.get(CircleOptions.PROPERTY_CIRCLE_RADIUS)) }
+  }
+
+  @Test
+  fun testCircleStrokeColorIntLayerProperty() {
+    every { style.styleSourceExists(any()) } returns true
+    verify(exactly = 0) { manager.layer?.circleStrokeColor(Expression.get(CircleOptions.PROPERTY_CIRCLE_STROKE_COLOR)) }
+    val options = CircleOptions()
+      .withPoint(Point.fromLngLat(0.0, 0.0))
+      .withCircleStrokeColor(Color.YELLOW)
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.circleStrokeColor(Expression.get(CircleOptions.PROPERTY_CIRCLE_STROKE_COLOR)) }
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.circleStrokeColor(Expression.get(CircleOptions.PROPERTY_CIRCLE_STROKE_COLOR)) }
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/FillManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/FillManagerTest.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.maps.plugin.annotation.generated
 
+import android.graphics.Color
 import android.graphics.PointF
 import android.view.View
 import com.mapbox.android.gestures.MoveDistancesObject
@@ -377,6 +378,19 @@ class FillManagerTest {
   }
 
   @Test
+  fun testFillColorIntLayerProperty() {
+    every { style.styleSourceExists(any()) } returns true
+    verify(exactly = 0) { manager.layer?.fillColor(Expression.get(FillOptions.PROPERTY_FILL_COLOR)) }
+    val options = FillOptions()
+      .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
+      .withFillColor(Color.YELLOW)
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.fillColor(Expression.get(FillOptions.PROPERTY_FILL_COLOR)) }
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.fillColor(Expression.get(FillOptions.PROPERTY_FILL_COLOR)) }
+  }
+
+  @Test
   fun testFillColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.fillColor(Expression.get(FillOptions.PROPERTY_FILL_COLOR)) }
@@ -400,6 +414,19 @@ class FillManagerTest {
     verify(exactly = 1) { manager.layer?.fillOpacity(Expression.get(FillOptions.PROPERTY_FILL_OPACITY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillOpacity(Expression.get(FillOptions.PROPERTY_FILL_OPACITY)) }
+  }
+
+  @Test
+  fun testFillOutlineColorIntLayerProperty() {
+    every { style.styleSourceExists(any()) } returns true
+    verify(exactly = 0) { manager.layer?.fillOutlineColor(Expression.get(FillOptions.PROPERTY_FILL_OUTLINE_COLOR)) }
+    val options = FillOptions()
+      .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
+      .withFillOutlineColor(Color.YELLOW)
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.fillOutlineColor(Expression.get(FillOptions.PROPERTY_FILL_OUTLINE_COLOR)) }
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.fillOutlineColor(Expression.get(FillOptions.PROPERTY_FILL_OUTLINE_COLOR)) }
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/LineManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/LineManagerTest.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.maps.plugin.annotation.generated
 
+import android.graphics.Color
 import android.graphics.PointF
 import android.view.View
 import com.mapbox.android.gestures.MoveDistancesObject
@@ -405,6 +406,19 @@ class LineManagerTest {
     verify(exactly = 1) { manager.layer?.lineBlur(Expression.get(LineOptions.PROPERTY_LINE_BLUR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineBlur(Expression.get(LineOptions.PROPERTY_LINE_BLUR)) }
+  }
+
+  @Test
+  fun testLineColorIntLayerProperty() {
+    every { style.styleSourceExists(any()) } returns true
+    verify(exactly = 0) { manager.layer?.lineColor(Expression.get(LineOptions.PROPERTY_LINE_COLOR)) }
+    val options = LineOptions()
+      .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
+      .withLineColor(Color.YELLOW)
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.lineColor(Expression.get(LineOptions.PROPERTY_LINE_COLOR)) }
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.lineColor(Expression.get(LineOptions.PROPERTY_LINE_COLOR)) }
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
@@ -3,6 +3,7 @@
 package com.mapbox.maps.plugin.annotation.generated
 
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.graphics.PointF
 import android.view.View
 import com.mapbox.android.gestures.MoveDistancesObject
@@ -650,6 +651,19 @@ class SymbolManagerTest {
   }
 
   @Test
+  fun testIconColorIntLayerProperty() {
+    every { style.styleSourceExists(any()) } returns true
+    verify(exactly = 0) { manager.layer?.iconColor(Expression.get(SymbolOptions.PROPERTY_ICON_COLOR)) }
+    val options = SymbolOptions()
+      .withPoint(Point.fromLngLat(0.0, 0.0))
+      .withIconColor(Color.YELLOW)
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.iconColor(Expression.get(SymbolOptions.PROPERTY_ICON_COLOR)) }
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.iconColor(Expression.get(SymbolOptions.PROPERTY_ICON_COLOR)) }
+  }
+
+  @Test
   fun testIconColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconColor(Expression.get(SymbolOptions.PROPERTY_ICON_COLOR)) }
@@ -673,6 +687,19 @@ class SymbolManagerTest {
     verify(exactly = 1) { manager.layer?.iconHaloBlur(Expression.get(SymbolOptions.PROPERTY_ICON_HALO_BLUR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconHaloBlur(Expression.get(SymbolOptions.PROPERTY_ICON_HALO_BLUR)) }
+  }
+
+  @Test
+  fun testIconHaloColorIntLayerProperty() {
+    every { style.styleSourceExists(any()) } returns true
+    verify(exactly = 0) { manager.layer?.iconHaloColor(Expression.get(SymbolOptions.PROPERTY_ICON_HALO_COLOR)) }
+    val options = SymbolOptions()
+      .withPoint(Point.fromLngLat(0.0, 0.0))
+      .withIconHaloColor(Color.YELLOW)
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.iconHaloColor(Expression.get(SymbolOptions.PROPERTY_ICON_HALO_COLOR)) }
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.iconHaloColor(Expression.get(SymbolOptions.PROPERTY_ICON_HALO_COLOR)) }
   }
 
   @Test
@@ -715,6 +742,19 @@ class SymbolManagerTest {
   }
 
   @Test
+  fun testTextColorIntLayerProperty() {
+    every { style.styleSourceExists(any()) } returns true
+    verify(exactly = 0) { manager.layer?.textColor(Expression.get(SymbolOptions.PROPERTY_TEXT_COLOR)) }
+    val options = SymbolOptions()
+      .withPoint(Point.fromLngLat(0.0, 0.0))
+      .withTextColor(Color.YELLOW)
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.textColor(Expression.get(SymbolOptions.PROPERTY_TEXT_COLOR)) }
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.textColor(Expression.get(SymbolOptions.PROPERTY_TEXT_COLOR)) }
+  }
+
+  @Test
   fun testTextColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textColor(Expression.get(SymbolOptions.PROPERTY_TEXT_COLOR)) }
@@ -738,6 +778,19 @@ class SymbolManagerTest {
     verify(exactly = 1) { manager.layer?.textHaloBlur(Expression.get(SymbolOptions.PROPERTY_TEXT_HALO_BLUR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textHaloBlur(Expression.get(SymbolOptions.PROPERTY_TEXT_HALO_BLUR)) }
+  }
+
+  @Test
+  fun testTextHaloColorIntLayerProperty() {
+    every { style.styleSourceExists(any()) } returns true
+    verify(exactly = 0) { manager.layer?.textHaloColor(Expression.get(SymbolOptions.PROPERTY_TEXT_HALO_COLOR)) }
+    val options = SymbolOptions()
+      .withPoint(Point.fromLngLat(0.0, 0.0))
+      .withTextHaloColor(Color.YELLOW)
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.textHaloColor(Expression.get(SymbolOptions.PROPERTY_TEXT_HALO_COLOR)) }
+    manager.create(options)
+    verify(exactly = 1) { manager.layer?.textHaloColor(Expression.get(SymbolOptions.PROPERTY_TEXT_HALO_COLOR)) }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[Annotation plugin] Add colorInt API for annotation options</changelog>`.

### Summary of changes
This pr add  convenient `colorInt` API for annotation options to enable users use `colorInt` to set annotation color while creating annotations.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->