### PR TITLE
[sdk] Use cached resourceOptions if it's initialized.

### DIFF
--- a/sdk/src/androidTest/java/com/mapbox/maps/MapboxMapIntegrationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/MapboxMapIntegrationTest.kt
@@ -36,12 +36,7 @@ class MapboxMapIntegrationTest {
   fun testGetResourceOptions() {
     val defaultOptions = MapboxOptions.getDefaultResourceOptions(mapView.context)
     val currentOptions = mapboxMap.getResourceOptions()
-    // TODO use assertEquals(defaultOptions, currentOptions) when equals() is supported on records
-    assertEquals(defaultOptions.accessToken, currentOptions.accessToken)
-    assertEquals(defaultOptions.baseURL, currentOptions.baseURL)
-    assertEquals(defaultOptions.assetPath, currentOptions.assetPath)
-    assertEquals(defaultOptions.cachePath, currentOptions.cachePath)
-    assertEquals(defaultOptions.cacheSize, currentOptions.cacheSize)
+    assertEquals(defaultOptions, currentOptions)
   }
 
   @UiThreadTest

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMapOptions.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMapOptions.kt
@@ -61,7 +61,11 @@ data class MapboxMapOptions constructor(
   init {
     val typedArray = context.obtainStyledAttributes(attrs, R.styleable.mapbox_MapView, 0, 0)
     try {
-      internalResourceOptions = ResourcesAttributeParser.parseResourcesOptions(context, typedArray)
+      internalResourceOptions = if (MapboxOptions.isInitialized()) {
+        MapboxOptions.getDefaultResourceOptions(context)
+      } else {
+        ResourcesAttributeParser.parseResourcesOptions(context, typedArray)
+      }
       mapOptions = MapAttributeParser.parseMapOptions(typedArray, pixelRatio)
       cameraOptions = CameraAttributeParser.parseCameraOptions(typedArray)
       textureView = typedArray.getInt(R.styleable.mapbox_MapView_mapbox_mapSurface, 0) != 0

--- a/sdk/src/main/java/com/mapbox/maps/MapboxOptions.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxOptions.kt
@@ -14,9 +14,9 @@ object MapboxOptions {
    */
   fun getDefaultResourceOptions(context: Context, accessToken: String? = null): ResourceOptions {
     if (!::defaultOptions.isInitialized) {
-      val accessToken = accessToken ?: context.getMapboxAccessTokenFromResources()
+      val token = accessToken ?: context.getMapboxAccessTokenFromResources()
         ?: throw MapboxConfigurationException()
-      defaultOptions = createResourceOptions(accessToken, context.filesDir.absolutePath)
+      defaultOptions = createResourceOptions(token, context.filesDir.absolutePath)
     }
     return defaultOptions
   }

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapOptionsTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapOptionsTest.kt
@@ -79,4 +79,12 @@ class MapboxMapOptionsTest {
 
     assertEquals("token", mapboxMapOptions.resourceOptions.accessToken)
   }
+
+  @Test
+  fun cacheResourceOptions() {
+    val resourceOptions = MapboxOptions.createResourceOptions(context, "token")
+    MapboxOptions.setDefaultResourceOptions(resourceOptions)
+    val mapboxMapOptions = MapboxMapOptions(context, 1.0f, attrs)
+    assertEquals(resourceOptions, mapboxMapOptions.resourceOptions)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[sdk] Use cached resourceOptions if it's initialized.</changelog>`.

### Summary of changes
This pr add the function that checks and use the cached `resourceOptions` if it's initialized instead of recreate it from ResourcesOptions
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->