### PR TITLE
[annotation] Fix text font issue in annotation plugin.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/SymbolActivity.kt
@@ -72,6 +72,12 @@ class SymbolActivity : AppCompatActivity() {
           val symbolOptions: SymbolOptions = SymbolOptions()
             .withPoint(Point.fromLngLat(AIRPORT_LONGITUDE, AIRPORT_LATITUDE))
             .withIconImage(it)
+            .withTextFont(
+              listOf(
+                "Arial Unicode MS Bold",
+                "Open Sans Regular"
+              )
+            )
             .withTextField(ID_ICON_AIRPORT)
             .withTextOffset(listOf(0.0, -2.0))
             .withTextColor(Color.RED)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
@@ -189,7 +189,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Font stack to use for displaying text.
    */
-  var textFont: List<String>? = null
+  var textFont: List<String> = listOf("Open Sans Regular", "Arial Unicode MS Regular")
 
   /**
    * Set text-font to initialise the symbol with.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/97

<changelog>[annotation] Fix text-font issue in annotation plugin.</changelog>

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

We should set the default value of textFont

```
var textFont: List<String> = listOf(
    "Open Sans Regular",
    "Arial Unicode MS Regular"
  )
```

Otherwise, if one of the symbols has provided the textFont, we will enable the data driven property of textFont and thus other symbols that don't specify the textFont property to have an empty text-font list, and result in
The resource 'https://api.mapbox.com/fonts/v1/mapbox//0-255.pbf' not found
And this blocks the annotation from being displayed.

This PR also updates the SymbolActivity to include usage of text font:

![Screenshot_20210303-200450](https://user-images.githubusercontent.com/2764714/109851101-f3422a80-7c5b-11eb-94c3-f92e9d98a6ae.jpg)

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->