### PR TITLE
[app] add example using feature state API

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -967,5 +967,17 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ExampleOverviewActivity" />
         </activity>
+        <activity
+            android:name=".examples.featurestate.FeatureStateActivity"
+            android:description="@string/description_feature_state"
+            android:exported="true"
+            android:label="@string/activity_feature_state">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_feature_state" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".ExampleOverviewActivity" />
+        </activity>
     </application>
 </manifest>

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/featurestate/FeatureStateActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/featurestate/FeatureStateActivity.kt
@@ -1,0 +1,116 @@
+package com.mapbox.maps.testapp.examples.featurestate
+
+import android.graphics.Color
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.bindgen.Value
+import com.mapbox.common.Logger
+import com.mapbox.geojson.Feature
+import com.mapbox.maps.RenderedQueryOptions
+import com.mapbox.maps.Style
+import com.mapbox.maps.extension.style.expressions.dsl.generated.switchCase
+import com.mapbox.maps.extension.style.layers.addLayerBelow
+import com.mapbox.maps.extension.style.layers.generated.fillLayer
+import com.mapbox.maps.extension.style.sources.addSource
+import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
+import com.mapbox.maps.plugin.gestures.addOnMapClickListener
+import com.mapbox.maps.testapp.R
+import kotlinx.android.synthetic.main.activity_simple_map.*
+
+/**
+ * Example of feature state API.
+ * Which allows to add additional feature state to an existing data source.
+ * In this example we add a geojson source that represents the countries around the world.
+ * When a country is clicked, we highlight it.
+ */
+class FeatureStateActivity : AppCompatActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_simple_map)
+    mapView.getMapboxMap().apply {
+      loadStyleUri(Style.MAPBOX_STREETS) {
+        // Add source for the countries data
+        it.addSource(geoJsonSource(SOURCE_ID) {
+          url(SOURCE_URL)
+        })
+
+        // Add fill layer to visualize the countries
+        it.addLayerBelow(fillLayer(LAYER_ID, SOURCE_ID) {
+          fillColor(Color.RED)
+          sourceLayer(SOURCE_LAYER)
+          fillOutlineColor(Color.YELLOW)
+          fillOpacity(
+            switchCase {
+              boolean {
+                featureState { literal("hover") }
+                literal(false)
+              }
+              literal(1.0)
+              literal(0.2)
+            })
+        }, LAYER_ID_BELOW)
+      }
+
+      // Add on map click listener to get notified when the clicks the map
+      addOnMapClickListener { point ->
+        // Validate if the click occurred on the runtime addded layer
+        queryRenderedFeatures(
+          pixelForCoordinate(point),
+          RenderedQueryOptions(listOf(LAYER_ID), null)
+        ) { expectedFeatures ->
+          val features = expectedFeatures.value as List<Feature>
+          // For every feature clicked, update the feature state
+          for (feature in features) {
+            val featureId = feature.id()
+            if (featureId != null) {
+              Logger.i(TAG, "Feature clicked: $feature")
+
+              // update the hover state of a feature to true
+              setFeatureState(
+                SOURCE_ID, SOURCE_LAYER, featureId,
+                Value.valueOf(hashMapOf(Pair("hover", Value.valueOf(true))))
+              )
+
+              // test to validate if feature state was updated
+              getFeatureState(SOURCE_ID, SOURCE_LAYER, featureId) {
+                Logger.i(TAG, "Feature state: " + it.value)
+              }
+            }
+          }
+        }
+        true
+      }
+    }
+  }
+
+  override fun onStart() {
+    super.onStart()
+    mapView.onStart()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView.onStop()
+  }
+
+  override fun onLowMemory() {
+    super.onLowMemory()
+    mapView.onLowMemory()
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    mapView.onDestroy()
+  }
+
+  companion object {
+    const val TAG = "FeatureState"
+    const val LAYER_ID = "fs_layer_id"
+    const val LAYER_ID_BELOW = "country-label"
+    const val SOURCE_ID = "fs_source_id"
+    const val SOURCE_LAYER = "fs_source_layer"
+    const val SOURCE_URL =
+      "https://raw.githubusercontent.com/johan/world.geo.json/master/countries.geo.json"
+  }
+}

--- a/app/src/main/res/values/example_categories.xml
+++ b/app/src/main/res/values/example_categories.xml
@@ -11,6 +11,7 @@
     <string name="category_config">Map configuration</string>
     <string name="category_lab">Lab</string>
     <string name="category_camera">Camera</string>
+    <string name="category_feature_state">Feature state</string>
     <string name="category_offline">Offline</string>
     <string name="category_sky">Sky</string>
     <string name="category_annotation">Annotation</string>

--- a/app/src/main/res/values/example_descriptions.xml
+++ b/app/src/main/res/values/example_descriptions.xml
@@ -76,4 +76,5 @@
     <string name="description_santa_catalina">Santa Catalina Walking Route</string>
     <string name="description_multiple_display">Display the map on a secondary display</string>
     <string name="description_map_view_customization">Customize your map view</string>
+    <string name="description_feature_state">Use feature state to highlight a country on the map when clicked</string>
 </resources>

--- a/app/src/main/res/values/example_titles.xml
+++ b/app/src/main/res/values/example_titles.xml
@@ -76,4 +76,5 @@
     <string name="activity_santa_catalina">Santa Catalina Island</string>
     <string name="activity_multiple_display">Multi display</string>
     <string name="activity_map_view_customization">Creating a map view</string>
+    <string name="activity_feature_state">Feature state</string>
 </resources>


### PR DESCRIPTION
Example to showcase feature state API. This API allows you to associate additional state to an existing feature. For example you can add feature properties to existing geojson. See the gl-js blogpost for more information: https://blog.mapbox.com/going-live-with-electoral-maps-a-guide-to-feature-state-b520e91a22d.

Atm, the example isn't fully working and need to revisit once we have a new upstream dependency released.