### PR TITLE
[locationcomponent] Fix jitter animations if interrupting animations

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/LocationComponentAnimationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/LocationComponentAnimationActivity.kt
@@ -24,6 +24,7 @@ class LocationComponentAnimationActivity : AppCompatActivity() {
 
   private lateinit var mapboxMap: MapboxMap
 
+  private var emitCount = 0
   private var delta = 0f
   private val handler = Handler()
 
@@ -33,7 +34,7 @@ class LocationComponentAnimationActivity : AppCompatActivity() {
 
     private fun emitFakeLocations() {
       // after several first emits we update puck animator options
-      if (delta >= 0.005f && delta < 0.006) {
+      if (emitCount == 6) {
         locationConsumer?.let {
           it.onPuckLocationAnimatorDefaultOptionsUpdated {
             // set same duration as our location emit frequency - it will make puck position change smooth
@@ -49,29 +50,44 @@ class LocationComponentAnimationActivity : AppCompatActivity() {
       }
       handler.postDelayed(
         {
-          // default animation duration = 1000 ms while we emit updates each 2000 ms
-          // this will result in gaps between puck animations
-
-          // however on third emit we will emit location almost immediately using custom animator options for single location update
-          if (delta >= 0.002f && delta < 0.003) {
-            locationConsumer?.onLocationUpdated(
-              Point.fromLngLat(
-                POINT_LNG + delta,
-                POINT_LAT + delta
-              )
-            ) {
-              duration = 100
+          when (emitCount) {
+            // set duration > location emit frequency -> location animator will interrupt running one
+            // and start from last interpolated point. Because of constant change of target point
+            // it will result in increasing puck speed.
+            in 1..3 -> {
+              locationConsumer?.onLocationUpdated(
+                Point.fromLngLat(
+                  POINT_LNG + delta,
+                  POINT_LAT + delta
+                )
+              ) {
+                duration = 4000
+              }
             }
-          } else {
-            locationConsumer?.onLocationUpdated(
-              Point.fromLngLat(
-                POINT_LNG + delta,
-                POINT_LAT + delta
+            // set duration < emit frequency -> puck will quickly jump and await next location emit
+            in 4..5 -> {
+              locationConsumer?.onLocationUpdated(
+                Point.fromLngLat(
+                  POINT_LNG + delta,
+                  POINT_LAT + delta
+                )
+              ) {
+                duration = 500
+              }
+            }
+            // set duration = emit frequency -> location animators do not interrupt each other
+            else -> {
+              locationConsumer?.onLocationUpdated(
+                Point.fromLngLat(
+                  POINT_LNG + delta,
+                  POINT_LAT + delta
+                )
               )
-            )
+            }
           }
           locationConsumer?.onBearingUpdated(BEARING + delta * 10000.0 * 5)
           delta += 0.001f
+          emitCount++
           emitFakeLocations()
         },
         2000

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/LocationComponentAnimationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/LocationComponentAnimationActivity.kt
@@ -34,7 +34,7 @@ class LocationComponentAnimationActivity : AppCompatActivity() {
 
     private fun emitFakeLocations() {
       // after several first emits we update puck animator options
-      if (emitCount == 6) {
+      if (emitCount == 5) {
         locationConsumer?.let {
           it.onPuckLocationAnimatorDefaultOptionsUpdated {
             // set same duration as our location emit frequency - it will make puck position change smooth
@@ -54,7 +54,7 @@ class LocationComponentAnimationActivity : AppCompatActivity() {
             // set duration > location emit frequency -> location animator will interrupt running one
             // and start from last interpolated point. Because of constant change of target point
             // it will result in increasing puck speed.
-            in 1..3 -> {
+            in 1..5 -> {
               locationConsumer?.onLocationUpdated(
                 Point.fromLngLat(
                   POINT_LNG + delta,
@@ -62,17 +62,6 @@ class LocationComponentAnimationActivity : AppCompatActivity() {
                 )
               ) {
                 duration = 4000
-              }
-            }
-            // set duration < emit frequency -> puck will quickly jump and await next location emit
-            in 4..5 -> {
-              locationConsumer?.onLocationUpdated(
-                Point.fromLngLat(
-                  POINT_LNG + delta,
-                  POINT_LAT + delta
-                )
-              ) {
-                duration = 500
               }
             }
             // set duration = emit frequency -> location animators do not interrupt each other

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -103,14 +103,20 @@ internal class LocationPuckManager(
 
   fun updateCurrentPosition(vararg points: Point, options: (ValueAnimator.() -> Unit)? = null) {
     val targets = arrayOf(lastLocation, *points)
-    lastLocation = arrayOf(*points).last()
-    animationManager.animatePosition(*targets, options = options)
+    animationManager.animatePosition(
+      *targets,
+      onUpdate = { lastLocation = it },
+      options = options
+    )
   }
 
   fun updateCurrentBearing(vararg bearings: Double, options: (ValueAnimator.() -> Unit)? = null) {
     val targets = doubleArrayOf(lastBearing, *bearings)
-    lastBearing = doubleArrayOf(*bearings).last()
-    animationManager.animateBearing(*targets, options = options)
+    animationManager.animateBearing(
+      *targets,
+      onUpdate = { lastBearing = it },
+      options = options
+    )
   }
 
   fun updateLocationAnimator(block: ValueAnimator.() -> Unit) {

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -28,8 +28,14 @@ internal class LocationPuckManager(
 
   private var lastLocation: Point =
     delegateProvider.mapCameraDelegate.getCameraOptions(null).center!!
+  private val onLocationUpdated: ((Point) -> Unit) = {
+    lastLocation = it
+  }
 
   private var lastBearing: Double = delegateProvider.mapCameraDelegate.getBearing()
+  private val onBearingUpdated: ((Double) -> Unit) = {
+    lastBearing = it
+  }
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var locationLayerRenderer =
@@ -43,10 +49,11 @@ internal class LocationPuckManager(
     }
 
   fun initialize(style: StyleManagerInterface) {
+    animationManager.setUpdateListeners(onLocationUpdated, onBearingUpdated)
     animationManager.setLocationLayerRenderer(locationLayerRenderer)
+    animationManager.applyPulsingAnimationSettings(settings)
     locationLayerRenderer.addLayers(positionManager)
     locationLayerRenderer.initializeComponents(style)
-    animationManager.applyPulsingAnimationSettings(settings)
     styleScaling(settings)
     updateCurrentPosition(lastLocation)
     updateCurrentBearing(lastBearing)
@@ -82,8 +89,6 @@ internal class LocationPuckManager(
         layerSourceProvider.getModelLayerRenderer(locationPuck)
       }
     }
-    animationManager.setLocationLayerRenderer(locationLayerRenderer)
-    animationManager.applyPulsingAnimationSettings(settings)
     delegateProvider.getStyle {
       initialize(it)
     }
@@ -105,7 +110,6 @@ internal class LocationPuckManager(
     val targets = arrayOf(lastLocation, *points)
     animationManager.animatePosition(
       *targets,
-      onUpdate = { lastLocation = it },
       options = options
     )
   }
@@ -114,7 +118,6 @@ internal class LocationPuckManager(
     val targets = doubleArrayOf(lastBearing, *bearings)
     animationManager.animateBearing(
       *targets,
-      onUpdate = { lastBearing = it },
       options = options
     )
   }

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimator.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimator.kt
@@ -14,7 +14,8 @@ internal abstract class PuckAnimator<T>(
   evaluator: TypeEvaluator<T>
 ) : ValueAnimator() {
 
-  private var puckUpdateListener: ((T) -> Unit)? = null
+  @VisibleForTesting(otherwise = PRIVATE)
+  internal var updateListener: ((T) -> Unit)? = null
   @VisibleForTesting(otherwise = PRIVATE)
   internal var userConfiguredAnimator: ValueAnimator
   protected var locationRenderer: LocationLayerRenderer? = null
@@ -28,7 +29,7 @@ internal abstract class PuckAnimator<T>(
       @Suppress("UNCHECKED_CAST")
       val updatedValue = it.animatedValue as T
       updateLayer(it.animatedFraction, updatedValue)
-      puckUpdateListener?.invoke(updatedValue)
+      updateListener?.invoke(updatedValue)
     }
     duration = LocationComponentConstants.DEFAULT_INTERVAL_MILLIS
     interpolator = DEFAULT_INTERPOLATOR
@@ -68,17 +69,21 @@ internal abstract class PuckAnimator<T>(
     return super.clone()
   }
 
+  fun setUpdateListener(updateListener: ((T) -> Unit)) {
+    if (this.updateListener != updateListener) {
+      this.updateListener = updateListener
+    }
+  }
+
   fun setLocationLayerRenderer(renderer: LocationLayerRenderer) {
     locationRenderer = renderer
   }
 
   fun animate(
     vararg targets: T,
-    onUpdate: ((T) -> Unit)? = null,
     options: (ValueAnimator.() -> Unit)? = null
   ) {
     cancelRunning()
-    puckUpdateListener = onUpdate
     if (options == null) {
       setObjectValues(*targets)
       start()

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
@@ -38,6 +38,14 @@ internal class PuckAnimatorManager(
     pulsingAnimator.setLocationLayerRenderer(renderer)
   }
 
+  fun setUpdateListeners(
+    onLocationUpdated: ((Point) -> Unit),
+    onBearingUpdated: ((Double) -> Unit)
+  ) {
+    positionAnimator.setUpdateListener(onLocationUpdated)
+    bearingAnimator.setUpdateListener(onBearingUpdated)
+  }
+
   fun onStart() {
     if (pulsingAnimator.enabled) {
       pulsingAnimator.animateInfinite()
@@ -52,7 +60,6 @@ internal class PuckAnimatorManager(
 
   fun animateBearing(
     vararg targets: Double,
-    onUpdate: ((Double) -> Unit),
     options: (ValueAnimator.() -> Unit)?
   ) {
     val optimized = DoubleArray(targets.size)
@@ -64,15 +71,14 @@ internal class PuckAnimatorManager(
           MathUtils.shortestRotation(MathUtils.normalize(get(i)), optimized[i - 1])
       }
     }
-    bearingAnimator.animate(*optimized.toTypedArray(), onUpdate = onUpdate, options = options)
+    bearingAnimator.animate(*optimized.toTypedArray(), options = options)
   }
 
   fun animatePosition(
     vararg targets: Point,
-    onUpdate: ((Point) -> Unit),
     options: (ValueAnimator.() -> Unit)?
   ) {
-    positionAnimator.animate(*targets, onUpdate = onUpdate, options = options)
+    positionAnimator.animate(*targets, options = options)
   }
 
   fun applyPulsingAnimationSettings(settings: LocationComponentSettings) {

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
@@ -50,7 +50,11 @@ internal class PuckAnimatorManager(
     pulsingAnimator.cancelRunning()
   }
 
-  fun animateBearing(vararg targets: Double, options: (ValueAnimator.() -> Unit)?) {
+  fun animateBearing(
+    vararg targets: Double,
+    onUpdate: ((Double) -> Unit),
+    options: (ValueAnimator.() -> Unit)?
+  ) {
     val optimized = DoubleArray(targets.size)
     targets.toTypedArray().apply {
       for (i in 0 until size) {
@@ -60,11 +64,15 @@ internal class PuckAnimatorManager(
           MathUtils.shortestRotation(MathUtils.normalize(get(i)), optimized[i - 1])
       }
     }
-    bearingAnimator.animate(*optimized.toTypedArray(), options = options)
+    bearingAnimator.animate(*optimized.toTypedArray(), onUpdate = onUpdate, options = options)
   }
 
-  fun animatePosition(vararg targets: Point, options: (ValueAnimator.() -> Unit)?) {
-    positionAnimator.animate(*targets, options = options)
+  fun animatePosition(
+    vararg targets: Point,
+    onUpdate: ((Point) -> Unit),
+    options: (ValueAnimator.() -> Unit)?
+  ) {
+    positionAnimator.animate(*targets, onUpdate = onUpdate, options = options)
   }
 
   fun applyPulsingAnimationSettings(settings: LocationComponentSettings) {

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -61,6 +61,8 @@ class LocationPuckManagerTest {
   fun testInitialise() {
     locationPuckManager.initialize(style)
     verify { animationManager.setLocationLayerRenderer(locationLayerRenderer) }
+    verify { animationManager.setUpdateListeners(any(), any()) }
+    verify { animationManager.applyPulsingAnimationSettings(settings) }
     verify { locationLayerRenderer.addLayers(positionManager) }
     verify { locationLayerRenderer.initializeComponents(style) }
     verify { locationLayerRenderer.show() }
@@ -104,7 +106,6 @@ class LocationPuckManagerTest {
     verify { positionManager.layerBelow = "layer-below" }
     verify { locationLayerRenderer.clearBitmaps() }
     verify { locationLayerRenderer.removeLayers() }
-    verify { animationManager.setLocationLayerRenderer(any()) }
     locationPuckManager.locationLayerRenderer = locationLayerRenderer
     callbackSlot.captured.invoke(style)
     verify { locationLayerRenderer.addLayers(positionManager) }
@@ -127,13 +128,13 @@ class LocationPuckManagerTest {
   @Test
   fun testUpdateCurrentPosition() {
     locationPuckManager.updateCurrentPosition(Point.fromLngLat(0.0, 0.0))
-    verify { animationManager.animatePosition(targets = anyVararg(), onUpdate = any(), options = null) }
+    verify { animationManager.animatePosition(targets = anyVararg(), options = null) }
   }
 
   @Test
   fun testUpdateCurrentBearing() {
     locationPuckManager.updateCurrentBearing(0.0)
-    verify { animationManager.animateBearing(targets = anyDoubleVararg(), onUpdate = any(), options = null) }
+    verify { animationManager.animateBearing(targets = anyDoubleVararg(), options = null) }
   }
 
   @Test

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -127,13 +127,13 @@ class LocationPuckManagerTest {
   @Test
   fun testUpdateCurrentPosition() {
     locationPuckManager.updateCurrentPosition(Point.fromLngLat(0.0, 0.0))
-    verify { animationManager.animatePosition(targets = anyVararg(), options = null) }
+    verify { animationManager.animatePosition(targets = anyVararg(), onUpdate = any(), options = null) }
   }
 
   @Test
   fun testUpdateCurrentBearing() {
     locationPuckManager.updateCurrentBearing(0.0)
-    verify { animationManager.animateBearing(targets = anyDoubleVararg(), options = null) }
+    verify { animationManager.animateBearing(targets = anyDoubleVararg(), onUpdate = any(), options = null) }
   }
 
   @Test

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManagerTest.kt
@@ -1,16 +1,21 @@
 package com.mapbox.maps.plugin.locationcomponent.animators
 
 import android.animation.ValueAnimator
+import android.os.Looper
 import com.mapbox.geojson.Point
 import com.mapbox.maps.plugin.locationcomponent.LocationLayerRenderer
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 import org.robolectric.annotation.LooperMode
 
 @RunWith(RobolectricTestRunner::class)
@@ -19,8 +24,8 @@ class PuckAnimatorManagerTest {
 
   private lateinit var puckAnimatorManager: PuckAnimatorManager
 
-  private val bearingAnimator: PuckBearingAnimator = mockk(relaxed = true)
-  private val positionAnimator: PuckPositionAnimator = mockk(relaxed = true)
+  private val bearingAnimator: PuckBearingAnimator = PuckBearingAnimator(mockk(relaxUnitFun = true))
+  private val positionAnimator: PuckPositionAnimator = PuckPositionAnimator(mockk(relaxUnitFun = true))
   private val pulsingAnimator: PuckPulsingAnimator = mockk(relaxed = true)
 
   @Before
@@ -72,19 +77,39 @@ class PuckAnimatorManagerTest {
   @Test
   fun animateBearing() {
     val options: (ValueAnimator.() -> Unit) = {}
-    puckAnimatorManager.animateBearing(0.0, 10.0, options = options)
-    verify {
-      bearingAnimator.animate(0.0, 10.0, options = options)
+    var counter = 0
+    var animatedValue = 0.0
+    val updateListener: ((Double) -> Unit) = {
+      counter++
+      animatedValue = it
     }
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    puckAnimatorManager.animateBearing(0.0, 10.0, onUpdate = updateListener, options = options)
+    verify {
+      bearingAnimator.animate(0.0, 10.0, onUpdate = updateListener, options = options)
+    }
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    MatcherAssert.assertThat(counter, Matchers.greaterThan(0))
+    Assert.assertEquals(10.0, animatedValue, 0.0001)
   }
 
   @Test
   fun animatePosition() {
     val options: (ValueAnimator.() -> Unit) = {}
-    puckAnimatorManager.animatePosition(START_POINT, END_POINT, options = options)
-    verify {
-      positionAnimator.animate(START_POINT, END_POINT, options = options)
+    var counter = 0
+    var animatedValue = START_POINT
+    val updateListener: ((Point) -> Unit) = {
+      counter++
+      animatedValue = it
     }
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    puckAnimatorManager.animatePosition(START_POINT, END_POINT, onUpdate = updateListener, options = options)
+    verify {
+      positionAnimator.animate(START_POINT, END_POINT, onUpdate = updateListener, options = options)
+    }
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    MatcherAssert.assertThat(counter, Matchers.greaterThan(0))
+    Assert.assertEquals(END_POINT, animatedValue)
   }
 
   @Test
@@ -113,16 +138,24 @@ class PuckAnimatorManagerTest {
 
   @Test
   fun updateBearingAnimator() {
-    val options: (ValueAnimator.() -> Unit) = {}
+    val options: (ValueAnimator.() -> Unit) = {
+      duration = 5000
+    }
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
     puckAnimatorManager.updateBearingAnimator(options)
-    verify { bearingAnimator.updateOptions(options) }
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    Assert.assertEquals(5000, bearingAnimator.duration)
   }
 
   @Test
   fun updatePositionAnimator() {
-    val options: (ValueAnimator.() -> Unit) = {}
+    val options: (ValueAnimator.() -> Unit) = {
+      duration = 5000
+    }
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
     puckAnimatorManager.updatePositionAnimator(options)
-    verify { positionAnimator.updateOptions(options) }
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    Assert.assertEquals(5000, positionAnimator.duration)
   }
 
   companion object {

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManagerTest.kt
@@ -75,6 +75,15 @@ class PuckAnimatorManagerTest {
   }
 
   @Test
+  fun setUpdateListeners() {
+    val positionUpdateListener: ((Point) -> Unit) = {}
+    val bearingUpdateListener: ((Double) -> Unit) = {}
+    puckAnimatorManager.setUpdateListeners(positionUpdateListener, bearingUpdateListener)
+    Assert.assertEquals(positionUpdateListener, positionAnimator.updateListener)
+    Assert.assertEquals(bearingUpdateListener, bearingAnimator.updateListener)
+  }
+
+  @Test
   fun animateBearing() {
     val options: (ValueAnimator.() -> Unit) = {}
     var counter = 0
@@ -84,9 +93,10 @@ class PuckAnimatorManagerTest {
       animatedValue = it
     }
     Shadows.shadowOf(Looper.getMainLooper()).pause()
-    puckAnimatorManager.animateBearing(0.0, 10.0, onUpdate = updateListener, options = options)
+    puckAnimatorManager.setUpdateListeners({}, updateListener)
+    puckAnimatorManager.animateBearing(0.0, 10.0, options = options)
     verify {
-      bearingAnimator.animate(0.0, 10.0, onUpdate = updateListener, options = options)
+      bearingAnimator.animate(0.0, 10.0, options = options)
     }
     Shadows.shadowOf(Looper.getMainLooper()).idle()
     MatcherAssert.assertThat(counter, Matchers.greaterThan(0))
@@ -103,9 +113,10 @@ class PuckAnimatorManagerTest {
       animatedValue = it
     }
     Shadows.shadowOf(Looper.getMainLooper()).pause()
-    puckAnimatorManager.animatePosition(START_POINT, END_POINT, onUpdate = updateListener, options = options)
+    puckAnimatorManager.setUpdateListeners(updateListener, {})
+    puckAnimatorManager.animatePosition(START_POINT, END_POINT, options = options)
     verify {
-      positionAnimator.animate(START_POINT, END_POINT, onUpdate = updateListener, options = options)
+      positionAnimator.animate(START_POINT, END_POINT, options = options)
     }
     Shadows.shadowOf(Looper.getMainLooper()).idle()
     MatcherAssert.assertThat(counter, Matchers.greaterThan(0))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #183 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[locationcomponent] Fix jitter animations if interrupting animations</changelog>`.

### Summary of changes

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->
Fix jitter animations if interrupting animations.
Such jittering happened before if location (or bearing) updates were arriving not evenly and animations cancelled each other making new animation start not from actual interpolated value but from end value of interrupted animation.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->