### PR TITLE
Use String protocol for passing GeoJSON data 

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/FillManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/FillManagerAndroidTest.kt
@@ -63,7 +63,7 @@ class FillManagerAndroidTest : BaseMapTest() {
     val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val annotation = fillManager.create(
       FillOptions()
-        .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
+        .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(1.0, 0.0))))
     )
     assertEquals(annotation, fillManager.annotations[0])
   }
@@ -72,7 +72,7 @@ class FillManagerAndroidTest : BaseMapTest() {
   fun createFromFeature() {
     val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val featureCollection =
-      FeatureCollection.fromFeature(Feature.fromGeometry(Polygon.fromLngLats(listOf(listOf(Point.fromLngLat(0.0, 0.0))))))
+      FeatureCollection.fromFeature(Feature.fromGeometry(Polygon.fromLngLats(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(1.0, 0.0))))))
     val annotations = fillManager.create(featureCollection.toJson())
     assertEquals(annotations.first(), fillManager.annotations[0])
     val annotations1 = fillManager.create(featureCollection)
@@ -83,8 +83,8 @@ class FillManagerAndroidTest : BaseMapTest() {
   fun createList() {
     val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val list = listOf(
-      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))),
-      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
+      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(1.0, 0.0), Point.fromLngLat(0.0, 1.0)))),
+      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(1.0, 0.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
     )
     val annotations = fillManager.create(list)
     assertEquals(annotations[0], fillManager.annotations[0])
@@ -94,9 +94,9 @@ class FillManagerAndroidTest : BaseMapTest() {
   @Test
   fun update() {
     val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
-    val annotation = fillManager.create(FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))))
+    val annotation = fillManager.create(FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(1.0, 0.0)))))
     assertEquals(annotation, fillManager.annotations[0])
-    annotation.points = listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))
+    annotation.points = listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(1.0, 0.0)))
     fillManager.update(annotation)
     assertEquals(annotation, fillManager.annotations[0])
   }
@@ -105,14 +105,14 @@ class FillManagerAndroidTest : BaseMapTest() {
   fun updateList() {
     val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val list = listOf(
-      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))),
-      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
+      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(1.0, 0.0), Point.fromLngLat(0.0, 1.0)))),
+      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(1.0, 0.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
     )
     val annotations = fillManager.create(list)
     assertEquals(annotations[0], fillManager.annotations[0])
     assertEquals(annotations[1], fillManager.annotations[1])
-    annotations[0].points = listOf(listOf(Point.fromLngLat(1.0, 0.0), Point.fromLngLat(1.0, 1.0)))
-    annotations[1].points = listOf(listOf(Point.fromLngLat(1.0, 0.0), Point.fromLngLat(1.0, 1.0)))
+    annotations[0].points = listOf(listOf(Point.fromLngLat(1.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(1.0, 0.0), Point.fromLngLat(0.0, 1.0)))
+    annotations[1].points = listOf(listOf(Point.fromLngLat(1.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))
     fillManager.update(annotations)
     assertEquals(annotations[0], fillManager.annotations[0])
     assertEquals(annotations[1], fillManager.annotations[1])
@@ -123,7 +123,7 @@ class FillManagerAndroidTest : BaseMapTest() {
     val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val annotation = fillManager.create(
       FillOptions()
-        .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
+        .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(1.0, 0.0))))
     )
     assertEquals(annotation, fillManager.annotations[0])
     fillManager.delete(annotation)
@@ -134,8 +134,8 @@ class FillManagerAndroidTest : BaseMapTest() {
   fun deleteList() {
     val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val list = listOf(
-      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))),
-      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
+      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(1.0, 0.0), Point.fromLngLat(0.0, 1.0)))),
+      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(1.0, 0.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(0.0, 0.0))))
     )
     val annotations = fillManager.create(list)
     assertEquals(annotations[0], fillManager.annotations[0])
@@ -149,8 +149,8 @@ class FillManagerAndroidTest : BaseMapTest() {
   fun deleteAll() {
     val fillManager = mapView.getAnnotationPlugin().createFillManager(mapView)
     val list = listOf(
-      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))),
-      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
+      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(1.0, 0.0), Point.fromLngLat(0.0, 1.0)))),
+      FillOptions().withPoints(listOf(listOf(Point.fromLngLat(1.0, 0.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(0.0, 0.0))))
     )
     val annotations = fillManager.create(list)
     assertEquals(annotations[0], fillManager.annotations[0])

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/LineManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/LineManagerAndroidTest.kt
@@ -96,7 +96,7 @@ class LineManagerAndroidTest : BaseMapTest() {
   fun createFromFeature() {
     val lineManager = mapView.getAnnotationPlugin().createLineManager(mapView)
     val featureCollection =
-      FeatureCollection.fromFeature(Feature.fromGeometry(LineString.fromLngLats(listOf(Point.fromLngLat(0.0, 0.0)))))
+      FeatureCollection.fromFeature(Feature.fromGeometry(LineString.fromLngLats(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))))
     val annotations = lineManager.create(featureCollection.toJson())
     assertEquals(annotations.first(), lineManager.annotations[0])
     val annotations1 = lineManager.create(featureCollection)

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/AnnotationUtils.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/AnnotationUtils.kt
@@ -27,7 +27,7 @@ object AnnotationUtils {
   fun createRandomPoints(): List<Point> {
     val random = Random()
     val points: MutableList<Point> = ArrayList<Point>()
-    for (i in 0 until random.nextInt(10)) {
+    for (i in 0 until random.nextInt(8) + 2) {
       points.add(
         Point.fromLngLat(
           random.nextDouble() * -360.0 + 180.0,
@@ -51,7 +51,7 @@ object AnnotationUtils {
       random.nextDouble() * -180.0 + 90.0
     )
     points.add(firstLast)
-    for (i in 0 until random.nextInt(10)) {
+    for (i in 0 until random.nextInt(6) + 4) {
       points.add(
         Point.fromLngLat(
           random.nextDouble() * -360.0 + 180.0,

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/utils/TypeUtilsTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/utils/TypeUtilsTest.kt
@@ -17,7 +17,7 @@ class TypeUtilsTest : BaseStyleTest() {
 
   @Test
   fun feature_toValue() {
-    val feature = Feature.fromJson(
+    val geojson =
       """
       {
         "type": "Feature",
@@ -31,9 +31,9 @@ class TypeUtilsTest : BaseStyleTest() {
         }
       }
       """.trimIndent()
-    )
+    val feature = Feature.fromJson(geojson)
     assertEquals(
-      "{geometry={coordinates=[125.6, 10.1], type=Point}, type=Feature, properties={name=Dinagat Islands}, bbox=[100.0, 0.0, -100.0, 105.0, 1.0, 0.0]}",
+      "{\"type\":\"Feature\",\"bbox\":[100.0,0.0,-100.0,105.0,1.0,0.0],\"geometry\":{\"type\":\"Point\",\"coordinates\":[125.6,10.1]},\"properties\":{\"name\":\"Dinagat Islands\"}}",
       feature.toValue().toString()
     )
   }
@@ -81,7 +81,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=FeatureCollection, features=[{geometry={coordinates=[[102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]], type=LineString}, id=id0, type=Feature, properties={prop1=value1, prop0=value0}}, {geometry={coordinates=[[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]], type=Polygon}, id=id1, type=Feature, properties={prop1=value1, prop0=value0}}], bbox=[100.0, 0.0, -100.0, 105.0, 1.0, 0.0]}",
+      "{\"type\":\"FeatureCollection\",\"bbox\":[100.0,0.0,-100.0,105.0,1.0,0.0],\"features\":[{\"type\":\"Feature\",\"id\":\"id0\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]},\"properties\":{\"prop0\":\"value0\",\"prop1\":\"value1\"}},{\"type\":\"Feature\",\"id\":\"id1\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]},\"properties\":{\"prop0\":\"value0\",\"prop1\":\"value1\"}}]}",
       feature.toValue().toString()
     )
   }
@@ -103,7 +103,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=Point, coordinates=[125.6, 10.1]}",
+      "{\"type\":\"Point\",\"coordinates\":[125.6,10.1]}",
       feature.geometry()!!.toValue().toString()
     )
   }
@@ -127,7 +127,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=LineString, coordinates=[[100.0, 0.0], [101.0, 1.0]]}",
+      "{\"type\":\"LineString\",\"coordinates\":[[100.0,0.0],[101.0,1.0]]}",
       feature.geometry()!!.toValue().toString()
     )
   }
@@ -151,7 +151,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=Polygon, coordinates=[[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]]}",
+      "{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}",
       feature.geometry()!!.toValue().toString()
     )
   }
@@ -176,7 +176,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=Polygon, coordinates=[[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]], [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]}",
+      "{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]],[[100.2,0.2],[100.8,0.2],[100.8,0.8],[100.2,0.8],[100.2,0.2]]]}",
       feature.geometry()!!.toValue().toString()
     )
   }
@@ -200,7 +200,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=MultiPoint, coordinates=[[100.0, 0.0], [101.0, 1.0]]}",
+      "{\"type\":\"MultiPoint\",\"coordinates\":[[100.0,0.0],[101.0,1.0]]}",
       feature.geometry()!!.toValue().toString()
     )
   }
@@ -225,7 +225,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=MultiLineString, coordinates=[[[100.0, 0.0], [101.0, 1.0]], [[102.0, 2.0], [103.0, 3.0]]]}",
+      "{\"type\":\"MultiLineString\",\"coordinates\":[[[100.0,0.0],[101.0,1.0]],[[102.0,2.0],[103.0,3.0]]]}",
       feature.geometry()!!.toValue().toString()
     )
   }
@@ -255,7 +255,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=MultiPolygon, coordinates=[[[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]], [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]], [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]]}",
+      "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[102.0,2.0],[103.0,2.0],[103.0,3.0],[102.0,3.0],[102.0,2.0]]],[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]],[[100.2,0.2],[100.8,0.2],[100.8,0.8],[100.2,0.8],[100.2,0.2]]]]}",
       feature.geometry()!!.toValue().toString()
     )
   }
@@ -288,7 +288,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=GeometryCollection, geometries=[{type=Point, coordinates=[100.0, 0.0]}, {type=LineString, coordinates=[[101.0, 0.0], [102.0, 1.0]]}]}",
+      "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[100.0,0.0]},{\"type\":\"LineString\",\"coordinates\":[[101.0,0.0],[102.0,1.0]]}]}",
       feature.geometry()!!.toValue().toString()
     )
   }
@@ -336,7 +336,7 @@ class TypeUtilsTest : BaseStyleTest() {
       """.trimIndent()
     )
     assertEquals(
-      "{type=GeometryCollection, geometries=[{type=Point, coordinates=[100.0, 0.0]}, {type=LineString, coordinates=[[101.0, 0.0], [102.0, 1.0]]}, {type=GeometryCollection, geometries=[{type=Point, coordinates=[100.0, 0.0]}, {type=LineString, coordinates=[[101.0, 0.0], [102.0, 1.0]]}]}]}",
+      "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[100.0,0.0]},{\"type\":\"LineString\",\"coordinates\":[[101.0,0.0],[102.0,1.0]]},{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[100.0,0.0]},{\"type\":\"LineString\",\"coordinates\":[[101.0,0.0],[102.0,1.0]]}]}]}",
       feature.geometry()!!.toValue().toString()
     )
   }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/utils/TypeUtils.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/utils/TypeUtils.kt
@@ -2,7 +2,6 @@ package com.mapbox.maps.extension.style.utils
 
 import com.google.gson.JsonPrimitive
 import com.mapbox.bindgen.Value
-import com.mapbox.common.ValueConverter
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Geometry
@@ -297,31 +296,19 @@ inline fun <reified T> StylePropertyValue.silentUnwrap(): T? {
  * Extension function for [Feature] to convert [Feature] to [Value].
  */
 fun Feature.toValue(): Value {
-  val expected = ValueConverter.fromJson(this.toJson())
-  expected.value?.let {
-    return it
-  }
-  throw RuntimeException(expected.error)
+  return TypeUtils.wrapToValue(this.toJson())
 }
 
 /**
  * Extension function for [FeatureCollection] to convert [FeatureCollection] to [Value].
  */
 fun FeatureCollection.toValue(): Value {
-  val expected = ValueConverter.fromJson(this.toJson())
-  expected.value?.let {
-    return it
-  }
-  throw RuntimeException(expected.error)
+  return TypeUtils.wrapToValue(this.toJson())
 }
 
 /**
  * Extension function for [Geometry] to convert [Geometry] to [Value].
  */
 fun Geometry.toValue(): Value {
-  val expected = ValueConverter.fromJson(this.toJson())
-  expected.value?.let {
-    return it
-  }
-  throw RuntimeException(expected.error)
+  return TypeUtils.wrapToValue(this.toJson())
 }

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
@@ -3,9 +3,7 @@
 package com.mapbox.maps.extension.style.sources.generated
 
 import com.mapbox.bindgen.Expected
-import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.bindgen.Value
-import com.mapbox.common.ValueConverter
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.StyleManager
@@ -13,7 +11,6 @@ import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
-import com.mapbox.maps.extension.style.ShadowValueConverter
 import com.mapbox.maps.extension.style.expressions.dsl.generated.get
 import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
 import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
@@ -27,7 +24,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(shadows = [ShadowValueConverter::class, ShadowStyleManager::class])
+@Config(shadows = [ShadowStyleManager::class])
 class GeoJsonSourceTest {
   private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
   private val valueSlot = slot<Value>()
@@ -37,8 +34,6 @@ class GeoJsonSourceTest {
 
   @Before
   fun prepareTest() {
-    mockkStatic(ValueConverter::class)
-    every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue<Value, String>(Value(1))
     every { style.addStyleSource(any(), any()) } returns expected
     every { style.setStyleSourceProperty(any(), any(), any()) } returns expected
     every { style.getStyleSourceProperty(any(), any()) } returns styleProperty
@@ -791,7 +786,6 @@ class GeoJsonSourceTest {
     testSource.bindTo(style)
     testSource.feature(feature)
     verify { style.setStyleSourceProperty("testId", "data", any()) }
-    verify { ValueConverter.fromJson(feature.toJson()) }
   }
 
   @Test
@@ -825,7 +819,6 @@ class GeoJsonSourceTest {
     testSource.bindTo(style)
     testSource.featureCollection(featureCollection)
     verify { style.setStyleSourceProperty("testId", "data", any()) }
-    verify { ValueConverter.fromJson(featureCollection.toJson()) }
   }
 
   @Test
@@ -848,7 +841,6 @@ class GeoJsonSourceTest {
     testSource.bindTo(style)
     testSource.geometry(feature.geometry()!!)
     verify { style.setStyleSourceProperty("testId", "data", any()) }
-    verify { ValueConverter.fromJson(feature.geometry()!!.toJson()) }
   }
 
   @Test
@@ -872,7 +864,6 @@ class GeoJsonSourceTest {
     }
     testSource.bindTo(style)
     verify { style.addStyleSource("testId", capture(valueSlot)) }
-    verify { ValueConverter.fromJson(feature.toJson()) }
     assertTrue(valueSlot.captured.toString().contains("type=geojson"))
   }
 
@@ -908,7 +899,6 @@ class GeoJsonSourceTest {
     }
     testSource.bindTo(style)
     verify { style.addStyleSource("testId", capture(valueSlot)) }
-    verify { ValueConverter.fromJson(featureCollection.toJson()) }
     assertTrue(valueSlot.captured.toString().contains("type=geojson"))
   }
 
@@ -933,7 +923,6 @@ class GeoJsonSourceTest {
     }
     testSource.bindTo(style)
     verify { style.addStyleSource("testId", capture(valueSlot)) }
-    verify { ValueConverter.fromJson(feature.geometry()!!.toJson()) }
     assertTrue(valueSlot.captured.toString().contains("type=geojson"))
   }
   // Default source property getters tests

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/utils/TypeUtilsTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/utils/TypeUtilsTest.kt
@@ -7,7 +7,6 @@ import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.common.ValueConverter
 import com.mapbox.geojson.Feature
-import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowValueConverter
@@ -20,7 +19,6 @@ import com.mapbox.maps.extension.style.types.transitionOptions
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -575,122 +573,10 @@ class TypeUtilsTest {
 
   @Test
   fun featureTest() {
-    val feature = Feature.fromJson(
-      """
-      {
-        "type": "Feature",
-        "bbox": [100.0, 0.0, -100.0, 105.0, 1.0, 0.0],
-        "geometry": {
-          "type": "Point",
-          "coordinates": [125.6, 10.1]
-        },
-        "properties": {
-          "name": "Dinagat Islands"
-        }
-      }
-      """.trimIndent()
-    )
-    feature.toValue()
-    verify { ValueConverter.fromJson(feature.toJson()) }
-  }
-
-  @Test(expected = RuntimeException::class)
-  fun featureExceptionTest() {
-    every { expected.value } returns null
-    every { expected.error } returns "error"
-
-    val feature = Feature.fromJson(
-      """
-      {
-        "type": "Feature",
-        "bbox": [100.0, 0.0, -100.0, 105.0, 1.0, 0.0],
-        "geometry": {
-          "type": "Point",
-          "coordinates": [125.6, 10.1]
-        },
-        "properties": {
-          "name": "Dinagat Islands"
-        }
-      }
-      """.trimIndent()
-    )
-    feature.toValue()
-    verify { ValueConverter.fromJson(feature.toJson()) }
-  }
-
-  @Test(expected = RuntimeException::class)
-  fun featureCollectionTest() {
-    every { expected.value } returns null
-    every { expected.error } returns "error"
-
-    val feature = FeatureCollection.fromJson(
-      """
-      {
-         "type": "FeatureCollection",
-         "bbox": [100.0, 0.0, -100.0, 105.0, 1.0, 0.0],
-         "features": [
-             {
-                 "type": "Feature",
-                 "id": "id0",
-                 "geometry": {
-                     "type": "LineString",
-                     "coordinates": [
-                         [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
-                     ]
-                 },
-                 "properties": {
-                     "prop0": "value0",
-                     "prop1": "value1"
-                 }
-             },
-             {
-                 "type": "Feature",
-                 "id": "id1",
-                 "geometry": {
-                     "type": "Polygon",
-                     "coordinates": [
-                         [
-                             [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]
-                         ]
-                     ]
-                 },
-                 "properties": {
-                     "prop0": "value0",
-                     "prop1": "value1"
-                 }
-             }
-         ]
-      }
-      """.trimIndent()
-    )
-    feature.toValue()
-    verify { ValueConverter.fromJson(feature.toJson()) }
-  }
-
-  @Test(expected = RuntimeException::class)
-  fun geometryTest() {
-    every { expected.value } returns null
-    every { expected.error } returns "error"
-
-    val feature = Feature.fromJson(
-      """
-      {
-        "type": "Feature",
-        "geometry": {
-          "type": "Polygon",
-          "coordinates": [
-           [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
-           [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
-          ]
-        },
-        "properties": {
-          "name": "Dinagat Islands"
-        }
-      }
-      """.trimIndent()
-    )
-    feature.geometry()?.toValue()
-    verify { ValueConverter.fromJson(feature.geometry()!!.toJson()) }
+    val featureString =
+      "{\"type\":\"Feature\",\"bbox\":[100.0,0.0,-100.0,105.0,1.0,0.0],\"geometry\":{\"type\":\"Point\",\"coordinates\":[125.6,10.1]},\"properties\":{\"name\":\"Dinagat Islands\"}}"
+    val actual = Feature.fromJson(featureString).toValue()
+    assertEquals(Value.valueOf(featureString), actual)
   }
 
   internal data class MockData(val a: Int, val b: String)


### PR DESCRIPTION
This PR changes how we marshal GeoJSON data across the JNI boundary. Instead of converting each Feature/Geometry to nested value types. We are taking the String representation of the GeoJSON data and wrapping that into a Value instead. Benchmark upstream has shown that this can result in a +3x improvement for ~10000 GeoJSON points. 


#### Todo: 
 - [x] back up this change with own benchmarks and track this as a metric overtime. 

cc @alexshalamov, thank you for leading out this improvement and stopgap solution. 