### PR TITLE
[Annotation plugin] Avoid adding same image multi times

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -255,10 +255,12 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
             if (image.startsWith(Symbol.ICON_DEFAULT_NAME_PREFIX)) {
               // User set the bitmap icon, add the icon to style
               symbol.iconImageBitmap?.let { bitmap ->
-                val imagePlugin = image(image) {
-                  bitmap(bitmap)
+                if (style.getStyleImage(image) == null) {
+                  val imagePlugin = image(image) {
+                    bitmap(bitmap)
+                  }
+                  style.addImage(imagePlugin)
                 }
-                style.addImage(imagePlugin)
               }
             }
           }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
@@ -69,7 +69,7 @@ class Symbol(
       value?.let {
         field = it
         if (iconImage == null) {
-          iconImage = ICON_DEFAULT_NAME_PREFIX + id
+          iconImage = ICON_DEFAULT_NAME_PREFIX + it.generationId
         }
       }
     }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleManagerTest.kt
@@ -79,6 +79,7 @@ class CircleManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMoveListener(any()) } just Runs

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/FillManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/FillManagerTest.kt
@@ -80,6 +80,7 @@ class FillManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMoveListener(any()) } just Runs

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/LineManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/LineManagerTest.kt
@@ -81,6 +81,7 @@ class LineManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMoveListener(any()) } just Runs

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
@@ -82,6 +82,7 @@ class SymbolManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMoveListener(any()) } just Runs
@@ -201,7 +202,30 @@ class SymbolManagerTest {
         .withIconImage(bitmap)
         .withPoint(Point.fromLngLat(0.0, 0.0))
     )
-    assertEquals(Symbol.ICON_DEFAULT_NAME_PREFIX + annotation.id, annotation.iconImage)
+    assertEquals(Symbol.ICON_DEFAULT_NAME_PREFIX + bitmap.generationId, annotation.iconImage)
+
+    verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun iconImageBitmapWithSameImage() {
+    every { style.styleSourceExists(any()) } returns true
+    val annotation = manager.create(
+      SymbolOptions()
+        .withIconImage(bitmap)
+        .withPoint(Point.fromLngLat(0.0, 0.0))
+    )
+    assertEquals(Symbol.ICON_DEFAULT_NAME_PREFIX + bitmap.generationId, annotation.iconImage)
+
+    verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+
+    every { style.getStyleImage(Symbol.ICON_DEFAULT_NAME_PREFIX + bitmap.generationId) } returns mockk()
+    val annotation2 = manager.create(
+      SymbolOptions()
+        .withIconImage(bitmap)
+        .withPoint(Point.fromLngLat(0.0, 0.0))
+    )
+    assertEquals(Symbol.ICON_DEFAULT_NAME_PREFIX + bitmap.generationId, annotation2.iconImage)
 
     verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #71 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[Annotation plugin] Avoid adding same image multi times</changelog>`.

### Summary of changes
The same bitmap could be added to style for multi times if multi symbols use this bitmap.
This PR adds the check to avoid adding the same image multi times.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->