### PR TITLE
[rendering] Expose setting FPS listener

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
@@ -39,6 +39,7 @@ class DebugModeActivity : AppCompatActivity() {
       )
     }
   }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_debug)
@@ -85,6 +86,11 @@ class DebugModeActivity : AppCompatActivity() {
   override fun onStart() {
     super.onStart()
     mapView.onStart()
+    mapView.setOnFpsChangedListener {
+      runOnUiThread {
+        fpsView.text = "${it.toInt()} FPS"
+      }
+    }
   }
 
   override fun onStop() {

--- a/app/src/main/res/layout/activity_debug.xml
+++ b/app/src/main/res/layout/activity_debug.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:mapbox="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/container"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:weightSum="2">
+    android:layout_height="match_parent">
 
     <com.mapbox.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintHeight_default="percent"
+        mapbox:layout_constraintHeight_percent="0.5"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="parent"
         mapbox:mapbox_scaleBarBorderWidth="1dp"
         mapbox:mapbox_scaleBarHeight="3dp"
         mapbox:mapbox_scaleBarMarginLeft="5dp"
@@ -25,11 +26,27 @@
         mapbox:mapbox_scaleBarTextSize="10dp"
         tools:context=".examples.SimpleMapActivity" />
 
+    <TextView
+        android:id="@+id/fpsView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="10dp"
+        android:textColor="@color/green"
+        android:textSize="18sp"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="parent"
+        tools:text="30 FPS" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        mapbox:layout_constraintBottom_toBottomOf="parent"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintHeight_default="percent"
+        mapbox:layout_constraintHeight_percent="0.5"
+        mapbox:layout_constraintStart_toStartOf="parent">
 
         <CheckBox
             android:id="@+id/checkboxTileBorders"
@@ -81,4 +98,4 @@
 
     </LinearLayout>
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_debug.xml
+++ b/app/src/main/res/layout/activity_debug.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -9,21 +9,21 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        mapbox:layout_constraintEnd_toEndOf="parent"
-        mapbox:layout_constraintHeight_default="percent"
-        mapbox:layout_constraintHeight_percent="0.5"
-        mapbox:layout_constraintStart_toStartOf="parent"
-        mapbox:layout_constraintTop_toTopOf="parent"
-        mapbox:mapbox_scaleBarBorderWidth="1dp"
-        mapbox:mapbox_scaleBarHeight="3dp"
-        mapbox:mapbox_scaleBarMarginLeft="5dp"
-        mapbox:mapbox_scaleBarMarginTop="5dp"
-        mapbox:mapbox_scaleBarPrimaryColor="@color/white"
-        mapbox:mapbox_scaleBarSecondaryColor="@color/design_default_color_on_secondary"
-        mapbox:mapbox_scaleBarTextBarMargin="5dp"
-        mapbox:mapbox_scaleBarTextBorderWidth="1dp"
-        mapbox:mapbox_scaleBarTextColor="@color/accent"
-        mapbox:mapbox_scaleBarTextSize="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_default="percent"
+        app:layout_constraintHeight_percent="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:mapbox_scaleBarBorderWidth="1dp"
+        app:mapbox_scaleBarHeight="3dp"
+        app:mapbox_scaleBarMarginLeft="5dp"
+        app:mapbox_scaleBarMarginTop="5dp"
+        app:mapbox_scaleBarPrimaryColor="@color/white"
+        app:mapbox_scaleBarSecondaryColor="@color/design_default_color_on_secondary"
+        app:mapbox_scaleBarTextBarMargin="5dp"
+        app:mapbox_scaleBarTextBorderWidth="1dp"
+        app:mapbox_scaleBarTextColor="@color/accent"
+        app:mapbox_scaleBarTextSize="10dp"
         tools:context=".examples.SimpleMapActivity" />
 
     <TextView
@@ -34,19 +34,19 @@
         android:padding="10dp"
         android:textColor="@color/green"
         android:textSize="18sp"
-        mapbox:layout_constraintStart_toStartOf="parent"
-        mapbox:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="30 FPS" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:orientation="vertical"
-        mapbox:layout_constraintBottom_toBottomOf="parent"
-        mapbox:layout_constraintEnd_toEndOf="parent"
-        mapbox:layout_constraintHeight_default="percent"
-        mapbox:layout_constraintHeight_percent="0.5"
-        mapbox:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_default="percent"
+        app:layout_constraintHeight_percent="0.5"
+        app:layout_constraintStart_toStartOf="parent">
 
         <CheckBox
             android:id="@+id/checkboxTileBorders"

--- a/sdk/src/main/java/com/mapbox/maps/MapControllable.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapControllable.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps
 
 import android.graphics.Bitmap
 import android.view.MotionEvent
+import com.mapbox.maps.renderer.OnFpsChangedListener
 
 /**
  * MapControllable interface is the gateway for public API to talk to the internal map controller.
@@ -66,6 +67,11 @@ interface MapControllable {
    * @param fps The maximum fps
    */
   fun setMaximumFps(fps: Int)
+
+  /**
+   * Set [OnFpsChangedListener] to get map rendering FPS.
+   */
+  fun setOnFpsChangedListener(listener: OnFpsChangedListener)
 
   /**
    * Called to start rendering

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -25,6 +25,7 @@ import com.mapbox.maps.plugin.logo.LogoPlugin
 import com.mapbox.maps.plugin.overlay.MapOverlayPlugin
 import com.mapbox.maps.plugin.scalebar.ScaleBarPlugin
 import com.mapbox.maps.renderer.MapboxRenderer
+import com.mapbox.maps.renderer.OnFpsChangedListener
 
 internal class MapController : MapPluginProviderDelegate, MapControllable {
 
@@ -153,6 +154,10 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       return
     }
     renderer.setMaximumFps(fps)
+  }
+
+  override fun setOnFpsChangedListener(listener: OnFpsChangedListener) {
+    renderer.setOnFpsChangedListener(listener)
   }
 
   //

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -8,6 +8,7 @@ import android.view.MotionEvent
 import android.view.Surface
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
 import com.mapbox.maps.renderer.MapboxSurfaceRenderer
+import com.mapbox.maps.renderer.OnFpsChangedListener
 
 /**
  * A [MapSurface] provides an embeddable map interface.
@@ -153,6 +154,13 @@ class MapSurface : MapPluginProviderDelegate, MapControllable {
       return
     }
     renderer.setMaximumFps(fps)
+  }
+
+  /**
+   * Set [OnFpsChangedListener] to get map rendering FPS.
+   */
+  override fun setOnFpsChangedListener(listener: OnFpsChangedListener) {
+    renderer.setOnFpsChangedListener(listener)
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -19,6 +19,7 @@ import com.mapbox.maps.plugin.MapPlugin
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
 import com.mapbox.maps.renderer.MapboxSurfaceHolderRenderer
 import com.mapbox.maps.renderer.MapboxTextureViewRenderer
+import com.mapbox.maps.renderer.OnFpsChangedListener
 import com.mapbox.maps.renderer.egl.EGLCore
 import java.lang.ref.WeakReference
 
@@ -284,6 +285,13 @@ class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   override fun onGenericMotionEvent(event: MotionEvent): Boolean {
     return mapController.onGenericMotionEvent(event) ||
       super.onGenericMotionEvent(event)
+  }
+
+  /**
+   * Set [OnFpsChangedListener] to get map rendering FPS.
+   */
+  override fun setOnFpsChangedListener(listener: OnFpsChangedListener) {
+    mapController.setOnFpsChangedListener(listener)
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -55,6 +55,9 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
   private var nativeRenderCreated = false
   private var nativeRenderNotSupported = false
 
+  internal var fpsChangedListener: OnFpsChangedListener? = null
+  private var timeElapsed = 0L
+
   constructor(mapboxRenderer: MapboxRenderer, translucentSurface: Boolean) {
     this.translucentSurface = translucentSurface
     this.mapboxRenderer = mapboxRenderer
@@ -171,6 +174,12 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       // we need to stop swap buffers for less than time requested in order to have some time to render upcoming frame
       // before next vsync so it will be drawn, otherwise we will drop it
       expectedVsyncWakeTimeNs = expectedEndRenderTimeNs - ONE_MILLISECOND_NS
+    }
+    fpsChangedListener?.let {
+      val currentTime = SystemClock.elapsedRealtimeNanos()
+      val fps = 1E9 / (currentTime - timeElapsed)
+      it.onFpsChanged(fps)
+      timeElapsed = currentTime
     }
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -176,10 +176,9 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       expectedVsyncWakeTimeNs = expectedEndRenderTimeNs - ONE_MILLISECOND_NS
     }
     fpsChangedListener?.let {
-      val currentTime = SystemClock.elapsedRealtimeNanos()
-      val fps = 1E9 / (currentTime - timeElapsed)
+      val fps = 1E9 / (actualEndRenderTimeNs - timeElapsed)
       it.onFpsChanged(fps)
-      timeElapsed = currentTime
+      timeElapsed = actualEndRenderTimeNs
     }
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -115,6 +115,12 @@ internal abstract class MapboxRenderer : MapClient() {
     renderThread.setMaximumFps(fps)
   }
 
+  @AnyThread
+  @Synchronized
+  fun setOnFpsChangedListener(listener: OnFpsChangedListener) {
+    renderThread.fpsChangedListener = listener
+  }
+
   @WorkerThread
   private fun performSnapshot(): Bitmap? {
     if (width == 0 && height == 0) {

--- a/sdk/src/main/java/com/mapbox/maps/renderer/OnFpsChangedListener.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/OnFpsChangedListener.kt
@@ -1,17 +1,20 @@
 package com.mapbox.maps.renderer
 
+import androidx.annotation.WorkerThread
 import com.mapbox.maps.MapView
 
 /**
  * Interface definition for a callback to be invoked when a frame is rendered to the map view.
+ * Important note: [onFpsChanged] is called on non-UI thread.
  *
  * @see [MapView.setOnFpsChangedListener]
  */
 fun interface OnFpsChangedListener {
   /**
-   * Called for every frame rendered to the map view.
+   * Called on non-UI thread for every frame rendered to the map view.
    *
    * @param fps The average number of frames rendered over the last second.
    */
+  @WorkerThread
   fun onFpsChanged(fps: Double)
 }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/OnFpsChangedListener.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/OnFpsChangedListener.kt
@@ -1,0 +1,17 @@
+package com.mapbox.maps.renderer
+
+import com.mapbox.maps.MapView
+
+/**
+ * Interface definition for a callback to be invoked when a frame is rendered to the map view.
+ *
+ * @see [MapView.setOnFpsChangedListener]
+ */
+fun interface OnFpsChangedListener {
+  /**
+   * Called for every frame rendered to the map view.
+   *
+   * @param fps The average number of frames rendered over the last second.
+   */
+  fun onFpsChanged(fps: Double)
+}

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -7,6 +7,7 @@ import com.mapbox.maps.loader.MapboxMapStaticInitializer
 import com.mapbox.maps.plugin.MapPluginRegistry
 import com.mapbox.maps.plugin.delegates.listeners.OnCameraChangeListener
 import com.mapbox.maps.renderer.MapboxRenderer
+import com.mapbox.maps.renderer.OnFpsChangedListener
 import io.mockk.*
 import org.junit.Assert
 import org.junit.Before
@@ -198,5 +199,12 @@ class MapControllerTest {
   fun setMaximumFpsInvalid() {
     mapController.setMaximumFps(-1)
     verify(exactly = 0) { renderer.setMaximumFps(any()) }
+  }
+
+  @Test
+  fun setOnFpsChangedListener() {
+    val listener = mockk<OnFpsChangedListener>()
+    mapController.setOnFpsChangedListener(listener)
+    verify { renderer.setOnFpsChangedListener(listener) }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/MapViewTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapViewTest.kt
@@ -6,6 +6,7 @@ import com.mapbox.common.ShadowLogger
 import com.mapbox.maps.loader.MapboxMapStaticInitializer
 import com.mapbox.maps.plugin.PLUGIN_LOGO_CLASS_NAME
 import com.mapbox.maps.plugin.logo.LogoPlugin
+import com.mapbox.maps.renderer.OnFpsChangedListener
 import io.mockk.*
 import junit.framework.Assert.assertFalse
 import junit.framework.Assert.assertTrue
@@ -163,5 +164,12 @@ class MapViewTest {
     every { mapController.getPlugin(clazz) } returns mockk()
     mapView.getPlugin(clazz)
     verify { mapController.getPlugin(clazz) }
+  }
+
+  @Test
+  fun setOnFpsChangedListener() {
+    val listener = mockk<OnFpsChangedListener>()
+    mapView.setOnFpsChangedListener(listener)
+    verify { mapController.setOnFpsChangedListener(listener) }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -274,4 +274,22 @@ class MapboxRenderThreadTest {
     mapboxRenderThread.requestRender()
     assert(mapboxRenderThread.requestRender.get())
   }
+
+  @Test
+  fun fpsListenerTest() {
+    val listener = mockk<OnFpsChangedListener>(relaxUnitFun = true)
+    val surface = mockk<Surface>()
+    every { surface.isValid } returns true
+    every { eglCore.eglStatusSuccess } returns true
+    every { eglCore.createWindowSurface(any()) } returns mockk(relaxed = true)
+    mapboxRenderThread.onSurfaceCreated(surface, 1, 1)
+    mapboxRenderThread.fpsChangedListener = listener
+    Shadows.shadowOf(workerThread.handler?.looper).pause()
+    mapboxRenderThread.requestRender()
+    mapboxRenderThread.requestRender()
+    Shadows.shadowOf(workerThread.handler?.looper).idle()
+    verify(exactly = 2) {
+      listener.onFpsChanged(any())
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
`<changelog>[rendering] Expose setting FPS listener</changelog>`

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

Expose setting listener to measure FPS for map rendering and show FPS in debug activity example.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

Breaking change in terms of extending public interface `MapControllable`.

<!--
If this PR introduces user-facing changes, please note them here.
-->