### PR TITLE
[Annotation plugin] Set default values for annotation option properties to null.

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Circle.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Circle.kt
@@ -66,8 +66,8 @@ class Circle(
      */
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_SORT_KEY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -99,8 +99,8 @@ class Circle(
      */
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_BLUR)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -132,8 +132,8 @@ class Circle(
     @ColorInt
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_COLOR)
-      if (!value.isJsonNull) {
-        ColorUtils.rgbaToColor(value.asString)?.let {
+      value?.let {
+        ColorUtils.rgbaToColor(it.asString)?.let {
           return it
         }
       }
@@ -168,8 +168,8 @@ class Circle(
      */
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_COLOR)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -199,8 +199,8 @@ class Circle(
      */
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_OPACITY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -232,8 +232,8 @@ class Circle(
      */
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_RADIUS)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -265,8 +265,8 @@ class Circle(
     @ColorInt
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_COLOR)
-      if (!value.isJsonNull) {
-        ColorUtils.rgbaToColor(value.asString)?.let {
+      value?.let {
+        ColorUtils.rgbaToColor(it.asString)?.let {
           return it
         }
       }
@@ -301,8 +301,8 @@ class Circle(
      */
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_COLOR)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -332,8 +332,8 @@ class Circle(
      */
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_OPACITY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -365,8 +365,8 @@ class Circle(
      */
     get() {
       val value = jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_WIDTH)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -409,28 +409,28 @@ class Circle(
    * Set the used data-driven properties
    */
   override fun setUsedDataDrivenProperties() {
-    if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_SORT_KEY).isJsonNull)) {
+    jsonObject.get(CircleOptions.PROPERTY_CIRCLE_SORT_KEY)?.let {
       annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_SORT_KEY)
     }
-    if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_BLUR).isJsonNull)) {
+    jsonObject.get(CircleOptions.PROPERTY_CIRCLE_BLUR)?.let {
       annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_BLUR)
     }
-    if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_COLOR).isJsonNull)) {
+    jsonObject.get(CircleOptions.PROPERTY_CIRCLE_COLOR)?.let {
       annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_COLOR)
     }
-    if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_OPACITY).isJsonNull)) {
+    jsonObject.get(CircleOptions.PROPERTY_CIRCLE_OPACITY)?.let {
       annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_OPACITY)
     }
-    if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_RADIUS).isJsonNull)) {
+    jsonObject.get(CircleOptions.PROPERTY_CIRCLE_RADIUS)?.let {
       annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_RADIUS)
     }
-    if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_COLOR).isJsonNull)) {
+    jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_COLOR)?.let {
       annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_STROKE_COLOR)
     }
-    if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_OPACITY).isJsonNull)) {
+    jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_OPACITY)?.let {
       annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_STROKE_OPACITY)
     }
-    if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_WIDTH).isJsonNull)) {
+    jsonObject.get(CircleOptions.PROPERTY_CIRCLE_STROKE_WIDTH)?.let {
       annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_STROKE_WIDTH)
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleOptions.kt
@@ -40,7 +40,7 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
   /**
    * Amount to blur the circle. 1 blurs the circle such that only the centerpoint is full opacity.
    */
-  var circleBlur: Double = 0.0
+  var circleBlur: Double? = null
 
   /**
    * Set circle-blur to initialise the circle with.
@@ -58,7 +58,7 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
   /**
    * The fill color of the circle.
    */
-  var circleColor: String = "rgba(0, 0, 0, 1)"
+  var circleColor: String? = null
 
   /**
    * Set circle-color to initialise the circle with.
@@ -89,7 +89,7 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
   /**
    * The opacity at which the circle will be drawn.
    */
-  var circleOpacity: Double = 1.0
+  var circleOpacity: Double? = null
 
   /**
    * Set circle-opacity to initialise the circle with.
@@ -107,7 +107,7 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
   /**
    * Circle radius.
    */
-  var circleRadius: Double = 5.0
+  var circleRadius: Double? = null
 
   /**
    * Set circle-radius to initialise the circle with.
@@ -125,7 +125,7 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
   /**
    * The stroke color of the circle.
    */
-  var circleStrokeColor: String = "rgba(0, 0, 0, 1)"
+  var circleStrokeColor: String? = null
 
   /**
    * Set circle-stroke-color to initialise the circle with.
@@ -156,7 +156,7 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
   /**
    * The opacity of the circle's stroke.
    */
-  var circleStrokeOpacity: Double = 1.0
+  var circleStrokeOpacity: Double? = null
 
   /**
    * Set circle-stroke-opacity to initialise the circle with.
@@ -174,7 +174,7 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
   /**
    * The width of the circle's stroke. Strokes are placed outside of the `circle-radius`.
    */
-  var circleStrokeWidth: Double = 0.0
+  var circleStrokeWidth: Double? = null
 
   /**
    * Set circle-stroke-width to initialise the circle with.
@@ -284,14 +284,30 @@ class CircleOptions : AnnotationOptions<Point, Circle> {
       throw RuntimeException("geometry field is required")
     }
     val jsonObject = JsonObject()
-    jsonObject.addProperty(PROPERTY_CIRCLE_SORT_KEY, circleSortKey)
-    jsonObject.addProperty(PROPERTY_CIRCLE_BLUR, circleBlur)
-    jsonObject.addProperty(PROPERTY_CIRCLE_COLOR, circleColor)
-    jsonObject.addProperty(PROPERTY_CIRCLE_OPACITY, circleOpacity)
-    jsonObject.addProperty(PROPERTY_CIRCLE_RADIUS, circleRadius)
-    jsonObject.addProperty(PROPERTY_CIRCLE_STROKE_COLOR, circleStrokeColor)
-    jsonObject.addProperty(PROPERTY_CIRCLE_STROKE_OPACITY, circleStrokeOpacity)
-    jsonObject.addProperty(PROPERTY_CIRCLE_STROKE_WIDTH, circleStrokeWidth)
+    circleSortKey?.let {
+      jsonObject.addProperty(PROPERTY_CIRCLE_SORT_KEY, it)
+    }
+    circleBlur?.let {
+      jsonObject.addProperty(PROPERTY_CIRCLE_BLUR, it)
+    }
+    circleColor?.let {
+      jsonObject.addProperty(PROPERTY_CIRCLE_COLOR, it)
+    }
+    circleOpacity?.let {
+      jsonObject.addProperty(PROPERTY_CIRCLE_OPACITY, it)
+    }
+    circleRadius?.let {
+      jsonObject.addProperty(PROPERTY_CIRCLE_RADIUS, it)
+    }
+    circleStrokeColor?.let {
+      jsonObject.addProperty(PROPERTY_CIRCLE_STROKE_COLOR, it)
+    }
+    circleStrokeOpacity?.let {
+      jsonObject.addProperty(PROPERTY_CIRCLE_STROKE_OPACITY, it)
+    }
+    circleStrokeWidth?.let {
+      jsonObject.addProperty(PROPERTY_CIRCLE_STROKE_WIDTH, it)
+    }
     val circle = Circle(id, annotationManager, jsonObject, geometry!!)
     circle.isDraggable = isDraggable
     circle.setData(data)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Fill.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Fill.kt
@@ -66,8 +66,8 @@ class Fill(
      */
     get() {
       val value = jsonObject.get(FillOptions.PROPERTY_FILL_SORT_KEY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -99,8 +99,8 @@ class Fill(
     @ColorInt
     get() {
       val value = jsonObject.get(FillOptions.PROPERTY_FILL_COLOR)
-      if (!value.isJsonNull) {
-        ColorUtils.rgbaToColor(value.asString)?.let {
+      value?.let {
+        ColorUtils.rgbaToColor(it.asString)?.let {
           return it
         }
       }
@@ -135,8 +135,8 @@ class Fill(
      */
     get() {
       val value = jsonObject.get(FillOptions.PROPERTY_FILL_COLOR)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -166,8 +166,8 @@ class Fill(
      */
     get() {
       val value = jsonObject.get(FillOptions.PROPERTY_FILL_OPACITY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -199,8 +199,8 @@ class Fill(
     @ColorInt
     get() {
       val value = jsonObject.get(FillOptions.PROPERTY_FILL_OUTLINE_COLOR)
-      if (!value.isJsonNull) {
-        ColorUtils.rgbaToColor(value.asString)?.let {
+      value?.let {
+        ColorUtils.rgbaToColor(it.asString)?.let {
           return it
         }
       }
@@ -235,8 +235,8 @@ class Fill(
      */
     get() {
       val value = jsonObject.get(FillOptions.PROPERTY_FILL_OUTLINE_COLOR)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -266,8 +266,8 @@ class Fill(
      */
     get() {
       val value = jsonObject.get(FillOptions.PROPERTY_FILL_PATTERN)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -318,19 +318,19 @@ class Fill(
    * Set the used data-driven properties
    */
   override fun setUsedDataDrivenProperties() {
-    if (!(jsonObject.get(FillOptions.PROPERTY_FILL_SORT_KEY).isJsonNull)) {
+    jsonObject.get(FillOptions.PROPERTY_FILL_SORT_KEY)?.let {
       annotationManager.enableDataDrivenProperty(FillOptions.PROPERTY_FILL_SORT_KEY)
     }
-    if (!(jsonObject.get(FillOptions.PROPERTY_FILL_COLOR).isJsonNull)) {
+    jsonObject.get(FillOptions.PROPERTY_FILL_COLOR)?.let {
       annotationManager.enableDataDrivenProperty(FillOptions.PROPERTY_FILL_COLOR)
     }
-    if (!(jsonObject.get(FillOptions.PROPERTY_FILL_OPACITY).isJsonNull)) {
+    jsonObject.get(FillOptions.PROPERTY_FILL_OPACITY)?.let {
       annotationManager.enableDataDrivenProperty(FillOptions.PROPERTY_FILL_OPACITY)
     }
-    if (!(jsonObject.get(FillOptions.PROPERTY_FILL_OUTLINE_COLOR).isJsonNull)) {
+    jsonObject.get(FillOptions.PROPERTY_FILL_OUTLINE_COLOR)?.let {
       annotationManager.enableDataDrivenProperty(FillOptions.PROPERTY_FILL_OUTLINE_COLOR)
     }
-    if (!(jsonObject.get(FillOptions.PROPERTY_FILL_PATTERN).isJsonNull)) {
+    jsonObject.get(FillOptions.PROPERTY_FILL_PATTERN)?.let {
       annotationManager.enableDataDrivenProperty(FillOptions.PROPERTY_FILL_PATTERN)
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/FillOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/FillOptions.kt
@@ -41,7 +41,7 @@ class FillOptions : AnnotationOptions<Polygon, Fill> {
   /**
    * The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1px stroke, if it is used.
    */
-  var fillColor: String = "rgba(0, 0, 0, 1)"
+  var fillColor: String? = null
 
   /**
    * Set fill-color to initialise the fill with.
@@ -72,7 +72,7 @@ class FillOptions : AnnotationOptions<Polygon, Fill> {
   /**
    * The opacity of the entire fill layer. In contrast to the `fill-color`, this value will also affect the 1px stroke around the fill, if the stroke is used.
    */
-  var fillOpacity: Double = 1.0
+  var fillOpacity: Double? = null
 
   /**
    * Set fill-opacity to initialise the fill with.
@@ -231,11 +231,21 @@ class FillOptions : AnnotationOptions<Polygon, Fill> {
       throw RuntimeException("geometry field is required")
     }
     val jsonObject = JsonObject()
-    jsonObject.addProperty(PROPERTY_FILL_SORT_KEY, fillSortKey)
-    jsonObject.addProperty(PROPERTY_FILL_COLOR, fillColor)
-    jsonObject.addProperty(PROPERTY_FILL_OPACITY, fillOpacity)
-    jsonObject.addProperty(PROPERTY_FILL_OUTLINE_COLOR, fillOutlineColor)
-    jsonObject.addProperty(PROPERTY_FILL_PATTERN, fillPattern)
+    fillSortKey?.let {
+      jsonObject.addProperty(PROPERTY_FILL_SORT_KEY, it)
+    }
+    fillColor?.let {
+      jsonObject.addProperty(PROPERTY_FILL_COLOR, it)
+    }
+    fillOpacity?.let {
+      jsonObject.addProperty(PROPERTY_FILL_OPACITY, it)
+    }
+    fillOutlineColor?.let {
+      jsonObject.addProperty(PROPERTY_FILL_OUTLINE_COLOR, it)
+    }
+    fillPattern?.let {
+      jsonObject.addProperty(PROPERTY_FILL_PATTERN, it)
+    }
     val fill = Fill(id, annotationManager, jsonObject, geometry!!)
     fill.isDraggable = isDraggable
     fill.setData(data)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Line.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Line.kt
@@ -66,8 +66,8 @@ class Line(
      */
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_JOIN)
-      if (!value.isJsonNull) {
-        return LineJoin.valueOf(value.asString)
+      value?.let {
+        return LineJoin.valueOf(it.asString)
       }
       return null
     }
@@ -99,8 +99,8 @@ class Line(
      */
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_SORT_KEY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -132,8 +132,8 @@ class Line(
      */
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_BLUR)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -165,8 +165,8 @@ class Line(
     @ColorInt
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_COLOR)
-      if (!value.isJsonNull) {
-        ColorUtils.rgbaToColor(value.asString)?.let {
+      value?.let {
+        ColorUtils.rgbaToColor(it.asString)?.let {
           return it
         }
       }
@@ -201,8 +201,8 @@ class Line(
      */
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_COLOR)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -232,8 +232,8 @@ class Line(
      */
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_GAP_WIDTH)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -265,8 +265,8 @@ class Line(
      */
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_OFFSET)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -298,8 +298,8 @@ class Line(
      */
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_OPACITY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -331,8 +331,8 @@ class Line(
      */
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_PATTERN)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -364,8 +364,8 @@ class Line(
      */
     get() {
       val value = jsonObject.get(LineOptions.PROPERTY_LINE_WIDTH)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -413,31 +413,31 @@ class Line(
    * Set the used data-driven properties
    */
   override fun setUsedDataDrivenProperties() {
-    if (!(jsonObject.get(LineOptions.PROPERTY_LINE_JOIN).isJsonNull)) {
+    jsonObject.get(LineOptions.PROPERTY_LINE_JOIN)?.let {
       annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_JOIN)
     }
-    if (!(jsonObject.get(LineOptions.PROPERTY_LINE_SORT_KEY).isJsonNull)) {
+    jsonObject.get(LineOptions.PROPERTY_LINE_SORT_KEY)?.let {
       annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_SORT_KEY)
     }
-    if (!(jsonObject.get(LineOptions.PROPERTY_LINE_BLUR).isJsonNull)) {
+    jsonObject.get(LineOptions.PROPERTY_LINE_BLUR)?.let {
       annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_BLUR)
     }
-    if (!(jsonObject.get(LineOptions.PROPERTY_LINE_COLOR).isJsonNull)) {
+    jsonObject.get(LineOptions.PROPERTY_LINE_COLOR)?.let {
       annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_COLOR)
     }
-    if (!(jsonObject.get(LineOptions.PROPERTY_LINE_GAP_WIDTH).isJsonNull)) {
+    jsonObject.get(LineOptions.PROPERTY_LINE_GAP_WIDTH)?.let {
       annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_GAP_WIDTH)
     }
-    if (!(jsonObject.get(LineOptions.PROPERTY_LINE_OFFSET).isJsonNull)) {
+    jsonObject.get(LineOptions.PROPERTY_LINE_OFFSET)?.let {
       annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_OFFSET)
     }
-    if (!(jsonObject.get(LineOptions.PROPERTY_LINE_OPACITY).isJsonNull)) {
+    jsonObject.get(LineOptions.PROPERTY_LINE_OPACITY)?.let {
       annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_OPACITY)
     }
-    if (!(jsonObject.get(LineOptions.PROPERTY_LINE_PATTERN).isJsonNull)) {
+    jsonObject.get(LineOptions.PROPERTY_LINE_PATTERN)?.let {
       annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_PATTERN)
     }
-    if (!(jsonObject.get(LineOptions.PROPERTY_LINE_WIDTH).isJsonNull)) {
+    jsonObject.get(LineOptions.PROPERTY_LINE_WIDTH)?.let {
       annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_WIDTH)
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/LineOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/LineOptions.kt
@@ -24,7 +24,7 @@ class LineOptions : AnnotationOptions<LineString, Line> {
   /**
    * The display of lines when joining.
    */
-  var lineJoin: LineJoin = LineJoin.MITER
+  var lineJoin: LineJoin? = null
 
   /**
    * Set line-join to initialise the line with.
@@ -60,7 +60,7 @@ class LineOptions : AnnotationOptions<LineString, Line> {
   /**
    * Blur applied to the line, in pixels.
    */
-  var lineBlur: Double = 0.0
+  var lineBlur: Double? = null
 
   /**
    * Set line-blur to initialise the line with.
@@ -78,7 +78,7 @@ class LineOptions : AnnotationOptions<LineString, Line> {
   /**
    * The color with which the line will be drawn.
    */
-  var lineColor: String = "rgba(0, 0, 0, 1)"
+  var lineColor: String? = null
 
   /**
    * Set line-color to initialise the line with.
@@ -109,7 +109,7 @@ class LineOptions : AnnotationOptions<LineString, Line> {
   /**
    * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
    */
-  var lineGapWidth: Double = 0.0
+  var lineGapWidth: Double? = null
 
   /**
    * Set line-gap-width to initialise the line with.
@@ -127,7 +127,7 @@ class LineOptions : AnnotationOptions<LineString, Line> {
   /**
    * The line's offset. For linear features, a positive value offsets the line to the right, relative to the direction of the line, and a negative value to the left. For polygon features, a positive value results in an inset, and a negative value results in an outset.
    */
-  var lineOffset: Double = 0.0
+  var lineOffset: Double? = null
 
   /**
    * Set line-offset to initialise the line with.
@@ -145,7 +145,7 @@ class LineOptions : AnnotationOptions<LineString, Line> {
   /**
    * The opacity at which the line will be drawn.
    */
-  var lineOpacity: Double = 1.0
+  var lineOpacity: Double? = null
 
   /**
    * Set line-opacity to initialise the line with.
@@ -181,7 +181,7 @@ class LineOptions : AnnotationOptions<LineString, Line> {
   /**
    * Stroke thickness.
    */
-  var lineWidth: Double = 1.0
+  var lineWidth: Double? = null
 
   /**
    * Set line-width to initialise the line with.
@@ -291,15 +291,33 @@ class LineOptions : AnnotationOptions<LineString, Line> {
       throw RuntimeException("geometry field is required")
     }
     val jsonObject = JsonObject()
-    jsonObject.addProperty(PROPERTY_LINE_JOIN, lineJoin.value)
-    jsonObject.addProperty(PROPERTY_LINE_SORT_KEY, lineSortKey)
-    jsonObject.addProperty(PROPERTY_LINE_BLUR, lineBlur)
-    jsonObject.addProperty(PROPERTY_LINE_COLOR, lineColor)
-    jsonObject.addProperty(PROPERTY_LINE_GAP_WIDTH, lineGapWidth)
-    jsonObject.addProperty(PROPERTY_LINE_OFFSET, lineOffset)
-    jsonObject.addProperty(PROPERTY_LINE_OPACITY, lineOpacity)
-    jsonObject.addProperty(PROPERTY_LINE_PATTERN, linePattern)
-    jsonObject.addProperty(PROPERTY_LINE_WIDTH, lineWidth)
+    lineJoin?.let {
+      jsonObject.addProperty(PROPERTY_LINE_JOIN, it.value)
+    }
+    lineSortKey?.let {
+      jsonObject.addProperty(PROPERTY_LINE_SORT_KEY, it)
+    }
+    lineBlur?.let {
+      jsonObject.addProperty(PROPERTY_LINE_BLUR, it)
+    }
+    lineColor?.let {
+      jsonObject.addProperty(PROPERTY_LINE_COLOR, it)
+    }
+    lineGapWidth?.let {
+      jsonObject.addProperty(PROPERTY_LINE_GAP_WIDTH, it)
+    }
+    lineOffset?.let {
+      jsonObject.addProperty(PROPERTY_LINE_OFFSET, it)
+    }
+    lineOpacity?.let {
+      jsonObject.addProperty(PROPERTY_LINE_OPACITY, it)
+    }
+    linePattern?.let {
+      jsonObject.addProperty(PROPERTY_LINE_PATTERN, it)
+    }
+    lineWidth?.let {
+      jsonObject.addProperty(PROPERTY_LINE_WIDTH, it)
+    }
     val line = Line(id, annotationManager, jsonObject, geometry!!)
     line.isDraggable = isDraggable
     line.setData(data)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/Symbol.kt
@@ -88,8 +88,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_ANCHOR)
-      if (!value.isJsonNull) {
-        return IconAnchor.valueOf(value.asString)
+      value?.let {
+        return IconAnchor.valueOf(it.asString)
       }
       return null
     }
@@ -121,8 +121,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_IMAGE)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -153,9 +153,9 @@ class Symbol(
      * @return [Point] value for List<Double>
      */
     get() {
-      val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_OFFSET) as JsonArray
-      if (!value.isJsonNull) {
-        return value.map { it.toString().toDouble() }
+      val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_OFFSET)
+      value?.let {
+        return (it as JsonArray).map { it.toString().toDouble() }
       }
       return null
     }
@@ -188,8 +188,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_ROTATE)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -221,8 +221,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_SIZE)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -254,8 +254,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_SYMBOL_SORT_KEY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -287,8 +287,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_ANCHOR)
-      if (!value.isJsonNull) {
-        return TextAnchor.valueOf(value.asString)
+      value?.let {
+        return TextAnchor.valueOf(it.asString)
       }
       return null
     }
@@ -320,8 +320,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_FIELD)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -352,9 +352,9 @@ class Symbol(
      * @return property wrapper value around List<String>
      */
     get() {
-      val value = jsonObject.getAsJsonArray(SymbolOptions.PROPERTY_TEXT_FONT)
-      if (!value.isJsonNull) {
-        return toStringArray(value)
+      val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_FONT)
+      value?.let {
+        return toStringArray(it as JsonArray)
       }
       return null
     }
@@ -385,8 +385,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_JUSTIFY)
-      if (!value.isJsonNull) {
-        return TextJustify.valueOf(value.asString)
+      value?.let {
+        return TextJustify.valueOf(it.asString)
       }
       return null
     }
@@ -418,8 +418,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_LETTER_SPACING)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -451,8 +451,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_MAX_WIDTH)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -483,9 +483,9 @@ class Symbol(
      * @return [Point] value for List<Double>
      */
     get() {
-      val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_OFFSET) as JsonArray
-      if (!value.isJsonNull) {
-        return value.map { it.toString().toDouble() }
+      val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_OFFSET)
+      value?.let {
+        return (it as JsonArray).map { it.toString().toDouble() }
       }
       return null
     }
@@ -518,8 +518,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_RADIAL_OFFSET)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -551,8 +551,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_ROTATE)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -584,8 +584,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_SIZE)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -617,8 +617,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_TRANSFORM)
-      if (!value.isJsonNull) {
-        return TextTransform.valueOf(value.asString)
+      value?.let {
+        return TextTransform.valueOf(it.asString)
       }
       return null
     }
@@ -650,8 +650,8 @@ class Symbol(
     @ColorInt
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_COLOR)
-      if (!value.isJsonNull) {
-        ColorUtils.rgbaToColor(value.asString)?.let {
+      value?.let {
+        ColorUtils.rgbaToColor(it.asString)?.let {
           return it
         }
       }
@@ -686,8 +686,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_COLOR)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -717,8 +717,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_BLUR)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -750,8 +750,8 @@ class Symbol(
     @ColorInt
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_COLOR)
-      if (!value.isJsonNull) {
-        ColorUtils.rgbaToColor(value.asString)?.let {
+      value?.let {
+        ColorUtils.rgbaToColor(it.asString)?.let {
           return it
         }
       }
@@ -786,8 +786,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_COLOR)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -817,8 +817,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_WIDTH)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -850,8 +850,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_ICON_OPACITY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -883,8 +883,8 @@ class Symbol(
     @ColorInt
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_COLOR)
-      if (!value.isJsonNull) {
-        ColorUtils.rgbaToColor(value.asString)?.let {
+      value?.let {
+        ColorUtils.rgbaToColor(it.asString)?.let {
           return it
         }
       }
@@ -919,8 +919,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_COLOR)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -950,8 +950,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_BLUR)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -983,8 +983,8 @@ class Symbol(
     @ColorInt
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_COLOR)
-      if (!value.isJsonNull) {
-        ColorUtils.rgbaToColor(value.asString)?.let {
+      value?.let {
+        ColorUtils.rgbaToColor(it.asString)?.let {
           return it
         }
       }
@@ -1019,8 +1019,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_COLOR)
-      if (!value.isJsonNull) {
-        return value.asString.toString()
+      value?.let {
+        return it.asString.toString()
       }
       return null
     }
@@ -1050,8 +1050,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_WIDTH)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -1083,8 +1083,8 @@ class Symbol(
      */
     get() {
       val value = jsonObject.get(SymbolOptions.PROPERTY_TEXT_OPACITY)
-      if (!value.isJsonNull) {
-        return value.asString.toDouble()
+      value?.let {
+        return it.asString.toDouble()
       }
       return null
     }
@@ -1127,85 +1127,85 @@ class Symbol(
    * Set the used data-driven properties
    */
   override fun setUsedDataDrivenProperties() {
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_ANCHOR).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_ANCHOR)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_ANCHOR)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_IMAGE).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_IMAGE)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_IMAGE)
     }
-    if ((jsonObject.get(SymbolOptions.PROPERTY_ICON_OFFSET) as JsonArray).size() > 0) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_OFFSET)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_OFFSET)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_ROTATE).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_ROTATE)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_ROTATE)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_SIZE).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_SIZE)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_SIZE)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_SYMBOL_SORT_KEY).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_SYMBOL_SORT_KEY)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_SYMBOL_SORT_KEY)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_ANCHOR).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_ANCHOR)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_ANCHOR)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_FIELD).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_FIELD)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_FIELD)
     }
-    if ((jsonObject.get(SymbolOptions.PROPERTY_TEXT_FONT) as JsonArray).size() > 0) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_FONT)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_FONT)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_JUSTIFY).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_JUSTIFY)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_JUSTIFY)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_LETTER_SPACING).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_LETTER_SPACING)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_LETTER_SPACING)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_MAX_WIDTH).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_MAX_WIDTH)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_MAX_WIDTH)
     }
-    if ((jsonObject.get(SymbolOptions.PROPERTY_TEXT_OFFSET) as JsonArray).size() > 0) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_OFFSET)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_OFFSET)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_RADIAL_OFFSET).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_RADIAL_OFFSET)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_RADIAL_OFFSET)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_ROTATE).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_ROTATE)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_ROTATE)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_SIZE).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_SIZE)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_SIZE)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_TRANSFORM).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_TRANSFORM)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_TRANSFORM)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_COLOR).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_COLOR)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_COLOR)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_BLUR).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_BLUR)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_HALO_BLUR)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_COLOR).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_COLOR)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_HALO_COLOR)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_WIDTH).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_HALO_WIDTH)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_HALO_WIDTH)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_OPACITY).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_ICON_OPACITY)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_OPACITY)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_COLOR).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_COLOR)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_COLOR)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_BLUR).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_BLUR)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_HALO_BLUR)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_COLOR).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_COLOR)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_HALO_COLOR)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_WIDTH).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_HALO_WIDTH)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_HALO_WIDTH)
     }
-    if (!(jsonObject.get(SymbolOptions.PROPERTY_TEXT_OPACITY).isJsonNull)) {
+    jsonObject.get(SymbolOptions.PROPERTY_TEXT_OPACITY)?.let {
       annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_TEXT_OPACITY)
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/SymbolOptions.kt
@@ -45,7 +45,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Part of the icon placed closest to the anchor.
    */
-  var iconAnchor: IconAnchor = IconAnchor.CENTER
+  var iconAnchor: IconAnchor? = null
 
   /**
    * Set icon-anchor to initialise the symbol with.
@@ -81,7 +81,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up. Each component is multiplied by the value of `icon-size` to obtain the final offset in pixels. When combined with `icon-rotate` the offset will be as if the rotated direction was up.
    */
-  var iconOffset: List<Double> = listOf(0.0, 0.0)
+  var iconOffset: List<Double>? = null
 
   /**
    * Set icon-offset to initialise the symbol with.
@@ -99,7 +99,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Rotates the icon clockwise.
    */
-  var iconRotate: Double = 0.0
+  var iconRotate: Double? = null
 
   /**
    * Set icon-rotate to initialise the symbol with.
@@ -117,7 +117,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Scales the original size of the icon by the provided factor. The new pixel size of the image will be the original pixel size multiplied by `icon-size`. 1 is the original size; 3 triples the size of the image.
    */
-  var iconSize: Double = 1.0
+  var iconSize: Double? = null
 
   /**
    * Set icon-size to initialise the symbol with.
@@ -153,7 +153,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Part of the text placed closest to the anchor.
    */
-  var textAnchor: TextAnchor = TextAnchor.CENTER
+  var textAnchor: TextAnchor? = null
 
   /**
    * Set text-anchor to initialise the symbol with.
@@ -189,7 +189,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Font stack to use for displaying text.
    */
-  var textFont: List<String> = listOf("Open Sans Regular", "Arial Unicode MS Regular")
+  var textFont: List<String>? = null
 
   /**
    * Set text-font to initialise the symbol with.
@@ -207,7 +207,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Text justification options.
    */
-  var textJustify: TextJustify = TextJustify.CENTER
+  var textJustify: TextJustify? = null
 
   /**
    * Set text-justify to initialise the symbol with.
@@ -225,7 +225,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Text tracking amount.
    */
-  var textLetterSpacing: Double = 0.0
+  var textLetterSpacing: Double? = null
 
   /**
    * Set text-letter-spacing to initialise the symbol with.
@@ -243,7 +243,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * The maximum line width for text wrapping.
    */
-  var textMaxWidth: Double = 10.0
+  var textMaxWidth: Double? = null
 
   /**
    * Set text-max-width to initialise the symbol with.
@@ -261,7 +261,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up. If used with text-variable-anchor, input values will be taken as absolute values. Offsets along the x- and y-axis will be applied automatically based on the anchor position.
    */
-  var textOffset: List<Double> = listOf(0.0, 0.0)
+  var textOffset: List<Double>? = null
 
   /**
    * Set text-offset to initialise the symbol with.
@@ -279,7 +279,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Radial offset of text, in the direction of the symbol's anchor. Useful in combination with `text-variable-anchor`, which defaults to using the two-dimensional `text-offset` if present.
    */
-  var textRadialOffset: Double = 0.0
+  var textRadialOffset: Double? = null
 
   /**
    * Set text-radial-offset to initialise the symbol with.
@@ -297,7 +297,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Rotates the text clockwise.
    */
-  var textRotate: Double = 0.0
+  var textRotate: Double? = null
 
   /**
    * Set text-rotate to initialise the symbol with.
@@ -315,7 +315,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Font size.
    */
-  var textSize: Double = 16.0
+  var textSize: Double? = null
 
   /**
    * Set text-size to initialise the symbol with.
@@ -333,7 +333,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Specifies how to capitalize text, similar to the CSS `text-transform` property.
    */
-  var textTransform: TextTransform = TextTransform.NONE
+  var textTransform: TextTransform? = null
 
   /**
    * Set text-transform to initialise the symbol with.
@@ -351,7 +351,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * The color of the icon. This can only be used with sdf icons.
    */
-  var iconColor: String = "rgba(0, 0, 0, 1)"
+  var iconColor: String? = null
 
   /**
    * Set icon-color to initialise the symbol with.
@@ -382,7 +382,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Fade out the halo towards the outside.
    */
-  var iconHaloBlur: Double = 0.0
+  var iconHaloBlur: Double? = null
 
   /**
    * Set icon-halo-blur to initialise the symbol with.
@@ -400,7 +400,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * The color of the icon's halo. Icon halos can only be used with SDF icons.
    */
-  var iconHaloColor: String = "rgba(0, 0, 0, 1)"
+  var iconHaloColor: String? = null
 
   /**
    * Set icon-halo-color to initialise the symbol with.
@@ -431,7 +431,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Distance of halo to the icon outline.
    */
-  var iconHaloWidth: Double = 0.0
+  var iconHaloWidth: Double? = null
 
   /**
    * Set icon-halo-width to initialise the symbol with.
@@ -449,7 +449,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * The opacity at which the icon will be drawn.
    */
-  var iconOpacity: Double = 1.0
+  var iconOpacity: Double? = null
 
   /**
    * Set icon-opacity to initialise the symbol with.
@@ -467,7 +467,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * The color with which the text will be drawn.
    */
-  var textColor: String = "rgba(0, 0, 0, 1)"
+  var textColor: String? = null
 
   /**
    * Set text-color to initialise the symbol with.
@@ -498,7 +498,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * The halo's fadeout distance towards the outside.
    */
-  var textHaloBlur: Double = 0.0
+  var textHaloBlur: Double? = null
 
   /**
    * Set text-halo-blur to initialise the symbol with.
@@ -516,7 +516,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * The color of the text's halo, which helps it stand out from backgrounds.
    */
-  var textHaloColor: String = "rgba(0, 0, 0, 1)"
+  var textHaloColor: String? = null
 
   /**
    * Set text-halo-color to initialise the symbol with.
@@ -547,7 +547,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.
    */
-  var textHaloWidth: Double = 0.0
+  var textHaloWidth: Double? = null
 
   /**
    * Set text-halo-width to initialise the symbol with.
@@ -565,7 +565,7 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
   /**
    * The opacity at which the text will be drawn.
    */
-  var textOpacity: Double = 1.0
+  var textOpacity: Double? = null
 
   /**
    * Set text-opacity to initialise the symbol with.
@@ -675,33 +675,87 @@ class SymbolOptions : AnnotationOptions<Point, Symbol> {
       throw RuntimeException("geometry field is required")
     }
     val jsonObject = JsonObject()
-    jsonObject.addProperty(PROPERTY_ICON_ANCHOR, iconAnchor.value)
-    jsonObject.addProperty(PROPERTY_ICON_IMAGE, iconImage)
-    jsonObject.add(PROPERTY_ICON_OFFSET, convertDoubleArray(iconOffset))
-    jsonObject.addProperty(PROPERTY_ICON_ROTATE, iconRotate)
-    jsonObject.addProperty(PROPERTY_ICON_SIZE, iconSize)
-    jsonObject.addProperty(PROPERTY_SYMBOL_SORT_KEY, symbolSortKey)
-    jsonObject.addProperty(PROPERTY_TEXT_ANCHOR, textAnchor.value)
-    jsonObject.addProperty(PROPERTY_TEXT_FIELD, textField)
-    jsonObject.add(PROPERTY_TEXT_FONT, convertStringArray(textFont))
-    jsonObject.addProperty(PROPERTY_TEXT_JUSTIFY, textJustify.value)
-    jsonObject.addProperty(PROPERTY_TEXT_LETTER_SPACING, textLetterSpacing)
-    jsonObject.addProperty(PROPERTY_TEXT_MAX_WIDTH, textMaxWidth)
-    jsonObject.add(PROPERTY_TEXT_OFFSET, convertDoubleArray(textOffset))
-    jsonObject.addProperty(PROPERTY_TEXT_RADIAL_OFFSET, textRadialOffset)
-    jsonObject.addProperty(PROPERTY_TEXT_ROTATE, textRotate)
-    jsonObject.addProperty(PROPERTY_TEXT_SIZE, textSize)
-    jsonObject.addProperty(PROPERTY_TEXT_TRANSFORM, textTransform.value)
-    jsonObject.addProperty(PROPERTY_ICON_COLOR, iconColor)
-    jsonObject.addProperty(PROPERTY_ICON_HALO_BLUR, iconHaloBlur)
-    jsonObject.addProperty(PROPERTY_ICON_HALO_COLOR, iconHaloColor)
-    jsonObject.addProperty(PROPERTY_ICON_HALO_WIDTH, iconHaloWidth)
-    jsonObject.addProperty(PROPERTY_ICON_OPACITY, iconOpacity)
-    jsonObject.addProperty(PROPERTY_TEXT_COLOR, textColor)
-    jsonObject.addProperty(PROPERTY_TEXT_HALO_BLUR, textHaloBlur)
-    jsonObject.addProperty(PROPERTY_TEXT_HALO_COLOR, textHaloColor)
-    jsonObject.addProperty(PROPERTY_TEXT_HALO_WIDTH, textHaloWidth)
-    jsonObject.addProperty(PROPERTY_TEXT_OPACITY, textOpacity)
+    iconAnchor?.let {
+      jsonObject.addProperty(PROPERTY_ICON_ANCHOR, it.value)
+    }
+    iconImage?.let {
+      jsonObject.addProperty(PROPERTY_ICON_IMAGE, it)
+    }
+    iconOffset?.let {
+      jsonObject.add(PROPERTY_ICON_OFFSET, convertDoubleArray(it))
+    }
+    iconRotate?.let {
+      jsonObject.addProperty(PROPERTY_ICON_ROTATE, it)
+    }
+    iconSize?.let {
+      jsonObject.addProperty(PROPERTY_ICON_SIZE, it)
+    }
+    symbolSortKey?.let {
+      jsonObject.addProperty(PROPERTY_SYMBOL_SORT_KEY, it)
+    }
+    textAnchor?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_ANCHOR, it.value)
+    }
+    textField?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_FIELD, it)
+    }
+    textFont?.let {
+      jsonObject.add(PROPERTY_TEXT_FONT, convertStringArray(it))
+    }
+    textJustify?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_JUSTIFY, it.value)
+    }
+    textLetterSpacing?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_LETTER_SPACING, it)
+    }
+    textMaxWidth?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_MAX_WIDTH, it)
+    }
+    textOffset?.let {
+      jsonObject.add(PROPERTY_TEXT_OFFSET, convertDoubleArray(it))
+    }
+    textRadialOffset?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_RADIAL_OFFSET, it)
+    }
+    textRotate?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_ROTATE, it)
+    }
+    textSize?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_SIZE, it)
+    }
+    textTransform?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_TRANSFORM, it.value)
+    }
+    iconColor?.let {
+      jsonObject.addProperty(PROPERTY_ICON_COLOR, it)
+    }
+    iconHaloBlur?.let {
+      jsonObject.addProperty(PROPERTY_ICON_HALO_BLUR, it)
+    }
+    iconHaloColor?.let {
+      jsonObject.addProperty(PROPERTY_ICON_HALO_COLOR, it)
+    }
+    iconHaloWidth?.let {
+      jsonObject.addProperty(PROPERTY_ICON_HALO_WIDTH, it)
+    }
+    iconOpacity?.let {
+      jsonObject.addProperty(PROPERTY_ICON_OPACITY, it)
+    }
+    textColor?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_COLOR, it)
+    }
+    textHaloBlur?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_HALO_BLUR, it)
+    }
+    textHaloColor?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_HALO_COLOR, it)
+    }
+    textHaloWidth?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_HALO_WIDTH, it)
+    }
+    textOpacity?.let {
+      jsonObject.addProperty(PROPERTY_TEXT_OPACITY, it)
+    }
     val symbol = Symbol(id, annotationManager, jsonObject, geometry!!)
     iconImageBitmap?.let {
       symbol.iconImageBitmap = iconImageBitmap


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #169 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[Annotation plugin] Set default values for annotation option properties to null.</changelog>`.

### Summary of changes
This pr change the default value to null for properties in annotation options to avoid triggering to many data-driven properties.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->