### PR TITLE
[annotation] Rename getAnnotationManager to createAnnotationManager.

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/UpdateAnnotationTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/UpdateAnnotationTest.kt
@@ -14,7 +14,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.generated.Symbol
 import com.mapbox.maps.plugin.annotation.generated.SymbolManager
 import com.mapbox.maps.plugin.annotation.generated.SymbolOptions
-import com.mapbox.maps.plugin.annotation.generated.getSymbolManager
+import com.mapbox.maps.plugin.annotation.generated.createSymbolManager
 import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.plugin.delegates.listeners.OnDidFinishRenderingMapListener
 import com.mapbox.maps.testapp.BaseMapTest
@@ -47,7 +47,7 @@ class UpdateAnnotationTest : BaseMapTest(), OnDidFinishRenderingMapListener {
 
       it.runOnUiThread {
         mapboxMap.loadStyleUri(AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]) {
-          symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+          symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
           symbol = symbolManager.create(
             SymbolOptions()
               .withIconColor(ColorUtils.colorToRgbaString(Color.RED))

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/CircleManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/CircleManagerAndroidTest.kt
@@ -10,7 +10,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.R
 import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.plugin.annotation.generated.CircleOptions
-import com.mapbox.maps.plugin.annotation.generated.getCircleManager
+import com.mapbox.maps.plugin.annotation.generated.createCircleManager
 import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.testapp.BaseMapTest
 import org.junit.Assert.assertEquals
@@ -36,7 +36,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
   @Test
   fun testCirclePitchAlignment() {
     val testValue = CirclePitchAlignment.MAP
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     circleManager.circlePitchAlignment = testValue
     assertEquals(testValue, circleManager.circlePitchAlignment)
   }
@@ -44,7 +44,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
   @Test
   fun testCirclePitchScale() {
     val testValue = CirclePitchScale.MAP
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     circleManager.circlePitchScale = testValue
     assertEquals(testValue, circleManager.circlePitchScale)
   }
@@ -52,7 +52,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
   @Test
   fun testCircleTranslate() {
     val testValue = listOf(0.0, 1.0)
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     circleManager.circleTranslate = testValue
     assertEquals(testValue, circleManager.circleTranslate)
   }
@@ -60,14 +60,14 @@ class CircleManagerAndroidTest : BaseMapTest() {
   @Test
   fun testCircleTranslateAnchor() {
     val testValue = CircleTranslateAnchor.MAP
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     circleManager.circleTranslateAnchor = testValue
     assertEquals(testValue, circleManager.circleTranslateAnchor)
   }
 
   @Test
   fun create() {
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     val annotation = circleManager.create(
       CircleOptions()
         .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -77,7 +77,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun createFromFeature() {
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     val featureCollection =
       FeatureCollection.fromFeature(Feature.fromGeometry(Point.fromLngLat(0.0, 0.0)))
     val annotations = circleManager.create(featureCollection.toJson())
@@ -88,7 +88,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun createList() {
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     val list = listOf(
       CircleOptions().withPoint(Point.fromLngLat(0.0, 0.0)),
       CircleOptions().withPoint(Point.fromLngLat(0.0, 0.0))
@@ -100,7 +100,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun update() {
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     val annotation = circleManager.create(CircleOptions().withPoint(Point.fromLngLat(0.0, 0.0)))
     assertEquals(annotation, circleManager.annotations[0])
     annotation.point = Point.fromLngLat(1.0, 1.0)
@@ -110,7 +110,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun updateList() {
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     val list = listOf(
       CircleOptions().withPoint(Point.fromLngLat(0.0, 0.0)),
       CircleOptions().withPoint(Point.fromLngLat(0.0, 0.0))
@@ -127,7 +127,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun delete() {
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     val annotation = circleManager.create(
       CircleOptions()
         .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -139,7 +139,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun deleteList() {
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     val list = listOf(
       CircleOptions().withPoint(Point.fromLngLat(0.0, 0.0)),
       CircleOptions().withPoint(Point.fromLngLat(0.0, 0.0))
@@ -154,7 +154,7 @@ class CircleManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun deleteAll() {
-    val circleManager = mapView.getAnnotationPlugin().getCircleManager(mapView)
+    val circleManager = mapView.getAnnotationPlugin().createCircleManager(mapView)
     val list = listOf(
       CircleOptions().withPoint(Point.fromLngLat(0.0, 0.0)),
       CircleOptions().withPoint(Point.fromLngLat(0.0, 0.0))

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/FillManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/FillManagerAndroidTest.kt
@@ -11,7 +11,7 @@ import com.mapbox.geojson.Polygon
 import com.mapbox.maps.R
 import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.plugin.annotation.generated.FillOptions
-import com.mapbox.maps.plugin.annotation.generated.getFillManager
+import com.mapbox.maps.plugin.annotation.generated.createFillManager
 import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.testapp.BaseMapTest
 import org.junit.Assert.assertEquals
@@ -37,7 +37,7 @@ class FillManagerAndroidTest : BaseMapTest() {
   @Test
   fun testFillAntialias() {
     val testValue = true
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     fillManager.fillAntialias = testValue
     assertEquals(testValue, fillManager.fillAntialias)
   }
@@ -45,7 +45,7 @@ class FillManagerAndroidTest : BaseMapTest() {
   @Test
   fun testFillTranslate() {
     val testValue = listOf(0.0, 1.0)
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     fillManager.fillTranslate = testValue
     assertEquals(testValue, fillManager.fillTranslate)
   }
@@ -53,14 +53,14 @@ class FillManagerAndroidTest : BaseMapTest() {
   @Test
   fun testFillTranslateAnchor() {
     val testValue = FillTranslateAnchor.MAP
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     fillManager.fillTranslateAnchor = testValue
     assertEquals(testValue, fillManager.fillTranslateAnchor)
   }
 
   @Test
   fun create() {
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val annotation = fillManager.create(
       FillOptions()
         .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -70,7 +70,7 @@ class FillManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun createFromFeature() {
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val featureCollection =
       FeatureCollection.fromFeature(Feature.fromGeometry(Polygon.fromLngLats(listOf(listOf(Point.fromLngLat(0.0, 0.0))))))
     val annotations = fillManager.create(featureCollection.toJson())
@@ -81,7 +81,7 @@ class FillManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun createList() {
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val list = listOf(
       FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))),
       FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -93,7 +93,7 @@ class FillManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun update() {
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val annotation = fillManager.create(FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))))
     assertEquals(annotation, fillManager.annotations[0])
     annotation.points = listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))
@@ -103,7 +103,7 @@ class FillManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun updateList() {
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val list = listOf(
       FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))),
       FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -120,7 +120,7 @@ class FillManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun delete() {
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val annotation = fillManager.create(
       FillOptions()
         .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -132,7 +132,7 @@ class FillManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun deleteList() {
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val list = listOf(
       FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))),
       FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -147,7 +147,7 @@ class FillManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun deleteAll() {
-    val fillManager = mapView.getAnnotationPlugin().getFillManager(mapView)
+    val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val list = listOf(
       FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))),
       FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/LineManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/LineManagerAndroidTest.kt
@@ -11,7 +11,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.R
 import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.plugin.annotation.generated.LineOptions
-import com.mapbox.maps.plugin.annotation.generated.getLineManager
+import com.mapbox.maps.plugin.annotation.generated.createLineManager
 import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.testapp.BaseMapTest
 import org.junit.Assert.assertEquals
@@ -37,7 +37,7 @@ class LineManagerAndroidTest : BaseMapTest() {
   @Test
   fun testLineCap() {
     val testValue = LineCap.BUTT
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     lineManager.lineCap = testValue
     assertEquals(testValue, lineManager.lineCap)
   }
@@ -45,7 +45,7 @@ class LineManagerAndroidTest : BaseMapTest() {
   @Test
   fun testLineMiterLimit() {
     val testValue = 1.0
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     lineManager.lineMiterLimit = testValue
     assertEquals(testValue, lineManager.lineMiterLimit)
   }
@@ -53,7 +53,7 @@ class LineManagerAndroidTest : BaseMapTest() {
   @Test
   fun testLineRoundLimit() {
     val testValue = 1.0
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     lineManager.lineRoundLimit = testValue
     assertEquals(testValue, lineManager.lineRoundLimit)
   }
@@ -61,7 +61,7 @@ class LineManagerAndroidTest : BaseMapTest() {
   @Test
   fun testLineDasharray() {
     val testValue = listOf(1.0, 2.0)
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     lineManager.lineDasharray = testValue
     assertEquals(testValue, lineManager.lineDasharray)
   }
@@ -69,7 +69,7 @@ class LineManagerAndroidTest : BaseMapTest() {
   @Test
   fun testLineTranslate() {
     val testValue = listOf(0.0, 1.0)
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     lineManager.lineTranslate = testValue
     assertEquals(testValue, lineManager.lineTranslate)
   }
@@ -77,14 +77,14 @@ class LineManagerAndroidTest : BaseMapTest() {
   @Test
   fun testLineTranslateAnchor() {
     val testValue = LineTranslateAnchor.MAP
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     lineManager.lineTranslateAnchor = testValue
     assertEquals(testValue, lineManager.lineTranslateAnchor)
   }
 
   @Test
   fun create() {
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     val annotation = lineManager.create(
       LineOptions()
         .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -94,7 +94,7 @@ class LineManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun createFromFeature() {
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     val featureCollection =
       FeatureCollection.fromFeature(Feature.fromGeometry(LineString.fromLngLats(listOf(Point.fromLngLat(0.0, 0.0)))))
     val annotations = lineManager.create(featureCollection.toJson())
@@ -105,7 +105,7 @@ class LineManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun createList() {
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     val list = listOf(
       LineOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0))),
       LineOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -117,7 +117,7 @@ class LineManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun update() {
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     val annotation = lineManager.create(LineOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0))))
     assertEquals(annotation, lineManager.annotations[0])
     annotation.points = listOf(Point.fromLngLat(1.0, 1.0), Point.fromLngLat(1.0, 1.0))
@@ -127,7 +127,7 @@ class LineManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun updateList() {
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     val list = listOf(
       LineOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0))),
       LineOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -144,7 +144,7 @@ class LineManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun delete() {
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     val annotation = lineManager.create(
       LineOptions()
         .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -156,7 +156,7 @@ class LineManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun deleteList() {
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     val list = listOf(
       LineOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0))),
       LineOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -171,7 +171,7 @@ class LineManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun deleteAll() {
-    val lineManager = mapView.getAnnotationPlugin().getLineManager(mapView)
+    val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     val list = listOf(
       LineOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0))),
       LineOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/SymbolManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/SymbolManagerAndroidTest.kt
@@ -10,7 +10,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.R
 import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.plugin.annotation.generated.SymbolOptions
-import com.mapbox.maps.plugin.annotation.generated.getSymbolManager
+import com.mapbox.maps.plugin.annotation.generated.createSymbolManager
 import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.testapp.BaseMapTest
 import org.junit.Assert.assertEquals
@@ -36,7 +36,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconAllowOverlap() {
     val testValue = true
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconAllowOverlap = testValue
     assertEquals(testValue, symbolManager.iconAllowOverlap)
   }
@@ -44,7 +44,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconIgnorePlacement() {
     val testValue = true
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconIgnorePlacement = testValue
     assertEquals(testValue, symbolManager.iconIgnorePlacement)
   }
@@ -52,7 +52,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconKeepUpright() {
     val testValue = true
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconKeepUpright = testValue
     assertEquals(testValue, symbolManager.iconKeepUpright)
   }
@@ -60,7 +60,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconOptional() {
     val testValue = true
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconOptional = testValue
     assertEquals(testValue, symbolManager.iconOptional)
   }
@@ -68,7 +68,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconPadding() {
     val testValue = 1.0
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconPadding = testValue
     assertEquals(testValue, symbolManager.iconPadding)
   }
@@ -76,7 +76,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconPitchAlignment() {
     val testValue = IconPitchAlignment.MAP
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconPitchAlignment = testValue
     assertEquals(testValue, symbolManager.iconPitchAlignment)
   }
@@ -84,7 +84,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconRotationAlignment() {
     val testValue = IconRotationAlignment.MAP
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconRotationAlignment = testValue
     assertEquals(testValue, symbolManager.iconRotationAlignment)
   }
@@ -92,7 +92,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconTextFit() {
     val testValue = IconTextFit.NONE
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconTextFit = testValue
     assertEquals(testValue, symbolManager.iconTextFit)
   }
@@ -100,7 +100,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconTextFitPadding() {
     val testValue = listOf(0.0, 1.0, 2.0, 3.0)
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconTextFitPadding = testValue
     assertEquals(testValue, symbolManager.iconTextFitPadding)
   }
@@ -108,7 +108,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testSymbolAvoidEdges() {
     val testValue = true
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.symbolAvoidEdges = testValue
     assertEquals(testValue, symbolManager.symbolAvoidEdges)
   }
@@ -116,7 +116,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testSymbolPlacement() {
     val testValue = SymbolPlacement.POINT
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.symbolPlacement = testValue
     assertEquals(testValue, symbolManager.symbolPlacement)
   }
@@ -124,7 +124,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testSymbolSpacing() {
     val testValue = 1.0
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.symbolSpacing = testValue
     assertEquals(testValue, symbolManager.symbolSpacing)
   }
@@ -132,7 +132,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextAllowOverlap() {
     val testValue = true
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textAllowOverlap = testValue
     assertEquals(testValue, symbolManager.textAllowOverlap)
   }
@@ -140,7 +140,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextIgnorePlacement() {
     val testValue = true
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textIgnorePlacement = testValue
     assertEquals(testValue, symbolManager.textIgnorePlacement)
   }
@@ -148,7 +148,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextKeepUpright() {
     val testValue = true
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textKeepUpright = testValue
     assertEquals(testValue, symbolManager.textKeepUpright)
   }
@@ -156,7 +156,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextLineHeight() {
     val testValue = 1.0
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textLineHeight = testValue
     assertEquals(testValue, symbolManager.textLineHeight)
   }
@@ -164,7 +164,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextMaxAngle() {
     val testValue = 1.0
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textMaxAngle = testValue
     assertEquals(testValue, symbolManager.textMaxAngle)
   }
@@ -172,7 +172,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextOptional() {
     val testValue = true
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textOptional = testValue
     assertEquals(testValue, symbolManager.textOptional)
   }
@@ -180,7 +180,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextPadding() {
     val testValue = 1.0
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textPadding = testValue
     assertEquals(testValue, symbolManager.textPadding)
   }
@@ -188,7 +188,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextPitchAlignment() {
     val testValue = TextPitchAlignment.MAP
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textPitchAlignment = testValue
     assertEquals(testValue, symbolManager.textPitchAlignment)
   }
@@ -196,7 +196,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextRotationAlignment() {
     val testValue = TextRotationAlignment.MAP
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textRotationAlignment = testValue
     assertEquals(testValue, symbolManager.textRotationAlignment)
   }
@@ -204,7 +204,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextVariableAnchor() {
     val testValue = listOf("center", "left")
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textVariableAnchor = testValue
     assertEquals(testValue, symbolManager.textVariableAnchor)
   }
@@ -212,7 +212,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextWritingMode() {
     val testValue = listOf("horizontal", "vertical")
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textWritingMode = testValue
     assertEquals(testValue, symbolManager.textWritingMode)
   }
@@ -220,7 +220,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconTranslate() {
     val testValue = listOf(0.0, 1.0)
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconTranslate = testValue
     assertEquals(testValue, symbolManager.iconTranslate)
   }
@@ -228,7 +228,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testIconTranslateAnchor() {
     val testValue = IconTranslateAnchor.MAP
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.iconTranslateAnchor = testValue
     assertEquals(testValue, symbolManager.iconTranslateAnchor)
   }
@@ -236,7 +236,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextTranslate() {
     val testValue = listOf(0.0, 1.0)
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textTranslate = testValue
     assertEquals(testValue, symbolManager.textTranslate)
   }
@@ -244,14 +244,14 @@ class SymbolManagerAndroidTest : BaseMapTest() {
   @Test
   fun testTextTranslateAnchor() {
     val testValue = TextTranslateAnchor.MAP
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     symbolManager.textTranslateAnchor = testValue
     assertEquals(testValue, symbolManager.textTranslateAnchor)
   }
 
   @Test
   fun create() {
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     val annotation = symbolManager.create(
       SymbolOptions()
         .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -261,7 +261,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun createFromFeature() {
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     val featureCollection =
       FeatureCollection.fromFeature(Feature.fromGeometry(Point.fromLngLat(0.0, 0.0)))
     val annotations = symbolManager.create(featureCollection.toJson())
@@ -272,7 +272,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun createList() {
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     val list = listOf(
       SymbolOptions().withPoint(Point.fromLngLat(0.0, 0.0)),
       SymbolOptions().withPoint(Point.fromLngLat(0.0, 0.0))
@@ -284,7 +284,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun update() {
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     val annotation = symbolManager.create(SymbolOptions().withPoint(Point.fromLngLat(0.0, 0.0)))
     assertEquals(annotation, symbolManager.annotations[0])
     annotation.point = Point.fromLngLat(1.0, 1.0)
@@ -294,7 +294,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun updateList() {
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     val list = listOf(
       SymbolOptions().withPoint(Point.fromLngLat(0.0, 0.0)),
       SymbolOptions().withPoint(Point.fromLngLat(0.0, 0.0))
@@ -311,7 +311,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun delete() {
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     val annotation = symbolManager.create(
       SymbolOptions()
         .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -323,7 +323,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun deleteList() {
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     val list = listOf(
       SymbolOptions().withPoint(Point.fromLngLat(0.0, 0.0)),
       SymbolOptions().withPoint(Point.fromLngLat(0.0, 0.0))
@@ -338,7 +338,7 @@ class SymbolManagerAndroidTest : BaseMapTest() {
 
   @Test
   fun deleteAll() {
-    val symbolManager = mapView.getAnnotationPlugin().getSymbolManager(mapView)
+    val symbolManager = mapView.getAnnotationPlugin().createSymbolManager(mapView)
     val list = listOf(
       SymbolOptions().withPoint(Point.fromLngLat(0.0, 0.0)),
       SymbolOptions().withPoint(Point.fromLngLat(0.0, 0.0))

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/CircleActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/CircleActivity.kt
@@ -31,7 +31,7 @@ class CircleActivity : AppCompatActivity() {
     setContentView(R.layout.activity_annotation)
     mapView.getMapboxMap().loadStyleUri(nextStyle) {
       val annotationPlugin = mapView.getAnnotationPlugin()
-      circleManager = annotationPlugin.getCircleManager(mapView).apply {
+      circleManager = annotationPlugin.createCircleManager(mapView).apply {
         addClickListener(
           OnCircleClickListener {
             Toast.makeText(this@CircleActivity, "click", Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/FillActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/FillActivity.kt
@@ -32,7 +32,7 @@ class FillActivity : AppCompatActivity() {
     setContentView(R.layout.activity_annotation)
     mapView.getMapboxMap().loadStyleUri(nextStyle) {
       val annotationPlugin = mapView.getAnnotationPlugin()
-      fillManager = annotationPlugin.getFillManager(mapView).apply {
+      fillManager = annotationPlugin.createFillManager(mapView).apply {
         addClickListener(
           OnFillClickListener {
             Toast.makeText(this@FillActivity, "click", Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/LineActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/LineActivity.kt
@@ -33,7 +33,7 @@ class LineActivity : AppCompatActivity() {
     setContentView(R.layout.activity_annotation)
     mapView.getMapboxMap().loadStyleUri(nextStyle) {
       val annotationPlugin = mapView.getAnnotationPlugin()
-      lineManager = annotationPlugin.getLineManager(
+      lineManager = annotationPlugin.createLineManager(
         mapView,
         AnnotationConfig(COUNTRY_LABEL, LAYER_ID, SOURCE_ID)
       ).apply {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
@@ -46,7 +46,7 @@ class SymbolActivity : AppCompatActivity() {
     setContentView(R.layout.activity_annotation)
     mapView.getMapboxMap().loadStyleUri(nextStyle) {
       val annotationPlugin = mapView.getAnnotationPlugin()
-      symbolManager = annotationPlugin.getSymbolManager(mapView).apply {
+      symbolManager = annotationPlugin.createSymbolManager(mapView).apply {
         addClickListener(
           OnSymbolClickListener {
             Toast.makeText(this@SymbolActivity, "Click: $it", Toast.LENGTH_LONG).show()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
@@ -19,14 +19,14 @@ class AnnotationPluginImpl : AnnotationPlugin {
   private var height = 0
 
   /**
-   * Get an annotation manger
+   * Create an annotation manger instance.
    *
    * @param mapView the mapView
    * @param type The type of he type of annotation manger
    * @param annotationConfig the configuration for AnnotationManager
    * @return the annotation manger
    */
-  override fun getAnnotationManager(
+  override fun createAnnotationManager(
     mapView: View,
     type: AnnotationType,
     annotationConfig: AnnotationConfig?

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleManager.kt
@@ -278,11 +278,11 @@ class CircleManager(
 }
 
 /**
- * Extension function to get CircleManager instance
+ * Extension function to create a CircleManager instance.
  */
-fun AnnotationPlugin.getCircleManager(
+fun AnnotationPlugin.createCircleManager(
   mapView: View,
   annotationConfig: AnnotationConfig? = null
 ): CircleManager {
-  return getAnnotationManager(mapView, AnnotationType.Circle, annotationConfig) as CircleManager
+  return createAnnotationManager(mapView, AnnotationType.Circle, annotationConfig) as CircleManager
 }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/FillManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/FillManager.kt
@@ -242,11 +242,11 @@ class FillManager(
 }
 
 /**
- * Extension function to get FillManager instance
+ * Extension function to create a FillManager instance.
  */
-fun AnnotationPlugin.getFillManager(
+fun AnnotationPlugin.createFillManager(
   mapView: View,
   annotationConfig: AnnotationConfig? = null
 ): FillManager {
-  return getAnnotationManager(mapView, AnnotationType.Fill, annotationConfig) as FillManager
+  return createAnnotationManager(mapView, AnnotationType.Fill, annotationConfig) as FillManager
 }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/LineManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/LineManager.kt
@@ -330,11 +330,11 @@ class LineManager(
 }
 
 /**
- * Extension function to get LineManager instance
+ * Extension function to create a LineManager instance.
  */
-fun AnnotationPlugin.getLineManager(
+fun AnnotationPlugin.createLineManager(
   mapView: View,
   annotationConfig: AnnotationConfig? = null
 ): LineManager {
-  return getAnnotationManager(mapView, AnnotationType.Line, annotationConfig) as LineManager
+  return createAnnotationManager(mapView, AnnotationType.Line, annotationConfig) as LineManager
 }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolManager.kt
@@ -906,11 +906,11 @@ class SymbolManager(
 }
 
 /**
- * Extension function to get SymbolManager instance
+ * Extension function to create a SymbolManager instance.
  */
-fun AnnotationPlugin.getSymbolManager(
+fun AnnotationPlugin.createSymbolManager(
   mapView: View,
   annotationConfig: AnnotationConfig? = null
 ): SymbolManager {
-  return getAnnotationManager(mapView, AnnotationType.Symbol, annotationConfig) as SymbolManager
+  return createAnnotationManager(mapView, AnnotationType.Symbol, annotationConfig) as SymbolManager
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
@@ -16,7 +16,7 @@ fun interface AnnotationPlugin : MapPlugin, MapSizePlugin {
    * @param annotationConfig the configuration for AnnotationManager
    * @return the annotation manger
    */
-  fun getAnnotationManager(
+  fun createAnnotationManager(
     mapView: View,
     type: AnnotationType,
     annotationConfig: AnnotationConfig?


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #102 
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Rename getAnnotationManager to createAnnotationManager.</changelog>`.

### Summary of changes
This PR renames the `getAnnotationManager` to `createAnnotationManager`.
This PR also renames the following methods:
`getLineManager` to `createLineManager`
`getCircleManager` to `createCircleManager`
`getFillManager` to `createFillManager`
`getSymbolManager` to `createSymbolManager`
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->