### PR TITLE
[animation] Fix zero duration animators, fix medium-level animators

### DIFF
--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.plugin.animation
 
 import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
 import android.os.Handler
@@ -804,6 +805,38 @@ class CameraAnimationsPluginImplTest {
     assertEquals(true, listenerTwo.cancelling)
     assertEquals(true, listenerTwo.ending)
     assertEquals(true, listenerTwo.interrupting)
+  }
+
+  @Test
+  fun easeToTestNonZeroDurationWithListener() {
+    val options = mapAnimationOptions {
+      duration(1000)
+      animatorListener(object : AnimatorListenerAdapter() {})
+    }
+    cameraAnimationsPluginImpl.easeTo(cameraOptions, options)
+    assert(cameraAnimationsPluginImpl.highLevelListener != null)
+  }
+
+  @Test
+  fun easeToTestZeroDurationWithListener() {
+    val options = mapAnimationOptions {
+      duration(0)
+      animatorListener(object : AnimatorListenerAdapter() {})
+    }
+    cameraAnimationsPluginImpl.easeTo(cameraOptions, options)
+    assert(cameraAnimationsPluginImpl.highLevelListener == null)
+  }
+
+  @Test
+  fun registerOnlyCameraAnimatorsTest() {
+    val pitch = createPitchAnimator(15.0, 0, 5)
+    val bearing = createBearingAnimator(10.0, 0, 5)
+    val animator = ValueAnimator.ofFloat(0.0f, 10.0f)
+    cameraAnimationsPluginImpl.playAnimatorsSequentially(pitch, bearing, animator)
+    assert(cameraAnimationsPluginImpl.animators.size == 2)
+    cameraAnimationsPluginImpl.unregisterAllAnimators()
+    cameraAnimationsPluginImpl.playAnimatorsTogether(pitch, bearing, animator)
+    assert(cameraAnimationsPluginImpl.animators.size == 2)
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #196 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[animation] Fix zero duration animators, fix medium-level animators to use only CameraAnimators</changelog>`.

### Summary of changes

 - Use standard `AnimatorListener` if animation duration is zero to get correct results if changing several `CameraOptions` properties
 - Register only `CameraAnimator`s for medium-level API like `playAnimatorsSequentially`  and `playAnimatorsTogether` and not all provided `ValueAnimator`s
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->