### PR TITLE
[Annotation plugin] Change the default value of textFont to null; Add size check for properties in Symbol

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
@@ -1133,7 +1133,7 @@ class Symbol(
     if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_IMAGE).isJsonNull)) {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_IMAGE)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_OFFSET).isJsonNull)) {
+    if ((jsonObject.get(SymbolOptions.PROPERTY_ICON_OFFSET) as JsonArray).size() > 0) {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_OFFSET)
     }
     if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_ROTATE).isJsonNull)) {
@@ -1151,7 +1151,7 @@ class Symbol(
     if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_FIELD).isJsonNull)) {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_FIELD)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_FONT).isJsonNull)) {
+    if ((jsonObject.get(SymbolOptions.PROPERTY_TEXT_FONT) as JsonArray).size() > 0) {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_FONT)
     }
     if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_JUSTIFY).isJsonNull)) {
@@ -1163,7 +1163,7 @@ class Symbol(
     if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_MAX_WIDTH).isJsonNull)) {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_MAX_WIDTH)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_OFFSET).isJsonNull)) {
+    if ((jsonObject.get(SymbolOptions.PROPERTY_TEXT_OFFSET) as JsonArray).size() > 0) {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_OFFSET)
     }
     if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_RADIAL_OFFSET).isJsonNull)) {

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
@@ -189,7 +189,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Font stack to use for displaying text.
    */
-  var textFont: List<String> = listOf("Open Sans Regular", "Arial Unicode MS Regular")
+  var textFont: List<String>? = null
 
   /**
    * Set text-font to initialise the symbol with.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #97 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[Annotation plugin] Change the default value of textFont to null; Add size check for properties in Symbol</changelog>`.

### Summary of changes
This PR changes the default value of textFont to null and adds size check in Symbol while enabling data-driven properties.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->