### PR TITLE
[sdk] Remove MapObserver from MapSurface's constructor.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/SurfaceActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/SurfaceActivity.kt
@@ -2,7 +2,6 @@ package com.mapbox.maps.testapp.examples
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.util.Log
 import android.view.SurfaceHolder
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.maps.*
@@ -27,8 +26,7 @@ class SurfaceActivity : AppCompatActivity(), SurfaceHolder.Callback {
     surfaceHolder.addCallback(this)
     mapSurface = MapSurface(
       this,
-      surfaceHolder.surface,
-      SurfaceObserver()
+      surfaceHolder.surface
     )
 
     // Load a map style
@@ -64,41 +62,6 @@ class SurfaceActivity : AppCompatActivity(), SurfaceHolder.Callback {
   override fun onDestroy() {
     super.onDestroy()
     mapSurface.onDestroy()
-  }
-
-  inner class SurfaceObserver : MapObserver() {
-    override fun onCameraChange(change: CameraChange, mode: CameraChangeMode) {
-      Log.i(TAG, "onMapChanged: $change: $mode")
-    }
-
-    override fun onMapChanged(change: MapChange) {
-      Log.i(TAG, "onMapChanged: $change")
-    }
-
-    override fun onMapLoadError(error: MapLoadError, message: String) {
-      Log.e(TAG, "OnMapLoadError: $error: $message")
-    }
-
-    override fun onDidFinishRenderingFrame(status: RenderFrameStatus) {
-      Log.i(TAG, "onDidFinishRenderingFrame: $status")
-    }
-
-    override fun onDidFinishRenderingMap(mode: RenderMode) {
-      Log.i(TAG, "onDidFinishRenderingMap: $mode")
-    }
-
-    override fun onSourceChanged(sourceId: String) {
-      Log.i(TAG, "onSourceChanged: $sourceId")
-    }
-
-    override fun onStyleImageMissing(imageId: String) {
-      Log.i(TAG, "onStyleImageMissing: $imageId")
-    }
-
-    override fun onCanRemoveUnusedStyleImage(imageId: String): Boolean {
-      Log.i(TAG, "onCanRemoveUnusedStyleImage: $imageId")
-      return false
-    }
   }
 
   companion object {

--- a/app/src/main/java/com/mapbox/maps/testapp/wallpaper/MapWallpaper.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/wallpaper/MapWallpaper.kt
@@ -25,7 +25,7 @@ class MapWallpaper : WallpaperService() {
       super.onCreate(surfaceHolder)
       surfaceHolder.addCallback(this)
 
-      mapSurface = MapSurface(context, surfaceHolder.surface, WallpaperObserver())
+      mapSurface = MapSurface(context, surfaceHolder.surface)
       mapboxMap = mapSurface.getMapboxMap()
 
       // Custom configuration
@@ -87,41 +87,6 @@ class MapWallpaper : WallpaperService() {
           .bearing(bearing)
           .build()
       )
-    }
-  }
-
-  inner class WallpaperObserver : MapObserver() {
-    override fun onCameraChange(change: CameraChange, mode: CameraChangeMode) {
-      Log.i(TAG, "onMapChanged: $change: $mode")
-    }
-
-    override fun onMapChanged(change: MapChange) {
-      Log.i(TAG, "onMapChanged: $change")
-    }
-
-    override fun onMapLoadError(error: MapLoadError, message: String) {
-      Log.e(TAG, "OnMapLoadError: $error: $message")
-    }
-
-    override fun onDidFinishRenderingFrame(status: RenderFrameStatus) {
-      Log.i(TAG, "onDidFinishRenderingFrame: $status")
-    }
-
-    override fun onDidFinishRenderingMap(mode: RenderMode) {
-      Log.i(TAG, "onDidFinishRenderingMap: $mode")
-    }
-
-    override fun onSourceChanged(sourceId: String) {
-      Log.i(TAG, "onSourceChanged: $sourceId")
-    }
-
-    override fun onStyleImageMissing(imageId: String) {
-      Log.i(TAG, "onStyleImageMissing: $imageId")
-    }
-
-    override fun onCanRemoveUnusedStyleImage(imageId: String): Boolean {
-      Log.i(TAG, "onCanRemoveUnusedStyleImage: $imageId")
-      return false
     }
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -24,24 +24,20 @@ class MapSurface : MapPluginProviderDelegate, MapControllable {
 
   private val mapboxMapOptions: MapboxMapOptions
   private val surface: Surface
-  private val mapObserver: MapObserver
   private val mapController: MapController
   private val renderer: MapboxSurfaceRenderer
 
   constructor(
     context: Context,
     surface: Surface,
-    mapObserver: MapObserver
-  ) : this(MapboxMapOptions(context), surface, mapObserver)
+  ) : this(MapboxMapOptions(context), surface)
 
   constructor(
     mapboxMapOptions: MapboxMapOptions,
     surface: Surface,
-    mapObserver: MapObserver
   ) {
     this.mapboxMapOptions = mapboxMapOptions
     this.surface = surface
-    this.mapObserver = mapObserver
     this.renderer = MapboxSurfaceRenderer()
     this.mapController = MapController(
       renderer,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[sdk] Remove MapObserver from MapSurface's constructor.</changelog>`.

### Summary of changes
MapSurface's creation shouldn't rely on the MapObserver. Users can subscribe to the map's events using `mapSurface.getMapboxMap().subscribe()` API.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->