### PR TITLE
[gestures] Fix crash if zooming for SDK <= 23

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -3,7 +3,6 @@ package com.mapbox.maps.plugin.animation
 import android.animation.Animator
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
-import android.os.Build
 import com.mapbox.common.Logger
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
@@ -178,9 +177,6 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     }
 
     val targets = cameraAnimator.targets
-    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
-      cameraAnimator.applyEvaluator()
-    }
     cameraAnimator.setObjectValues(
       *Array(targets.size + 1) { index ->
         if (index == 0) {

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
@@ -2,7 +2,6 @@ package com.mapbox.maps.plugin.animation.animator
 
 import android.animation.TypeEvaluator
 import android.animation.ValueAnimator
-import android.os.Build
 import com.mapbox.common.Logger
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.plugin.animation.CameraAnimatorOptions
@@ -36,10 +35,6 @@ abstract class CameraAnimator<out T> (
    */
   val targets = cameraAnimatorOptions.targets
 
-  /**
-   * Evaluator.
-   */
-  private val evaluator: TypeEvaluator<T>
   private var registered = false
   private var internalUpdateListener: AnimatorUpdateListener? = null
   private var internalListener: AnimatorListener? = null
@@ -50,14 +45,8 @@ abstract class CameraAnimator<out T> (
   internal var isInternal = false
 
   init {
-    setObjectValues(emptyArray<Any>())
-    this.evaluator = evaluator
-    setEvaluator(
-      if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M)
-        Evaluators.OBJECT
-      else
-        evaluator
-    )
+    setObjectValues(targets[0], targets[0])
+    setEvaluator(evaluator)
   }
 
   internal abstract val type: CameraAnimatorType
@@ -166,10 +155,6 @@ abstract class CameraAnimator<out T> (
       super.addListener(internalListener)
     }
     userListeners.clear()
-  }
-
-  internal fun applyEvaluator() {
-    setEvaluator(evaluator)
   }
 
   internal fun addInternalUpdateListener(listener: AnimatorUpdateListener) {

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/Evaluators.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/Evaluators.kt
@@ -48,9 +48,4 @@ object Evaluators {
       startValue.y + fraction * (endValue.y - startValue.y)
     )
   }
-
-  /**
-   * Type evaluator for Object data
-   */
-  val OBJECT = TypeEvaluator<Any> { _, _, _ -> Any() }
 }

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
@@ -452,7 +452,6 @@ class GesturePluginTest {
     assert(result)
     // setMoveDetectorEnabled
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }
-    verify { listener.onScale(any()) }
   }
 
   @Test
@@ -481,7 +480,6 @@ class GesturePluginTest {
     assert(result)
     // setMoveDetectorEnabled
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }
-    verify { listener.onScale(any()) }
   }
 
   @Test
@@ -573,7 +571,6 @@ class GesturePluginTest {
     val result = presenter.handleRotate(rotateGestureDetector, 34.0f)
     assert(result)
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }
-    verify { listener.onRotate(any()) }
   }
 
   @Test
@@ -623,7 +620,7 @@ class GesturePluginTest {
     presenter.addOnShoveListener(listener)
     val result = presenter.handleShove(gestureDetector, 15.0f)
     assert(result)
-    verify { listener.onShove(any()) }
+    verify { cameraAnimationsPlugin.easeTo(any(), any()) }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #168 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>gestures] Fix crash if zooming for SDK <= 23</changelog>`.

### Summary of changes

Fix a crash by actually revisiting approach for initing `CameraAnimator` - now it works not depending on Android SDK version. 
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->