### PR TITLE
[Annotation plugin] Implement MapStyleObserverPlugin to listen style load event to reload layer and source

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -8,7 +8,6 @@ import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
-import com.mapbox.maps.MapChange
 import com.mapbox.maps.RenderedQueryOptions
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.StyleManagerInterface
@@ -60,7 +59,6 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   private val mapMoveResolver = MapMove()
   private var draggedAnnotation: T? = null
   private val annotationMap = mutableMapOf<Long, T>()
-  private var mapChangeListenerAdded = false
   protected var touchAreaShiftX: Int = mapView.scrollX
   protected var touchAreaShiftY: Int = mapView.scrollY
   protected abstract val layerId: String
@@ -181,19 +179,11 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     }
 
     updateSource()
+  }
 
-    // Listen to map change event to reload layer and source in the first init
-    if (!mapChangeListenerAdded) {
-      mapChangeListenerAdded = true
-      delegateProvider.mapListenerDelegate.addOnMapChangedListener {
-        if (it == MapChange.DID_FULLY_LOAD_STYLE) {
-          delegateProvider.getStyle {
-            style = it
-            initLayerAndSource()
-          }
-        }
-      }
-    }
+  override fun onStyleLoaded(styleDelegate: StyleManagerInterface) {
+    style = styleDelegate
+    initLayerAndSource()
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -181,6 +181,9 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     updateSource()
   }
 
+  /**
+   * Invoked when the style is loaded
+   */
   override fun onStyleLoaded(styleDelegate: StyleManagerInterface) {
     style = styleDelegate
     initLayerAndSource()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -8,6 +8,7 @@ import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
+import com.mapbox.maps.MapChange
 import com.mapbox.maps.RenderedQueryOptions
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.StyleManagerInterface
@@ -106,10 +107,12 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     gesturesPlugin.addOnMapClickListener(mapClickResolver)
     gesturesPlugin.addOnMapLongClickListener(mapLongClickResolver)
     gesturesPlugin.addOnMoveListener(mapMoveResolver)
-    delegateProvider.mapListenerDelegate.addOnDidFinishRenderingMapListener {
-      delegateProvider.getStyle {
-        style = it
-        initLayerAndSource()
+    delegateProvider.mapListenerDelegate.addOnMapChangedListener {
+      if (it == MapChange.DID_FULLY_LOAD_STYLE) {
+        delegateProvider.getStyle {
+          style = it
+          initLayerAndSource()
+        }
       }
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -165,7 +165,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     }
   }
 
-  protected fun initLayerAndSource() {
+  @Synchronized protected fun initLayerAndSource() {
     if (layer == null || source == null) {
       initializeDataDrivenPropertyMap()
       source = createSource()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.plugin.annotation
 
 import android.view.View
+import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.plugin.annotation.generated.CircleManager
 import com.mapbox.maps.plugin.annotation.generated.FillManager
 import com.mapbox.maps.plugin.annotation.generated.LineManager
@@ -51,6 +52,20 @@ class AnnotationPluginImpl : AnnotationPlugin {
     this.width = width
     this.height = height
     managerList.forEach { it.get()?.onSizeChanged(width, height) }
+  }
+
+  /**
+   * Called when a new Style is being loaded.
+   */
+  override fun onStyleLoading() {
+    // no-op
+  }
+
+  /**
+   * Called when a new Style is loaded.
+   */
+  override fun onStyleChanged(styleDelegate: StyleManagerInterface) {
+    managerList.forEach { it.get()?.onStyleLoaded(styleDelegate) }
   }
 
   /**

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleManagerTest.kt
@@ -62,7 +62,6 @@ class CircleManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
-    every { delegateProvider.mapListenerDelegate.addOnMapChangedListener(any()) } just Runs
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleManagerTest.kt
@@ -62,7 +62,7 @@ class CircleManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
-    every { delegateProvider.mapListenerDelegate.addOnDidFinishRenderingMapListener(any()) } just Runs
+    every { delegateProvider.mapListenerDelegate.addOnMapChangedListener(any()) } just Runs
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/FillManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/FillManagerTest.kt
@@ -63,7 +63,7 @@ class FillManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
-    every { delegateProvider.mapListenerDelegate.addOnDidFinishRenderingMapListener(any()) } just Runs
+    every { delegateProvider.mapListenerDelegate.addOnMapChangedListener(any()) } just Runs
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/FillManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/FillManagerTest.kt
@@ -63,7 +63,6 @@ class FillManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
-    every { delegateProvider.mapListenerDelegate.addOnMapChangedListener(any()) } just Runs
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/LineManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/LineManagerTest.kt
@@ -64,7 +64,7 @@ class LineManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
-    every { delegateProvider.mapListenerDelegate.addOnDidFinishRenderingMapListener(any()) } just Runs
+    every { delegateProvider.mapListenerDelegate.addOnMapChangedListener(any()) } just Runs
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/LineManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/LineManagerTest.kt
@@ -64,7 +64,6 @@ class LineManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
-    every { delegateProvider.mapListenerDelegate.addOnMapChangedListener(any()) } just Runs
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
@@ -65,7 +65,6 @@ class SymbolManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
-    every { delegateProvider.mapListenerDelegate.addOnMapChangedListener(any()) } just Runs
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/SymbolManagerTest.kt
@@ -65,7 +65,7 @@ class SymbolManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
-    every { delegateProvider.mapListenerDelegate.addOnDidFinishRenderingMapListener(any()) } just Runs
+    every { delegateProvider.mapListenerDelegate.addOnMapChangedListener(any()) } just Runs
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManager.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManager.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.plugin.annotation
 
 import com.mapbox.geojson.Geometry
+import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 
 /**
@@ -60,6 +61,11 @@ interface AnnotationManager<
    * @param height the height of mapView
    */
   fun onSizeChanged(width: Int, height: Int)
+
+  /**
+   * Invoked when the style is loaded
+   */
+  fun onStyleLoaded(styleDelegate: StyleManagerInterface)
 
   /**
    * The delegateProvider

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
@@ -3,11 +3,12 @@ package com.mapbox.maps.plugin.annotation
 import android.view.View
 import com.mapbox.maps.plugin.MapPlugin
 import com.mapbox.maps.plugin.MapSizePlugin
+import com.mapbox.maps.plugin.MapStyleObserverPlugin
 
 /**
  * Plugin interface for the annotation.
  */
-fun interface AnnotationPlugin : MapPlugin, MapSizePlugin {
+interface AnnotationPlugin : MapPlugin, MapSizePlugin, MapStyleObserverPlugin {
   /**
    * Get an annotation manger
    *


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[Annotation plugin] Implement MapStyleObserverPlugin to listen style load event to reload layer and source</changelog>`.

### Summary of changes
This pr implement MapStyleObserverPlugin listen in annotation plugin to prevent reload failed issue.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->