### PR TITLE
[snapshotter] Introduce interfaces for style events and snapshot result

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/LocationComponentActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/LocationComponentActivity.kt
@@ -13,9 +13,9 @@ import com.mapbox.maps.plugin.LocationPuck3D
 import com.mapbox.maps.plugin.gestures.getGesturesPlugin
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
-import com.mapbox.maps.plugin.toJson
 import com.mapbox.maps.testapp.R
 import com.mapbox.maps.testapp.utils.LocationPermissionHelper
+import com.mapbox.maps.toJson
 import kotlinx.android.synthetic.main.activity_simple_map.*
 
 class LocationComponentActivity : AppCompatActivity() {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/LocationTrackingActivity.kt
@@ -14,9 +14,9 @@ import com.mapbox.maps.plugin.gestures.getGesturesPlugin
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorBearingChangedListener
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
-import com.mapbox.maps.plugin.toJson
 import com.mapbox.maps.testapp.R
 import com.mapbox.maps.testapp.utils.LocationPermissionHelper
+import com.mapbox.maps.toJson
 import kotlinx.android.synthetic.main.activity_location_layer_mode.*
 
 /**

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/sky/SkyLayerSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/sky/SkyLayerSnapshotterActivity.kt
@@ -1,6 +1,5 @@
 package com.mapbox.maps.testapp.examples.sky
 
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -8,7 +7,6 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.*
 import com.mapbox.maps.extension.style.expressions.dsl.generated.interpolate
 import com.mapbox.maps.extension.style.layers.addLayer
-import com.mapbox.maps.extension.style.layers.generated.SkyLayer
 import com.mapbox.maps.extension.style.layers.generated.skyLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.SkyType
 import com.mapbox.maps.extension.style.style
@@ -16,7 +14,6 @@ import com.mapbox.maps.plugin.compass.getCompassPlugin
 import com.mapbox.maps.plugin.scalebar.getScaleBarPlugin
 import com.mapbox.maps.testapp.R
 import kotlinx.android.synthetic.main.activity_sky_snapshotter.*
-import java.nio.ByteBuffer
 
 /**
  * Prototype for Junction view showing upcoming maneuver.
@@ -68,10 +65,12 @@ class SkyLayerSnapshotterActivity : AppCompatActivity() {
     snapshotter = Snapshotter(this, snapshotMapOptions).apply {
       setStyleListener(object : SnapshotStyleListener {
         override fun onDidFinishLoadingStyle(style: Style) {
-          val skyLayer = SkyLayer("sky_snapshotter")
-          skyLayer.skyType(SkyType.ATMOSPHERE)
-          skyLayer.skyAtmosphereSun(listOf(0.0, 90.0))
-          style.addLayer(skyLayer)
+          style.addLayer(
+            skyLayer("sky_snapshotter") {
+              skyType(SkyType.ATMOSPHERE)
+              skyAtmosphereSun(listOf(0.0, 90.0))
+            }
+          )
         }
       })
       setCameraOptions(
@@ -85,12 +84,7 @@ class SkyLayerSnapshotterActivity : AppCompatActivity() {
       setUri(Style.MAPBOX_STREETS)
       start {
         it?.let { snapshot ->
-          val image = snapshot.image()
-          val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
-          val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
-          val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
-          bitmap.copyPixelsFromBuffer(buffer)
-          maneuverView.setImageBitmap(bitmap)
+          maneuverView.setImageBitmap(snapshot.bitmap())
           maneuverCaption.visibility = View.VISIBLE
         }
       }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/DataDrivenMapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/DataDrivenMapSnapshotterActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
@@ -38,48 +37,50 @@ class DataDrivenMapSnapshotterActivity : AppCompatActivity() {
       .resourceOptions(MapboxOptions.getDefaultResourceOptions(this))
       .build()
 
-    snapshotter = Snapshotter(this, snapshotMapOptions)
-    snapshotter.setCameraOptions(
-      CameraOptions.Builder()
-        .center(Point.fromLngLat(-94.0, 15.0))
-        .zoom(5.0)
-        .padding(EdgeInsets(1.0, 1.0, 1.0, 1.0))
-        .build()
-    )
-    snapshotter.setUri(Style.OUTDOORS)
-    snapshotter.start(object : Snapshotter.SnapshotReadyCallback {
-      override fun onStyleLoaded(style: Style) {
-        showToast("Map load style success!")
+    snapshotter = Snapshotter(this, snapshotMapOptions).apply {
+      setStyleListener(object : SnapshotStyleListener {
+        override fun onDidFinishLoadingStyle(style: Style) {
+          Toast.makeText(
+            this@DataDrivenMapSnapshotterActivity,
+            "Map load style success!",
+            Toast.LENGTH_LONG
+          ).show()
 
-        // GeoJSON earthquake source using low level style API
-        val properties = HashMap<String, Value>()
-        properties["type"] = Value.valueOf("geojson")
-        properties["data"] = Value.valueOf(EARTHQUAKE_SOURCE_URL)
-        val sourceResult = style.addStyleSource(EARTHQUAKE_SOURCE_ID, Value.valueOf(properties))
-        if (sourceResult.isError) {
-          throw RuntimeException(sourceResult.error)
+          // GeoJSON earthquake source using low level style API
+          val properties = HashMap<String, Value>()
+          properties["type"] = Value.valueOf("geojson")
+          properties["data"] = Value.valueOf(EARTHQUAKE_SOURCE_URL)
+          val sourceResult = style.addStyleSource(EARTHQUAKE_SOURCE_ID, Value.valueOf(properties))
+          if (sourceResult.isError) {
+            throw RuntimeException(sourceResult.error)
+          }
+
+          // Heatmap layer using high level style PI
+          style.addLayer(getHeatmapLayer())
         }
+      })
+      setCameraOptions(
+        CameraOptions.Builder()
+          .center(Point.fromLngLat(-94.0, 15.0))
+          .zoom(5.0)
+          .padding(EdgeInsets(1.0, 1.0, 1.0, 1.0))
+          .build()
+      )
+      setUri(Style.OUTDOORS)
+    }
+    snapshotter.start {
+      it?.let { snapshot ->
+        val image = snapshot.image()
+        val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
+        val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
+        val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
+        bitmap.copyPixelsFromBuffer(buffer)
 
-        // Heatmap layer using high level style PI
-        style.addLayer(getHeatmapLayer())
+        val imageView = ImageView(this@DataDrivenMapSnapshotterActivity)
+        imageView.setImageBitmap(bitmap)
+        setContentView(imageView)
       }
-
-      override fun onSnapshotCreated(snapshot: Expected<MapSnapshotInterface?, String?>) {
-        if (snapshot.isError) {
-          showToast("ERROR! ${snapshot.error}")
-        } else {
-          val image = snapshot.value!!.image()
-          val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
-          val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
-          val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
-          bitmap.copyPixelsFromBuffer(buffer)
-
-          val imageView = ImageView(this@DataDrivenMapSnapshotterActivity)
-          imageView.setImageBitmap(bitmap)
-          setContentView(imageView)
-        }
-      }
-    })
+    }
   }
 
   private fun getHeatmapLayer(): HeatmapLayer {
@@ -142,10 +143,6 @@ class DataDrivenMapSnapshotterActivity : AppCompatActivity() {
   override fun onDestroy() {
     super.onDestroy()
     snapshotter.cancel()
-  }
-
-  private fun showToast(message: String) {
-    Toast.makeText(this, message, Toast.LENGTH_LONG).show()
   }
 
   companion object {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/DataDrivenMapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/DataDrivenMapSnapshotterActivity.kt
@@ -1,6 +1,5 @@
 package com.mapbox.maps.testapp.examples.snapshotter
 
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.widget.ImageView
 import android.widget.Toast
@@ -19,7 +18,6 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression.Companio
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.rgba
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.generated.HeatmapLayer
-import java.nio.ByteBuffer
 
 /**
  * Example that showcases using Snapshotter with data driven styling.
@@ -70,14 +68,8 @@ class DataDrivenMapSnapshotterActivity : AppCompatActivity() {
     }
     snapshotter.start {
       it?.let { snapshot ->
-        val image = snapshot.image()
-        val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
-        val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
-        val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
-        bitmap.copyPixelsFromBuffer(buffer)
-
         val imageView = ImageView(this@DataDrivenMapSnapshotterActivity)
-        imageView.setImageBitmap(bitmap)
+        imageView.setImageBitmap(snapshot.bitmap())
         setContentView(imageView)
       }
     }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/LocalStyleMapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/LocalStyleMapSnapshotterActivity.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import android.os.Bundle
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.bindgen.Expected
 import com.mapbox.common.Logger
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
@@ -14,7 +13,7 @@ import java.nio.ByteBuffer
 /**
  * Activity to validate creating a snapshot from a configuration not using style URI or JSON
  */
-class LocalStyleMapSnapshotterActivity : AppCompatActivity(), Snapshotter.SnapshotReadyCallback {
+class LocalStyleMapSnapshotterActivity : AppCompatActivity() {
   private lateinit var mapSnapshotter: Snapshotter
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -63,30 +62,21 @@ class LocalStyleMapSnapshotterActivity : AppCompatActivity(), Snapshotter.Snapsh
         }
       """.trimIndent()
     )
-    mapSnapshotter.start(this)
-  }
+    mapSnapshotter.start {
+      it?.let { mapSnapshot ->
+        Logger.e(TAG, "Result: ${mapSnapshot.image().data.size}")
 
-  override fun onStyleLoaded(style: Style) {
-    Logger.i(TAG, "OnStyleLoaded: ${style.styleURI}")
-  }
+        val image = mapSnapshot.image()
 
-  override fun onSnapshotCreated(snapshot: Expected<MapSnapshotInterface?, String?>) {
-    if (snapshot.isValue) {
-      val mapSnapshot = snapshot.value as MapSnapshotInterface
-      Logger.e(TAG, "Result: ${mapSnapshot.image().data.size}")
+        val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
+        val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
+        val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
+        bitmap.copyPixelsFromBuffer(buffer)
 
-      val image = mapSnapshot.image()
-
-      val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
-      val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
-      val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
-      bitmap.copyPixelsFromBuffer(buffer)
-
-      val imageView = ImageView(this)
-      imageView.setImageBitmap(bitmap)
-      setContentView(imageView)
-    } else {
-      Logger.e(TAG, "Error: ${snapshot.error}")
+        val imageView = ImageView(this)
+        imageView.setImageBitmap(bitmap)
+        setContentView(imageView)
+      }
     }
   }
 

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/LocalStyleMapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/LocalStyleMapSnapshotterActivity.kt
@@ -1,14 +1,11 @@
 package com.mapbox.maps.testapp.examples.snapshotter
 
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.common.Logger
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
 import com.mapbox.maps.testapp.R
-import java.nio.ByteBuffer
 
 /**
  * Activity to validate creating a snapshot from a configuration not using style URI or JSON
@@ -64,17 +61,8 @@ class LocalStyleMapSnapshotterActivity : AppCompatActivity() {
     )
     mapSnapshotter.start {
       it?.let { mapSnapshot ->
-        Logger.e(TAG, "Result: ${mapSnapshot.image().data.size}")
-
-        val image = mapSnapshot.image()
-
-        val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
-        val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
-        val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
-        bitmap.copyPixelsFromBuffer(buffer)
-
         val imageView = ImageView(this)
-        imageView.setImageBitmap(bitmap)
+        imageView.setImageBitmap(mapSnapshot.bitmap())
         setContentView(imageView)
       }
     }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapSnapshotterActivity.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import android.os.Bundle
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.bindgen.Expected
 import com.mapbox.common.Logger
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
@@ -12,7 +11,8 @@ import com.mapbox.maps.Snapshotter
 import com.mapbox.maps.testapp.R
 import java.nio.ByteBuffer
 
-class MapSnapshotterActivity : AppCompatActivity(), Snapshotter.SnapshotReadyCallback {
+class MapSnapshotterActivity : AppCompatActivity(), SnapshotStyleListener {
+
   private lateinit var mapSnapshotter: Snapshotter
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,40 +30,37 @@ class MapSnapshotterActivity : AppCompatActivity(), Snapshotter.SnapshotReadyCal
       .pixelRatio(1.0f)
       .build()
 
-    mapSnapshotter = Snapshotter(this, snapshotterOptions)
-    mapSnapshotter.setUri(Style.MAPBOX_STREETS)
-    mapSnapshotter.setCameraOptions(
-      CameraOptions.Builder().zoom(14.0).center(
-        Point.fromLngLat(
-          4.895033, 52.374724
-        )
-      ).build()
-    )
-    mapSnapshotter.start(this)
-  }
+    mapSnapshotter = Snapshotter(this, snapshotterOptions).apply {
+      setStyleListener(this@MapSnapshotterActivity)
+      setUri(Style.MAPBOX_STREETS)
+      setCameraOptions(
+        CameraOptions.Builder().zoom(14.0).center(
+          Point.fromLngLat(
+            4.895033, 52.374724
+          )
+        ).build()
+      )
+      start {
+        it?.let { mapSnapshot ->
+          Logger.i(TAG, "Result: ${mapSnapshot.image().data.size}")
 
-  override fun onStyleLoaded(style: Style) {
-    Logger.e(TAG, "OnStyleLoaded: ${style.styleURI}")
-  }
+          val image = mapSnapshot.image()
 
-  override fun onSnapshotCreated(snapshot: Expected<MapSnapshotInterface?, String?>) {
-    if (snapshot.isValue) {
-      val mapSnapshot = snapshot.value as MapSnapshotInterface
-      Logger.e(TAG, "Result: ${mapSnapshot.image().data.size}")
+          val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
+          val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
+          val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
+          bitmap.copyPixelsFromBuffer(buffer)
 
-      val image = mapSnapshot.image()
-
-      val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
-      val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
-      val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
-      bitmap.copyPixelsFromBuffer(buffer)
-
-      val imageView = ImageView(this)
-      imageView.setImageBitmap(bitmap)
-      setContentView(imageView)
-    } else {
-      Logger.e(TAG, "Error: ${snapshot.error}")
+          val imageView = ImageView(this@MapSnapshotterActivity)
+          imageView.setImageBitmap(bitmap)
+          setContentView(imageView)
+        }
+      }
     }
+  }
+
+  override fun onDidFinishLoadingStyle(style: Style) {
+    Logger.i(TAG, "OnStyleLoaded: ${style.styleURI}")
   }
 
   override fun onDestroy() {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapSnapshotterActivity.kt
@@ -1,6 +1,5 @@
 package com.mapbox.maps.testapp.examples.snapshotter
 
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
@@ -8,9 +7,12 @@ import com.mapbox.common.Logger
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
 import com.mapbox.maps.Snapshotter
+import com.mapbox.maps.bitmap
 import com.mapbox.maps.testapp.R
-import java.nio.ByteBuffer
 
+/**
+ * Example demonstrating taking simple snapshot using [Snapshotter].
+ */
 class MapSnapshotterActivity : AppCompatActivity(), SnapshotStyleListener {
 
   private lateinit var mapSnapshotter: Snapshotter
@@ -42,17 +44,8 @@ class MapSnapshotterActivity : AppCompatActivity(), SnapshotStyleListener {
       )
       start {
         it?.let { mapSnapshot ->
-          Logger.i(TAG, "Result: ${mapSnapshot.image().data.size}")
-
-          val image = mapSnapshot.image()
-
-          val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
-          val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
-          val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
-          bitmap.copyPixelsFromBuffer(buffer)
-
           val imageView = ImageView(this@MapSnapshotterActivity)
-          imageView.setImageBitmap(bitmap)
+          imageView.setImageBitmap(mapSnapshot.bitmap())
           setContentView(imageView)
         }
       }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapViewSnapshotActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapViewSnapshotActivity.kt
@@ -1,12 +1,18 @@
 package com.mapbox.maps.testapp.examples.snapshotter
 
 import android.os.Bundle
+import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.Snapshotter
 import com.mapbox.maps.Style
 import com.mapbox.maps.testapp.R
 import kotlinx.android.synthetic.main.activity_view_snapshot.*
 
+/**
+ * Example demonstrating taking simple snapshot or screenshot not using [Snapshotter] appearing
+ * in bottom-left corner as [ImageView].
+ */
 class MapViewSnapshotActivity : AppCompatActivity() {
 
   private lateinit var mapboxMap: MapboxMap

--- a/sdk-base/src/main/java/com/mapbox/maps/ExtensionUtils.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/ExtensionUtils.kt
@@ -1,7 +1,9 @@
-package com.mapbox.maps.plugin
+package com.mapbox.maps
 
+import android.graphics.Bitmap
 import com.mapbox.bindgen.Value
 import com.mapbox.common.ValueConverter
+import java.nio.ByteBuffer
 import kotlin.math.abs
 
 /**
@@ -23,4 +25,16 @@ fun Double.roughlyEquals(other: Double): Boolean {
  */
 fun Value.toJson(): String {
   return ValueConverter.toJson(this)
+}
+
+/**
+ * Extension function to obtain [Bitmap] from snapshotter converted from [Image].
+ */
+fun MapSnapshotInterface.bitmap(): Bitmap {
+  val image = image()
+  val configBmp: Bitmap.Config = Bitmap.Config.ARGB_8888
+  val bitmap: Bitmap = Bitmap.createBitmap(image.width, image.height, configBmp)
+  val buffer: ByteBuffer = ByteBuffer.wrap(image.data)
+  bitmap.copyPixelsFromBuffer(buffer)
+  return bitmap
 }

--- a/sdk/src/main/java/com/mapbox/maps/CustomSnapshotInterface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/CustomSnapshotInterface.kt
@@ -1,6 +1,0 @@
-package com.mapbox.maps
-
-/**
- * Temporary interface wrapper around MapSnapshotterInterface and StyleManagerInterface
- */
-interface CustomSnapshotInterface : MapSnapshotterInterface, StyleManagerInterface

--- a/sdk/src/main/java/com/mapbox/maps/SnapshotCreatedListener.kt
+++ b/sdk/src/main/java/com/mapbox/maps/SnapshotCreatedListener.kt
@@ -1,0 +1,15 @@
+package com.mapbox.maps
+
+/**
+ * Interface for getting snapshot when it's finished.
+ */
+fun interface SnapshotCreatedListener {
+
+  /**
+   * Invoked when snapshot finished despite successful or not.
+   *
+   * @param snapshot An image snapshot of a map rendered by MapSnapshotter.
+   * If [snapshot] = NULL it means snapshot was not successful and error message may be found in log.
+   */
+  fun onSnapshotResult(snapshot: MapSnapshotInterface?)
+}

--- a/sdk/src/main/java/com/mapbox/maps/SnapshotStyleListener.kt
+++ b/sdk/src/main/java/com/mapbox/maps/SnapshotStyleListener.kt
@@ -1,0 +1,35 @@
+package com.mapbox.maps
+
+/**
+ * Interface for getting all style related events for snapshotter.
+ */
+interface SnapshotStyleListener {
+
+  /**
+   * Notifies the client when style loading completed, not including the style specified sprite and sources.
+   *
+   * @param style style that was loaded for given snapshotter.
+   */
+  fun onDidFinishLoadingStyle(style: Style)
+
+  /**
+   * Notifies the client when style loading completed, including the style specified sprite and sources.
+   *
+   * @param style style that was loaded for given snapshotter.
+   */
+  fun onDidFullyLoadStyle(style: Style) { }
+
+  /**
+   * Notifies the client about style load errors.
+   *
+   * @param message Error message associated with the error.
+   */
+  fun onDidFailLoadingStyle(message: String) { }
+
+  /**
+   * Notifies the client about a missing style image.
+   *
+   * @param imageId The id of the image that is missing.
+   */
+  fun onStyleImageMissing(imageId: String) { }
+}

--- a/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
@@ -9,14 +9,13 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.res.ResourcesCompat
-import com.mapbox.bindgen.Expected
-import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.common.Logger
 import com.mapbox.geojson.Point
 import com.mapbox.maps.attribution.AttributionLayout
 import com.mapbox.maps.attribution.AttributionMeasure
 import com.mapbox.maps.attribution.AttributionParser
 import java.lang.ref.WeakReference
+import kotlin.math.min
 
 /**
  * [Snapshotter] is high-level component responsible for taking map snapshot with given [MapSnapshotOptions].
@@ -25,8 +24,10 @@ class Snapshotter : MapSnapshotterObserver {
 
   private val context: WeakReference<Context>
   private val coreSnapshotter: MapSnapshotterInterface
-  private var snapshotReadyCallback: SnapshotReadyCallback? = null
   private val pixelRatio: Float
+
+  private var snapshotReadyCallback: SnapshotCreatedListener? = null
+  private var snapshotStyleCallback: SnapshotStyleListener? = null
 
   constructor(context: Context, options: MapSnapshotOptions) {
     this.context = WeakReference(context)
@@ -47,21 +48,21 @@ class Snapshotter : MapSnapshotterObserver {
    * @param message Error message associated with the error.
    */
   override fun onDidFailLoadingStyle(message: String) {
-    Logger.e(TAG, message)
+    snapshotStyleCallback?.onDidFailLoadingStyle(message)
   }
 
   /**
-   * Notifies the client when style loading finished.
+   * Notifies the client when style loading completed, not including the style specified sprite and sources.
    */
   override fun onDidFinishLoadingStyle() {
-    snapshotReadyCallback?.onStyleLoaded(Style(coreSnapshotter, pixelRatio))
+    snapshotStyleCallback?.onDidFinishLoadingStyle(Style(coreSnapshotter, pixelRatio))
   }
 
   /**
    * Notifies the client when style loading completed, including the style specified sprite and sources.
    */
   override fun onDidFullyLoadStyle() {
-    Logger.e(TAG, "Style fully loaded.")
+    snapshotStyleCallback?.onDidFullyLoadStyle(Style(coreSnapshotter, pixelRatio))
   }
 
   /**
@@ -70,33 +71,40 @@ class Snapshotter : MapSnapshotterObserver {
    * @param imageId The id of the image that is missing.
    */
   override fun onStyleImageMissing(imageId: String) {
-    Logger.e(TAG, "Style image missing: $imageId")
+    snapshotStyleCallback?.onStyleImageMissing(imageId)
+  }
+
+  /**
+   * Set [SnapshotStyleListener] to listen to all events style related.
+   */
+  fun setStyleListener(listener: SnapshotStyleListener) {
+    snapshotStyleCallback = listener
   }
 
   /**
    * Start taking a snapshot.
    *
-   * @param callback that will be triggered when snapshot will be ready.
+   * @param callback instance of [SnapshotCreatedListener] that will be triggered
+   *  when snapshot will be ready or will error out.
    */
-  fun start(callback: SnapshotReadyCallback) {
+  fun start(callback: SnapshotCreatedListener) {
     snapshotReadyCallback = callback
     if (getJson().isEmpty() && getUri().isEmpty()) {
       throw IllegalStateException("It's required to call setUri or setJson to provide a style definition before calling start.")
     }
 
     coreSnapshotter.start { result ->
-      lateinit var interceptedResult: Expected<MapSnapshotInterface?, String?>
       if (result.isValue) {
         result.value?.let {
-          interceptedResult =
-            ExpectedFactory.createValue(addOverlay(Snapshot(it)) as MapSnapshotInterface)
+          snapshotReadyCallback?.onSnapshotResult(addOverlay(Snapshot(it)) as MapSnapshotInterface)
         } ?: run {
-          interceptedResult = ExpectedFactory.createError("snapshot is empty")
+          Logger.e(TAG, result.error ?: "Snapshot is empty.")
+          snapshotReadyCallback?.onSnapshotResult(null)
         }
       } else {
-        interceptedResult = ExpectedFactory.createError(result.error ?: "")
+        Logger.e(TAG, result.error ?: "Undefined error happened.")
+        snapshotReadyCallback?.onSnapshotResult(null)
       }
-      snapshotReadyCallback?.onSnapshotCreated(interceptedResult)
     }
   }
 
@@ -199,7 +207,7 @@ class Snapshotter : MapSnapshotterObserver {
    *
    * This method should be called on the same thread where @see Map object is initialized.
    *
-   * @param json A JSON string containing a serialized Mapbox Style.
+   * @param styleJson A JSON string containing a serialized Mapbox Style.
    */
   fun setJson(styleJson: String) {
     coreSnapshotter.styleJSON = styleJson
@@ -408,7 +416,7 @@ class Snapshotter : MapSnapshotterObserver {
     val heightRatio = displayMetrics.heightPixels / snapshot.height.toFloat()
     val prefWidth = logo.width / widthRatio
     val prefHeight = logo.height / heightRatio
-    var calculatedScale = Math.min(prefWidth / logo.width, prefHeight / logo.height) * 2
+    var calculatedScale = min(prefWidth / logo.width, prefHeight / logo.height) * 2
     if (calculatedScale > 1) {
       // don't allow over-scaling
       calculatedScale = 1.0f
@@ -424,21 +432,6 @@ class Snapshotter : MapSnapshotterObserver {
     val small: Bitmap,
     val scale: Float
   )
-
-  /**
-   * Callback for getting snapshot when it's finished.
-   */
-  interface SnapshotReadyCallback {
-    /**
-     * @param mapStyleDelegate The style delegate
-     */
-    fun onStyleLoaded(style: Style)
-
-    /**
-     * @param snapshot An image snapshot of a map rendered by MapSnapshotter.
-     */
-    fun onSnapshotCreated(snapshot: Expected<MapSnapshotInterface?, String?>)
-  }
 
   /**
    * Static variables and methods.

--- a/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
@@ -26,7 +26,7 @@ class Snapshotter : MapSnapshotterObserver {
   private val coreSnapshotter: MapSnapshotterInterface
   private val pixelRatio: Float
 
-  private var snapshotReadyCallback: SnapshotCreatedListener? = null
+  private var snapshotCreatedCallback: SnapshotCreatedListener? = null
   private var snapshotStyleCallback: SnapshotStyleListener? = null
 
   constructor(context: Context, options: MapSnapshotOptions) {
@@ -88,7 +88,7 @@ class Snapshotter : MapSnapshotterObserver {
    *  when snapshot will be ready or will error out.
    */
   fun start(callback: SnapshotCreatedListener) {
-    snapshotReadyCallback = callback
+    snapshotCreatedCallback = callback
     if (getJson().isEmpty() && getUri().isEmpty()) {
       throw IllegalStateException("It's required to call setUri or setJson to provide a style definition before calling start.")
     }
@@ -96,14 +96,14 @@ class Snapshotter : MapSnapshotterObserver {
     coreSnapshotter.start { result ->
       if (result.isValue) {
         result.value?.let {
-          snapshotReadyCallback?.onSnapshotResult(addOverlay(Snapshot(it)) as MapSnapshotInterface)
+          snapshotCreatedCallback?.onSnapshotResult(addOverlay(Snapshot(it)) as MapSnapshotInterface)
         } ?: run {
           Logger.e(TAG, result.error ?: "Snapshot is empty.")
-          snapshotReadyCallback?.onSnapshotResult(null)
+          snapshotCreatedCallback?.onSnapshotResult(null)
         }
       } else {
         Logger.e(TAG, result.error ?: "Undefined error happened.")
-        snapshotReadyCallback?.onSnapshotResult(null)
+        snapshotCreatedCallback?.onSnapshotResult(null)
       }
     }
   }
@@ -113,7 +113,7 @@ class Snapshotter : MapSnapshotterObserver {
    */
   fun cancel() {
     coreSnapshotter.cancel()
-    snapshotReadyCallback = null
+    snapshotCreatedCallback = null
   }
 
   /**

--- a/sdk/src/test/java/com/mapbox/maps/SnapshotterDelegateTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/SnapshotterDelegateTest.kt
@@ -120,7 +120,7 @@ class SnapshotterDelegateTest {
 
   @Test
   fun start() {
-    val callback = mockk<Snapshotter.SnapshotReadyCallback>()
+    val callback = mockk<SnapshotCreatedListener>()
     every { coreSnapshotter.styleJSON } returns "foobar"
     snapshotter.start(callback)
     verify { coreSnapshotter.start(any()) }
@@ -128,7 +128,7 @@ class SnapshotterDelegateTest {
 
   @Test(expected = IllegalStateException::class)
   fun startException() {
-    val callback = mockk<Snapshotter.SnapshotReadyCallback>()
+    val callback = mockk<SnapshotCreatedListener>()
     snapshotter.start(callback)
     verify { coreSnapshotter.start(any()) }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
`<changelog>[snapshotter] Introduce interfaces for style events and snapshot result</changelog>`

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

Clear division of interfaces for `Snapshotter` for taking an actual snapshot and loading a style for a `Snapshotter`.
Now functional interface `SnapshotCreatedListener` is used to perform an actual snapshot (or return null if not successful) and `SnapshotStyleListener` is used to listen to all style related callbacks.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->