### PR TITLE
[Annotation plugin] Show all icons and texts of symbols by default

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
@@ -61,10 +61,6 @@ class SymbolActivity : AppCompatActivity() {
           }
         )
 
-        // set non data driven properties
-        iconAllowOverlap = true
-        textAllowOverlap = true
-
         BitmapUtils.getBitmapFromDrawable(
           ResourcesCompat.getDrawable(
             resources,
@@ -77,10 +73,10 @@ class SymbolActivity : AppCompatActivity() {
             .withPoint(Point.fromLngLat(AIRPORT_LONGITUDE, AIRPORT_LATITUDE))
             .withIconImage(it)
             .withTextField(ID_ICON_AIRPORT)
-            .withTextOffset(listOf(0.0, -1.0))
+            .withTextOffset(listOf(0.0, -2.0))
             .withTextColor(Color.RED)
             .withIconSize(1.3)
-            .withIconOffset(listOf(5.0, 10.0))
+            .withIconOffset(listOf(0.0, -5.0))
             .withSymbolSortKey(10.0)
             .withDraggable(true)
           symbol = create(symbolOptions)
@@ -89,7 +85,7 @@ class SymbolActivity : AppCompatActivity() {
         BitmapUtils.getBitmapFromDrawable(
           ResourcesCompat.getDrawable(
             resources,
-            R.drawable.custom_user_arrow,
+            R.drawable.mapbox_user_icon,
             this@SymbolActivity.theme
           )
         )?.let {
@@ -97,8 +93,8 @@ class SymbolActivity : AppCompatActivity() {
           val nearbyOptions: SymbolOptions = SymbolOptions()
             .withPoint(Point.fromLngLat(NEARBY_LONGITUDE, NEARBY_LATITUDE))
             .withIconImage(it)
-            .withIconColor(Color.YELLOW)
             .withIconSize(2.5)
+            .withTextField(ID_ICON_AIRPORT)
             .withSymbolSortKey(5.0)
             .withDraggable(true)
           create(nearbyOptions)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolManager.kt
@@ -38,6 +38,11 @@ class SymbolManager(
     delegateProvider.getStyle {
       style = it
       initLayerAndSource()
+      // Show all icons and texts by default. 
+      iconAllowOverlap = true
+      textAllowOverlap = true
+      iconIgnorePlacement = true
+      textIgnorePlacement = true
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[Annotation plugin] Show all icons and texts of symbols by default</changelog>`.

### Summary of changes
By default, symbols will not be shown if there are overlaps or collide. 
This pr change these default values to show all symbols by default. 
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->