### PR TITLE
Change default gesture interpolator to LinearOutSlowInInterpolator

### DIFF
--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -9,7 +9,7 @@ import android.os.Handler
 import android.util.AttributeSet
 import android.view.InputDevice
 import android.view.MotionEvent
-import android.view.animation.DecelerateInterpolator
+import androidx.interpolator.view.animation.LinearOutSlowInInterpolator
 import com.mapbox.android.gestures.*
 import com.mapbox.maps.AnimationOptions
 import com.mapbox.maps.CameraOptions
@@ -80,7 +80,7 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase {
   private var scaleAnimators: Array<ValueAnimator>? = null
   private var rotateAnimators: Array<ValueAnimator>? = null
   private val scheduledAnimators = ArrayList<ValueAnimator>()
-  private val gesturesInterpolator = DecelerateInterpolator()
+  private val gesturesInterpolator = LinearOutSlowInInterpolator()
 
   /**
    * Cancels scheduled velocity animations if user doesn't lift fingers within [SCHEDULED_ANIMATION_TIMEOUT]


### PR DESCRIPTION
This PR changes the default interpolator from `Decelerate` to `LinearOutSlowInInterpolator`. Conceptually they do the same thing but the latter was introduced as part of material design spec as an improved version of the former. 

See https://material.io/design/motion/speed.html > decelerate easing. 

cc @kiryldz 