### PR TITLE
[Compass plugin] Hidden the compass if facing north; apply the opacity correctly.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
@@ -8,6 +8,7 @@ import com.mapbox.maps.*
 import com.mapbox.maps.extension.observable.getEventData
 import com.mapbox.maps.extension.observable.subscribeResourceRequest
 import com.mapbox.maps.extension.observable.unsubscribeResourceRequest
+import com.mapbox.maps.plugin.compass.getCompassPlugin
 import com.mapbox.maps.plugin.scalebar.ScaleBarPlugin
 import com.mapbox.maps.plugin.scalebar.getScaleBarPlugin
 import com.mapbox.maps.testapp.R
@@ -49,6 +50,7 @@ class DebugModeActivity : AppCompatActivity() {
     // Using the extension method
     mapboxMap.subscribeResourceRequest(extensionObservable)
     mapboxMap.loadStyleUri(Style.MAPBOX_STREETS)
+    mapView.getCompassPlugin().opacity = 0.5f
     scaleBarPlugin = mapView.getScaleBarPlugin()
     scaleBarPlugin.enabled = false
     scaleBarPlugin.textColor = ContextCompat.getColor(this@DebugModeActivity, R.color.primary)

--- a/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
+++ b/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
@@ -51,11 +51,15 @@ open class CompassViewPlugin(
         compassView.isCompassVisible = false
       }
     )
-    fadeAnimator.addUpdateListener { compassView.setCompassAlpha(it.animatedValue as Float) }
+    fadeAnimator.addUpdateListener {
+      val value = it.animatedValue as Float
+      if (value < internalSettings.opacity) {
+        compassView.setCompassAlpha(value)
+      }
+    }
   }
 
   override fun applySettings() {
-    compassView.isCompassVisible = internalSettings.visibility
     compassView.compassGravity = internalSettings.position
     internalSettings.image?.let {
       compassView.compassImage = it
@@ -70,7 +74,6 @@ open class CompassViewPlugin(
       internalSettings.marginBottom.toInt()
     )
     update(mapCameraDelegate.getBearing())
-    updateVisibility()
   }
 
   /**
@@ -115,6 +118,7 @@ open class CompassViewPlugin(
   override fun onPluginView(view: View) {
     compassView = view as? CompassView
       ?: throw IllegalArgumentException("The provided view needs to implement CompassContract.CompassView")
+    updateVisibility(false)
   }
 
   /**
@@ -217,7 +221,7 @@ open class CompassViewPlugin(
     updateVisibility()
   }
 
-  private fun updateVisibility() {
+  private fun updateVisibility(withAnimator: Boolean = true) {
     if (!compassView.isCompassEnabled) {
       return
     }
@@ -227,12 +231,17 @@ open class CompassViewPlugin(
         return
       }
       isHidden = true
-      fadeAnimator.start()
+      if (withAnimator) {
+        fadeAnimator.start()
+      } else {
+        compassView.isCompassVisible = false
+        compassView.setCompassAlpha(0.0f)
+      }
     } else {
       isHidden = false
       fadeAnimator.cancel()
       compassView.isCompassVisible = true
-      compassView.setCompassAlpha(1.0f)
+      compassView.setCompassAlpha(internalSettings.opacity)
     }
   }
 

--- a/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
+++ b/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
@@ -66,6 +66,26 @@ class CompassViewPluginTest {
   }
 
   @Test
+  fun fadeAnimatorValue() {
+    compassPlugin.opacity = 0.5f
+    every { fadeAnimator.animatedValue } returns 1.0f
+    fadeAnimatorUpdateListener.onAnimationUpdate(fadeAnimator)
+    verify(exactly = 0) { compassView.setCompassAlpha(1.0f) }
+
+    every { fadeAnimator.animatedValue } returns 0.6f
+    fadeAnimatorUpdateListener.onAnimationUpdate(fadeAnimator)
+    verify(exactly = 0) { compassView.setCompassAlpha(0.6f) }
+
+    every { fadeAnimator.animatedValue } returns 0.4f
+    fadeAnimatorUpdateListener.onAnimationUpdate(fadeAnimator)
+    verify(exactly = 1) { compassView.setCompassAlpha(0.4f) }
+
+    every { fadeAnimator.animatedValue } returns 0.1f
+    fadeAnimatorUpdateListener.onAnimationUpdate(fadeAnimator)
+    verify(exactly = 1) { compassView.setCompassAlpha(0.1f) }
+  }
+
+  @Test
   fun fadeAnimatorUpdateListener() {
     every { fadeAnimator.animatedValue } returns 0.78f
     fadeAnimatorUpdateListener.onAnimationUpdate(fadeAnimator)
@@ -191,6 +211,7 @@ class CompassViewPluginTest {
     every { mapView.context } returns mockk(relaxed = true)
     assertEquals(compassView, compassPlugin.bind(mapView, mockk(relaxUnitFun = true), 1.0f))
     verify { compassView.injectPresenter(compassPlugin) }
+    verify { compassView.isCompassVisible = false }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #41 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[Compass plugin] Hidden the compass if facing north; apply the opacity correctly.</changelog>`.

### Summary of changes
This pr will hide the compass while opening a map that faces north.
In the past, the opacity will change from 1.0 to 0.0 while the compass is hiding even user sets the compass opacity, this pr fix this issue too.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->