### PR TITLE
[rendering] Differentiate render tasks and non-render tasks

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapControllable.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapControllable.kt
@@ -41,11 +41,12 @@ interface MapControllable {
   fun onSizeChanged(w: Int, h: Int)
 
   /**
-   * Called to queue an event on the render thread.
+   * Queue a runnable to be executed on the map renderer thread.
    *
-   * @param runnable the runnable to be queued
+   * @param event the runnable to queue
+   * @param needRender if we should force redraw after running event (e.g. execute some GL commands)
    */
-  fun queueEvent(runnable: Runnable)
+  fun queueEvent(event: Runnable, needRender: Boolean = true)
 
   /**
    * Called to capture a snapshot synchronously.

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -143,8 +143,12 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     pluginRegistry.onSizeChanged(w, h)
   }
 
-  override fun queueEvent(runnable: Runnable) {
-    renderer.queueEvent(runnable)
+  override fun queueEvent(event: Runnable, needRender: Boolean) {
+    if (needRender) {
+      renderer.queueRenderEvent(event)
+    } else {
+      renderer.queueEvent(event)
+    }
   }
 
   override fun snapshot() = renderer.snapshot()

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -117,12 +117,13 @@ class MapSurface : MapPluginProviderDelegate, MapControllable {
   }
 
   /**
-   * Called to queue an event on the render thread.
+   * Queue a runnable to be executed on the map renderer thread.
    *
-   * @param runnable the runnable to be queued
+   * @param event the runnable to queue
+   * @param needRender if we should force redraw after running event (e.g. execute some GL commands)
    */
-  override fun queueEvent(runnable: Runnable) {
-    mapController.queueEvent(runnable)
+  override fun queueEvent(event: Runnable, needRender: Boolean) {
+    mapController.queueEvent(event)
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -189,10 +189,11 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   /**
    * Queue a runnable to be executed on the map renderer thread.
    *
-   * @param runnable the runnable to queue
+   * @param event the runnable to queue
+   * @param needRender if we should force redraw after running event (e.g. execute some GL commands)
    */
-  override fun queueEvent(runnable: Runnable) {
-    mapController.queueEvent(runnable)
+  override fun queueEvent(event: Runnable, needRender: Boolean) {
+    mapController.queueEvent(event, needRender)
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -9,7 +9,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import com.mapbox.common.Logger
 import com.mapbox.maps.renderer.egl.EGLCore
-import java.util.LinkedList
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantLock
 import javax.microedition.khronos.egl.EGL10
@@ -34,7 +35,8 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
   private val createCondition = lock.newCondition()
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-  internal val eventQueue = LinkedList<Runnable>()
+  internal val renderEventQueue = CopyOnWriteArrayList<Runnable>()
+  private val eventQueue = CopyOnWriteArrayList<Runnable>()
 
   private var surface: Surface? = null
   private var eglSurface: EGLSurface? = EGL10.EGL_NO_SURFACE
@@ -45,8 +47,8 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
   internal val renderTimeNs = AtomicLong(0)
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   private var needRenderOnResume = false
-  private var previousVsyncFrameStartTimeNs = 0L
   private var expectedVsyncWakeTimeNs = 0L
+  private var awaitingNextVsync = AtomicBoolean(false)
   private var sizeChanged = false
   private var paused = false
   private var shouldExit = false
@@ -78,8 +80,8 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     this.eglSurface = null
   }
 
-  private fun postRender() {
-    handlerThread.post { render() }
+  private fun postPrepareRenderFrame() {
+    handlerThread.post { prepareRenderFrame() }
   }
 
   private fun checkSurfaceReady(): Boolean {
@@ -110,14 +112,14 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     }
     if (!surface.isValid) {
       Logger.w(TAG, "EGL was configured but surface is not valid.")
-      postRender()
+      postPrepareRenderFrame()
       return false
     }
     eglSurface = eglCore.createWindowSurface(surface)
     if (!eglCore.eglStatusSuccess) {
       // Set EGL Surface as EGL_NO_SURFACE and try recreate it in next iteration.
       eglSurface = EGL10.EGL_NO_SURFACE
-      postRender()
+      postPrepareRenderFrame()
       return false
     }
     eglSurface?.let {
@@ -184,7 +186,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     }
   }
 
-  private fun render() {
+  private fun prepareRenderFrame() {
     // Check first if we have to stop rendering at all (even if there was no EGL config) and cleanup EGL.
     // We need to check it ASAP in order not to block thread that is calling `onSurfaceTextureDestroyed`.
     // After that check MapView could be actually rendered on this device (has valid EGL config).
@@ -199,15 +201,18 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       return
     }
     checkSurfaceSizeChanged()
-    eventQueue.poll()?.let {
-      it.run()
-      // assuming runnable will most likely contain GL commands or something else rendering related
-      // we post draw call not considering `requestRender` flag
-      Choreographer.getInstance().postFrameCallback(this)
-      return
+    renderEventQueue.apply {
+      if (isNotEmpty()) {
+        forEach {
+          it.run()
+        }
+        clear()
+      }
     }
-    // listen to next VSYNC event
-    Choreographer.getInstance().postFrameCallback(this)
+    // listen to next VSYNC event if not listening already
+    if (awaitingNextVsync.compareAndSet(false, true)) {
+      Choreographer.getInstance().postFrameCallback(this)
+    }
   }
 
   @UiThread
@@ -217,7 +222,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
         this.width = width
         this.height = height
         sizeChanged = true
-        render()
+        prepareRenderFrame()
       }
     }
   }
@@ -226,6 +231,10 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
   fun onSurfaceDestroyed() {
     lock.withLock {
       handlerThread.post {
+        awaitingNextVsync.set(false)
+        Choreographer.getInstance().removeFrameCallback(this)
+        eventQueue.clear()
+        renderEventQueue.clear()
         shouldExit = true
         lock.withLock {
           mapboxRenderer.onSurfaceDestroyed()
@@ -259,7 +268,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
         this.width = width
         this.height = height
         shouldExit = false
-        render()
+        prepareRenderFrame()
       }
       createCondition.await()
     }
@@ -272,15 +281,24 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
 
   @WorkerThread
   override fun doFrame(frameTimeNanos: Long) {
-    // if frame started being rendered time is less or equal to previous one
-    // it means we did not have time to render everything on previous frame
-    // we do no drawing in order not to overload render thread
-    if (frameTimeNanos <= previousVsyncFrameStartTimeNs) {
-      return
-    }
-    if (eglPrepared && !paused && !shouldExit) {
-      previousVsyncFrameStartTimeNs = frameTimeNanos
-      draw()
+    try {
+      awaitingNextVsync.set(false)
+      // if frame started being rendered time is less or equal to previous one
+      // it means we did not have time to render everything on previous frame
+      // we do no drawing in order not to overload render thread
+      if (eglPrepared && !paused && !shouldExit) {
+        draw()
+      }
+    } finally {
+      // regardless if we did drawing or not execute all non gl relative events
+      eventQueue.apply {
+        if (isNotEmpty()) {
+          forEach {
+            it.run()
+          }
+          clear()
+        }
+      }
     }
   }
 
@@ -288,14 +306,25 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
 
   @AnyThread
   fun requestRender() {
-    postRender()
+    postPrepareRenderFrame()
+  }
+
+  @AnyThread
+  fun queueRenderEvent(runnable: Runnable) {
+    renderEventQueue.add(runnable)
+    postPrepareRenderFrame()
   }
 
   @AnyThread
   fun queueEvent(runnable: Runnable) {
-    handlerThread.post {
+    // if we already waiting listening for next VSYNC then add runnable to queue to execute
+    // after actual drawing otherwise execute asap on render thread
+    if (awaitingNextVsync.get()) {
       eventQueue.add(runnable)
-      render()
+    } else {
+      handlerThread.post {
+        runnable.run()
+      }
     }
   }
 
@@ -311,7 +340,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     handlerThread.post {
       paused = false
       if (needRenderOnResume) {
-        render()
+        prepareRenderFrame()
         needRenderOnResume = false
       }
     }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -96,9 +96,7 @@ internal abstract class MapboxRenderer : MapClient() {
 
   @AnyThread
   fun queueEvent(runnable: Runnable) {
-    renderThread.queueEvent {
-      runnable.run()
-    }
+    renderThread.queueEvent(runnable)
   }
 
   @AnyThread

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -9,6 +9,7 @@ import com.mapbox.maps.MapClient
 import com.mapbox.maps.MapInterface
 import com.mapbox.maps.MapView.OnSnapshotReady
 import com.mapbox.maps.Size
+import com.mapbox.maps.Task
 import com.mapbox.maps.renderer.gl.PixelReader
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -42,6 +43,13 @@ internal abstract class MapboxRenderer : MapClient() {
   @AnyThread
   override fun scheduleRepaint() {
     renderThread.requestRender()
+  }
+
+  @AnyThread
+  override fun scheduleTask(task: Task) {
+    renderThread.queueEvent {
+      task.run()
+    }
   }
 
   @WorkerThread
@@ -82,8 +90,15 @@ internal abstract class MapboxRenderer : MapClient() {
   }
 
   @AnyThread
+  fun queueRenderEvent(runnable: Runnable) {
+    renderThread.queueRenderEvent(runnable)
+  }
+
+  @AnyThread
   fun queueEvent(runnable: Runnable) {
-    renderThread.queueEvent(runnable)
+    renderThread.queueEvent {
+      runnable.run()
+    }
   }
 
   @AnyThread
@@ -92,7 +107,7 @@ internal abstract class MapboxRenderer : MapClient() {
     val waitCondition = lock.newCondition()
     lock.withLock {
       var snapshot: Bitmap? = null
-      renderThread.queueEvent {
+      renderThread.queueRenderEvent {
         lock.withLock {
           snapshot = performSnapshot()
           waitCondition.signal()
@@ -105,7 +120,7 @@ internal abstract class MapboxRenderer : MapClient() {
 
   @AnyThread
   fun snapshot(listener: OnSnapshotReady) {
-    renderThread.queueEvent {
+    renderThread.queueRenderEvent {
       listener.onSnapshotReady(performSnapshot())
     }
   }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxSurfaceRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxSurfaceRenderer.kt
@@ -2,7 +2,6 @@ package com.mapbox.maps.renderer
 
 import android.view.Surface
 import androidx.annotation.VisibleForTesting
-import com.mapbox.maps.Task
 
 internal open class MapboxSurfaceRenderer : MapboxRenderer {
 
@@ -46,11 +45,5 @@ internal open class MapboxSurfaceRenderer : MapboxRenderer {
   override fun onDestroy() {
     super.onDestroy()
     renderThread.destroy()
-  }
-
-  override fun scheduleTask(task: Task) {
-    renderThread.queueEvent {
-      task.run()
-    }
   }
 }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxTextureViewRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxTextureViewRenderer.kt
@@ -4,7 +4,6 @@ import android.graphics.SurfaceTexture
 import android.view.Surface
 import android.view.TextureView
 import androidx.annotation.VisibleForTesting
-import com.mapbox.maps.Task
 import java.lang.ref.WeakReference
 
 internal class MapboxTextureViewRenderer : MapboxRenderer, TextureView.SurfaceTextureListener {
@@ -54,11 +53,5 @@ internal class MapboxTextureViewRenderer : MapboxRenderer, TextureView.SurfaceTe
     super.onDestroy()
     textureView.get()?.surfaceTextureListener = null
     renderThread.destroy()
-  }
-
-  override fun scheduleTask(task: Task) {
-    renderThread.queueEvent {
-      task.run()
-    }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -38,12 +38,6 @@ class MapControllerTest {
 
   private val motionEvent: MotionEvent = mockk(relaxed = true)
 
-  private val pixelRatio = 1f
-
-  private val cachePath = "foo/bar"
-
-  private val resourcesPath = "foo/bar/biz"
-
   private lateinit var mapController: MapController
 
   @Before
@@ -170,8 +164,10 @@ class MapControllerTest {
   @Test
   fun queueEvent() {
     val event = mockk<Runnable>()
-    mapController.queueEvent(event)
+    mapController.queueEvent(event, false)
     verify { renderer.queueEvent(event) }
+    mapController.queueEvent(event, true)
+    verify { renderer.queueRenderEvent(event) }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -260,9 +260,9 @@ class MapboxRenderThreadTest {
     every { eglCore.createWindowSurface(any()) } returns mockk(relaxed = true)
     mapboxRenderThread.onSurfaceCreated(surface, 1, 1)
     Shadows.shadowOf(workerThread.handler?.looper).pause()
-    mapboxRenderThread.queueEvent { }
+    mapboxRenderThread.queueRenderEvent { }
     Shadows.shadowOf(workerThread.handler?.looper).idle()
-    assert(mapboxRenderThread.eventQueue.isEmpty())
+    assert(mapboxRenderThread.renderEventQueue.isEmpty())
     // one swap buffer from surface creation, one for custom event
     verify(exactly = 2) {
       eglCore.swapBuffers(any())

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -253,18 +254,63 @@ class MapboxRenderThreadTest {
   }
 
   @Test
-  fun queueEventTest() {
+  fun queueRenderEventTest() {
     val surface = mockk<Surface>()
     every { surface.isValid } returns true
     every { eglCore.eglStatusSuccess } returns true
     every { eglCore.createWindowSurface(any()) } returns mockk(relaxed = true)
     mapboxRenderThread.onSurfaceCreated(surface, 1, 1)
+    val runnable = mockk<Runnable>(relaxUnitFun = true)
     Shadows.shadowOf(workerThread.handler?.looper).pause()
-    mapboxRenderThread.queueRenderEvent { }
+    mapboxRenderThread.queueRenderEvent(runnable)
     Shadows.shadowOf(workerThread.handler?.looper).idle()
     assert(mapboxRenderThread.renderEventQueue.isEmpty())
+    verify { runnable.run() }
     // one swap buffer from surface creation, one for custom event
     verify(exactly = 2) {
+      eglCore.swapBuffers(any())
+    }
+  }
+
+  @Test
+  fun queueEventTestWithAwaitVsync() {
+    val surface = mockk<Surface>()
+    every { surface.isValid } returns true
+    every { eglCore.eglStatusSuccess } returns true
+    every { eglCore.createWindowSurface(any()) } returns mockk(relaxed = true)
+    mapboxRenderThread.onSurfaceCreated(surface, 1, 1)
+    val runnable = mockk<Runnable>(relaxUnitFun = true)
+    mapboxRenderThread.awaitingNextVsync.set(true)
+    Shadows.shadowOf(workerThread.handler?.looper).pause()
+    mapboxRenderThread.queueEvent(runnable)
+    Assert.assertEquals(1, mapboxRenderThread.eventQueue.size)
+    mapboxRenderThread.requestRender()
+    Shadows.shadowOf(workerThread.handler?.looper).idle()
+    assert(mapboxRenderThread.eventQueue.isEmpty())
+    verify { runnable.run() }
+    // one swap buffer from surface creation, one for custom event
+    verify(exactly = 2) {
+      eglCore.swapBuffers(any())
+    }
+  }
+
+  @Test
+  fun queueEventTestWithoutAwaitVsync() {
+    val surface = mockk<Surface>()
+    every { surface.isValid } returns true
+    every { eglCore.eglStatusSuccess } returns true
+    every { eglCore.createWindowSurface(any()) } returns mockk(relaxed = true)
+    mapboxRenderThread.onSurfaceCreated(surface, 1, 1)
+    val runnable = mockk<Runnable>(relaxUnitFun = true)
+    mapboxRenderThread.awaitingNextVsync.set(false)
+    Shadows.shadowOf(workerThread.handler?.looper).pause()
+    mapboxRenderThread.queueEvent(runnable)
+    Assert.assertEquals(0, mapboxRenderThread.eventQueue.size)
+    Shadows.shadowOf(workerThread.handler?.looper).idle()
+    assert(mapboxRenderThread.eventQueue.isEmpty())
+    verify { runnable.run() }
+    // one swap buffer from surface creation and no from custom event
+    verify(exactly = 1) {
       eglCore.swapBuffers(any())
     }
   }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -8,6 +8,7 @@ import com.mapbox.common.ShadowLogger
 import com.mapbox.maps.MapInterface
 import com.mapbox.maps.MapView
 import com.mapbox.maps.Size
+import com.mapbox.maps.Task
 import com.mapbox.maps.renderer.gl.PixelReader
 import io.mockk.every
 import io.mockk.mockk
@@ -49,6 +50,13 @@ internal abstract class MapboxRendererTest {
   }
 
   @Test
+  fun scheduleTaskTest() {
+    val task = mockk<Task>(relaxUnitFun = true)
+    mapboxRenderer.scheduleTask(task)
+    verify { renderThread.queueEvent(any()) }
+  }
+
+  @Test
   fun onStartTest() {
     mapboxRenderer.onStart()
     verify { renderThread.resume() }
@@ -68,8 +76,16 @@ internal abstract class MapboxRendererTest {
 
   @Test
   fun queueEventTest() {
-    mapboxRenderer.queueEvent {}
-    verify { renderThread.queueRenderEvent(any()) }
+    val event = mockk<Runnable>(relaxUnitFun = true)
+    mapboxRenderer.queueEvent(event)
+    verify { renderThread.queueEvent(event) }
+  }
+
+  @Test
+  fun queueRenderEventTest() {
+    val event = mockk<Runnable>(relaxUnitFun = true)
+    mapboxRenderer.queueRenderEvent(event)
+    verify { renderThread.queueRenderEvent(event) }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -69,7 +69,7 @@ internal abstract class MapboxRendererTest {
   @Test
   fun queueEventTest() {
     mapboxRenderer.queueEvent {}
-    verify { renderThread.queueEvent(any()) }
+    verify { renderThread.queueRenderEvent(any()) }
   }
 
   @Test
@@ -116,7 +116,7 @@ internal abstract class MapboxRendererTest {
       handler = Handler(this.looper)
     }
     val runnable = slot<Runnable>()
-    every { renderThread.queueEvent(capture(runnable)) } answers {
+    every { renderThread.queueRenderEvent(capture(runnable)) } answers {
       handler.post(runnable.captured)
     }
     mapboxRenderer.pixelReader = pixelReader
@@ -140,7 +140,7 @@ internal abstract class MapboxRendererTest {
       handler = Handler(this.looper)
     }
     val runnable = slot<Runnable>()
-    every { renderThread.queueEvent(capture(runnable)) } answers {
+    every { renderThread.queueRenderEvent(capture(runnable)) } answers {
       handler.post(runnable.captured)
     }
     mapboxRenderer.pixelReader = pixelReader


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #156 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[rendering] Differentiate render tasks and non-render tasks</changelog>`.

### Summary of changes

Renderer now could execute basically 2 types of events on render (GL) thread. One does require true drawing (swapping buffers) and another simply executes `Task` or `Runnable` on render thread without actually swapping buffers.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

`MapView` has updated API for `queueEvent`:
```
queueEvent(event: Runnable, needRender: Boolean)
```

<!--
If this PR introduces user-facing changes, please note them here.
-->