### PR TITLE
[sdk] clear listeners for success/error style loading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ commands:
                 --app app/build/outputs/apk/release/app-release.apk \
                 --device model=sailfish,version=28,locale=en,orientation=portrait \
                 --device model=zeroflte,version=23,locale=en,orientation=portrait \
+                --device model=Pixel2,version=30,locale=en,orientation=portrait \
                 --device model=mata,version=25,locale=en,orientation=portrait \
                 --timeout 90s
             fi

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -123,6 +123,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   }
 
   override fun onDestroy() {
+    mapboxMap.clearListeners()
     nativeObserver.clearListeners()
     renderer.onDestroy()
     pluginRegistry.cleanup()

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -1,5 +1,6 @@
 package com.mapbox.maps
 
+import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Point
@@ -80,7 +81,7 @@ class MapboxMapTest {
     val mapLoadError = mockk<OnMapLoadErrorListener>()
     mapboxMap.onFinishLoadingStyle(styleLoadCallback, mapLoadError)
     verify { styleLoadCallback.onStyleLoaded(any()) }
-    verify { mapObserver.awaitingStyleGetters.clear() }
+    assertTrue(mapboxMap.awaitingStyleGetters.isEmpty())
   }
 
   @Test
@@ -122,7 +123,7 @@ class MapboxMapTest {
   fun getStyleWaitCallback() {
     val styleLoadCallback = mockk<Style.OnStyleLoaded>()
     mapboxMap.getStyle(styleLoadCallback)
-    verify { mapObserver.awaitingStyleGetters.add(styleLoadCallback) }
+    verify { mapboxMap.awaitingStyleGetters.add(styleLoadCallback) }
   }
 
   @Test
@@ -142,7 +143,7 @@ class MapboxMapTest {
     every { style.fullyLoaded } returns false
     val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     mapboxMap.getStyle(styleLoadCallback)
-    verify { mapObserver.awaitingStyleGetters.add(styleLoadCallback) }
+    verify { mapboxMap.awaitingStyleGetters.add(styleLoadCallback) }
   }
 
   @Test
@@ -745,6 +746,17 @@ class MapboxMapTest {
     mapboxMap.gesturesPlugin { addOnMoveListener(moveListener) }
     verify(exactly = 0) {
       gestures.addOnMoveListener(moveListener)
+    }
+
+    val expected = ExpectedFactory.createValue<Value, String>(Value.valueOf(1.0))
+    if (expected.isValue) {
+      expected.value!!.contents
+    }
+
+    val expected2 = ExpectedFactory.createValue<Value, String>(Value.valueOf(1.0))
+    val value = expected.value
+    if (expected.isValue) {
+      expected.value!!.contents
     }
   }
 }


### PR DESCRIPTION
This PR optimizes for the following use-case:

```
I load a style -> error occurs
I load a new style -> loaded successful
```

Currently the second action results in invoking 2 callbacks:
-  the style loaded callback of the first attempt 
-  the style loaded callback of the second attempt

This logic is encapsulated in the added test and has been optimized for. 
Additionally this PR also move awaitingStyleGetters to be made part of MapboxMap.
This an implementation detail of MapboxMap and unrelated to NativeObserver. 



