### PR TITLE
[animations] Process anchor animators correctly

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -153,7 +153,8 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     val startValue = cameraAnimator.startValue ?: when (cameraAnimator.type) {
       CameraAnimatorType.CENTER -> mapCameraDelegate.getCameraOptions().center
       CameraAnimatorType.ZOOM -> mapCameraDelegate.getCameraOptions().zoom
-      CameraAnimatorType.ANCHOR -> anchor
+      // TODO revisit after https://github.com/mapbox/mapbox-maps-android/issues/119
+      CameraAnimatorType.ANCHOR -> anchor ?: ScreenCoordinate(0.0, 0.0)
       CameraAnimatorType.PADDING -> mapCameraDelegate.getCameraOptions().padding
       CameraAnimatorType.BEARING -> mapCameraDelegate.getCameraOptions().bearing
       CameraAnimatorType.PITCH -> mapCameraDelegate.getCameraOptions().pitch

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -43,7 +43,7 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
   private val zoomListeners = CopyOnWriteArraySet<CameraAnimatorChangeListener<Double>>()
   private val paddingListeners = CopyOnWriteArraySet<CameraAnimatorChangeListener<EdgeInsets>>()
   private val anchorListeners =
-    CopyOnWriteArraySet<CameraAnimatorChangeListener<ScreenCoordinate>>()
+    CopyOnWriteArraySet<CameraAnimatorNullableChangeListener<ScreenCoordinate?>>()
   private val bearingListeners = CopyOnWriteArraySet<CameraAnimatorChangeListener<Double>>()
   private val pitchListeners = CopyOnWriteArraySet<CameraAnimatorChangeListener<Double>>()
 
@@ -73,11 +73,9 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     }
   }
 
-  private var anchor by Delegates.observable<ScreenCoordinate?>(null) { _, old, new ->
-    new?.let {
-      if (old != it) {
-        anchorListeners.forEach { listener -> listener.onChanged(it) }
-      }
+  override var anchor by Delegates.observable<ScreenCoordinate?>(null) { _, old, new ->
+    if (old != new) {
+      anchorListeners.forEach { listener -> listener.onChanged(new) }
     }
   }
 
@@ -155,7 +153,7 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     val startValue = cameraAnimator.startValue ?: when (cameraAnimator.type) {
       CameraAnimatorType.CENTER -> mapCameraDelegate.getCameraOptions().center
       CameraAnimatorType.ZOOM -> mapCameraDelegate.getCameraOptions().zoom
-      CameraAnimatorType.ANCHOR -> cameraAnimator.startValue
+      CameraAnimatorType.ANCHOR -> anchor
       CameraAnimatorType.PADDING -> mapCameraDelegate.getCameraOptions().padding
       CameraAnimatorType.BEARING -> mapCameraDelegate.getCameraOptions().bearing
       CameraAnimatorType.PITCH -> mapCameraDelegate.getCameraOptions().pitch
@@ -191,7 +189,6 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
 
   internal fun notifyListeners(cameraOptions: CameraOptions) {
     cameraOptions.also {
-      anchor = it.anchor
       bearing = it.bearing
       center = it.center
       padding = it.padding
@@ -278,7 +275,11 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
             unregisterAnimators(this, cancelAnimators = false)
           }
           if (runningAnimatorsQueue.isEmpty()) {
-            performMapJump(cameraOptionsBuilder.build())
+            // TODO revisit after https://github.com/mapbox/mapbox-maps-android/issues/119
+            if (animator.type == CameraAnimatorType.ANCHOR) {
+              anchor = animatedValue as ScreenCoordinate
+            }
+            performMapJump(cameraOptionsBuilder.anchor(anchor).build())
             mapTransformDelegate.setUserAnimationInProgress(false)
           }
         } ?: throw RuntimeException(
@@ -312,7 +313,12 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
           null
         }
       }
+      // TODO revisit after https://github.com/mapbox/mapbox-maps-android/issues/119
+      if (animator.type == CameraAnimatorType.ANCHOR) {
+        anchor = it.animatedValue as ScreenCoordinate
+      }
       cameraOptions?.let { camera ->
+        camera.anchor = anchor
         // move map camera
         performMapJump(camera)
         // reset values
@@ -471,20 +477,20 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
   }
 
   /**
-   * Add [CameraAnimatorChangeListener] to receive map anchor updates.
+   * Add [CameraAnimatorNullableChangeListener] to receive map anchor updates.
    *
-   * @param listener Instance of [CameraAnimatorChangeListener]
+   * @param listener Instance of [CameraAnimatorNullableChangeListener]
    */
-  override fun addCameraAnchorChangeListener(listener: CameraAnimatorChangeListener<ScreenCoordinate>) {
+  override fun addCameraAnchorChangeListener(listener: CameraAnimatorNullableChangeListener<ScreenCoordinate?>) {
     anchorListeners.add(listener)
   }
 
   /**
-   * Remove [CameraAnimatorChangeListener]. No updates will arrive after that.
+   * Remove [CameraAnimatorNullableChangeListener]. No updates will arrive after that.
    *
-   * @param listener Instance of [CameraAnimatorChangeListener]
+   * @param listener Instance of [CameraAnimatorNullableChangeListener]
    */
-  override fun removeCameraAnchorChangeListener(listener: CameraAnimatorChangeListener<ScreenCoordinate>) {
+  override fun removeCameraAnchorChangeListener(listener: CameraAnimatorNullableChangeListener<ScreenCoordinate?>) {
     anchorListeners.remove(listener)
   }
 

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsChangeListenersTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsChangeListenersTest.kt
@@ -123,7 +123,7 @@ class CameraAnimationsChangeListenersTest {
   @Test
   fun addCameraAnchorChangeListener() {
     val cameraAnimationsPluginImpl = CameraAnimationsPluginImpl()
-    val listener = CameraAnimatorChangeListener<ScreenCoordinate> { updatedValue ->
+    val listener = CameraAnimatorNullableChangeListener<ScreenCoordinate?> { updatedValue ->
       Assert.assertEquals(
         ScreenCoordinate(
           CameraAnimationsPluginImplTest.VALUE,
@@ -139,7 +139,7 @@ class CameraAnimationsChangeListenersTest {
   @Test
   fun removeCameraAnchorChangeListener() {
     val cameraAnimationsPluginImpl = CameraAnimationsPluginImpl()
-    val listener = CameraAnimatorChangeListener<ScreenCoordinate> { assert(false) }
+    val listener = CameraAnimatorNullableChangeListener<ScreenCoordinate?> { assert(false) }
     cameraAnimationsPluginImpl.addCameraAnchorChangeListener(listener)
     cameraAnimationsPluginImpl.removeCameraAnchorChangeListener(listener)
     cameraAnimationsPluginImpl.notifyListeners(cameraOptions)

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -806,6 +806,28 @@ class CameraAnimationsPluginImplTest {
     assertEquals(true, listenerTwo.interrupting)
   }
 
+  @Test
+  fun anchorTest() {
+    shadowOf(getMainLooper()).pause()
+    val anchor = ScreenCoordinate(7.0, 7.0)
+    val anchorAnimator = cameraAnimationsPluginImpl.createAnchorAnimator(
+      cameraAnimatorOptions(anchor) {
+        startValue(anchor)
+      }
+    ) {
+      duration = 10L
+    }
+    cameraAnimationsPluginImpl.registerAnimators(anchorAnimator)
+    anchorAnimator.start()
+    shadowOf(getMainLooper()).idle()
+    assertEquals(anchor, cameraAnimationsPluginImpl.anchor)
+    var counter = 0
+    cameraAnimationsPluginImpl.addCameraAnchorChangeListener { counter++ }
+    cameraAnimationsPluginImpl.anchor = null
+    assertEquals(null, cameraAnimationsPluginImpl.anchor)
+    assertEquals(1, counter)
+  }
+
   class LifecycleListener : CameraAnimationsLifecycleListener {
     var starting = false
     var interrupting = false

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
@@ -11,6 +11,13 @@ import com.mapbox.maps.plugin.MapPlugin
  * Interface to interact with Camera Animations plugin
  */
 interface CameraAnimationsPlugin : MapPlugin {
+
+  /**
+   * Map camera anchor value.
+   * If equal to NULL then center of map view is treated as anchor.
+   */
+  var anchor: ScreenCoordinate?
+
   /**
    * Ease the map camera to a given camera options.
    *
@@ -245,14 +252,14 @@ interface CameraAnimationsPlugin : MapPlugin {
    *
    * @param listener to be invoked when camera bearing value changes
    */
-  fun addCameraAnchorChangeListener(listener: CameraAnimatorChangeListener<ScreenCoordinate>)
+  fun addCameraAnchorChangeListener(listener: CameraAnimatorNullableChangeListener<ScreenCoordinate?>)
 
   /**
    * Remove camera anchor change listener
    *
    * @param listener to be invoked when camera anchor value changes
    */
-  fun removeCameraAnchorChangeListener(listener: CameraAnimatorChangeListener<ScreenCoordinate>)
+  fun removeCameraAnchorChangeListener(listener: CameraAnimatorNullableChangeListener<ScreenCoordinate?>)
 
   /**
    * Add camera bearing change listener

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
@@ -14,7 +14,15 @@ interface CameraAnimationsPlugin : MapPlugin {
 
   /**
    * Map camera anchor value.
-   * If equal to NULL then center of map view is treated as anchor.
+   * Default value is NULL meaning center of given map view.
+   * Left-top corner is represented as [ScreenCoordinate] (0.0, 0.0).
+   *
+   * If [anchor] is set to some specific value (set directly or by some running anchor animation)
+   * it will be used as anchor for all upcoming animations even if they do not animate anchor directly.
+   *
+   * **Note**: If anchor animator is started and no start value is specified explicitly
+   * and [anchor] = NULL - then start value will be set to ScreenCoordinate(0.0, 0.0) automatically
+   * and it will be start point for interpolation.
    */
   var anchor: ScreenCoordinate?
 

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorNullableChangeListener.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorNullableChangeListener.kt
@@ -1,14 +1,14 @@
 package com.mapbox.maps.plugin.animation
 
 /**
- * Interface to get updated non-nullable animator values.
+ * Interface to get updated animator values including nulls.
  */
-fun interface CameraAnimatorChangeListener<T> {
+fun interface CameraAnimatorNullableChangeListener<T> {
 
   /**
    * Called when new animator value has arrived different from previous one.
    *
    * @param updatedValue value when given camera property has changed.
    */
-  fun onChanged(updatedValue: T)
+  fun onChanged(updatedValue: T?)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #82 
`<changelog>[animations] Cache map anchor in animation plugin, fix anchor camera animators</changelog>`

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

Treat `CameraOptions.anchor(ScreenCoordinate)` as all other camera options (zoom, bearing, etc). It means that if some animator did change an anchor - it will be saved and cached in `CameraAnimationPlugin` and used as initial start value for all upcoming animators if start value not specified explicitly.
This change fixes using anchor animators in gesture plugin.
`CameraAnimationsPlugin.anchor` override var is added to get / set anchor values.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->