### PR TITLE
[map] remove renderStill API, this is an internal API

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -819,32 +819,6 @@ class MapboxMap internal constructor(
   }
 
   /**
-   * Render the map to an image asynchronously, resulting image will be provided
-   * through a callback interface.
-   *
-   * @param stillImageCallback the callback to be invoked when the map image has been created
-   */
-  fun renderStill(stillImageCallback: StillImageCallback) {
-    nativeMapWeakRef.call { this.renderStill(stillImageCallback) }
-  }
-
-  /**
-   * Render an image of the map based on camera options and debug options asynchronously,
-   * resulting image will be provided through a callback interface.
-   *
-   * @param cameraOptions the camera options to use when rendering the map image
-   * @param debugOptions the debug options to enable when rendering the map image
-   * @param stillImageCallback the callback to be invoked when the map image has been created
-   */
-  fun renderStill(
-    cameraOptions: CameraOptions,
-    debugOptions: List<MapDebugOptions>,
-    stillImageCallback: StillImageCallback
-  ) {
-    nativeMapWeakRef.call { this.renderStill(cameraOptions, debugOptions, stillImageCallback) }
-  }
-
-  /**
    * @brief Rebinds the default frame buffer object
    *
    * @param framebufferId ID of the new frame buffer object

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -455,26 +455,10 @@ class MapboxMapTest {
   }
 
   @Test
-  fun renderStill() {
-    val callback: StillImageCallback = mockk()
-    mapboxMap.renderStill(callback)
-    verify { nativeMap.renderStill(callback) }
-  }
-
-  @Test
   fun setDefaultFramebufferObject() {
     val id = 1
     mapboxMap.setDefaultFramebufferObject(id)
     verify { nativeMap.setDefaultFramebufferObject(id) }
-  }
-
-  @Test
-  fun renderStillTwo() {
-    val cameraOptions: CameraOptions = mockk()
-    val callback: StillImageCallback = mockk()
-    val debugOptions: List<MapDebugOptions> = mockk()
-    mapboxMap.renderStill(cameraOptions, debugOptions, callback)
-    verify { nativeMap.renderStill(cameraOptions, debugOptions, callback) }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/NativeMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeMapTest.kt
@@ -401,24 +401,6 @@ class NativeMapTest {
   }
 
   @Test
-  fun renderStill() {
-    val value = mockk<StillImageCallback>()
-    val nativeMap = NativeMapImpl(map)
-    nativeMap.renderStill(value)
-    verify { map.renderStill(value) }
-  }
-
-  @Test
-  fun renderStillOptions() {
-    val cameraOptions = mockk<CameraOptions>()
-    val debugOptions = mockk<MutableList<MapDebugOptions>>()
-    val value = mockk<StillImageCallback>()
-    val nativeMap = NativeMapImpl(map)
-    nativeMap.renderStill(cameraOptions, debugOptions, value)
-    verify { map.renderStill(cameraOptions, debugOptions, value) }
-  }
-
-  @Test
   fun triggerRepaint() {
     val nativeMap = NativeMapImpl(map)
     nativeMap.triggerRepaint()


### PR DESCRIPTION
The renderStill API wasn't supposed to be exposed. Users can leverage snapshot() instead.