### PR TITLE
[gestures] Introduce platform-driven drag API to move a map

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -585,19 +585,6 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
   }
 
   /**
-   * Calculate target [Point] for moving by offset
-   *
-   * @param offset The screen coordinate distance to move by
-   */
-  override fun calculateMoveBy(offset: ScreenCoordinate): Point =
-    CameraTransform.calculateLatLngMoveBy(
-      offset,
-      mapCameraDelegate.getCameraOptions(),
-      mapTransformDelegate,
-      mapProjectionDelegate
-    )
-
-  /**
    * Scale the map by with optional animation.
    *
    * @param amount The amount to scale by

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
@@ -195,11 +195,6 @@ interface CameraAnimationsPlugin : MapPlugin {
   fun calculateScaleBy(amount: Double, currentZoom: Double): Double
 
   /**
-   * Utility method to calculate move by based on a offset screencoordinate
-   */
-  fun calculateMoveBy(offset: ScreenCoordinate): Point?
-
-  /**
    * Add camera bearing change listener
    *
    * @param listener to be invoked when camera bearing value changes

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapTransformDelegate.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapTransformDelegate.kt
@@ -122,12 +122,6 @@ interface MapTransformDelegate {
   fun getSize(): Size
 
   /**
-   * Is terrain enabled for loaded style of the map.
-   * @return True if terrain is enabled for given style and false otherwise.
-   */
-  fun terrainEnabled(): Boolean
-
-  /**
    * Prepares the drag gesture to use the provided screen coordinate as a pivot point.
    * This function should be called each time when user starts a dragging action (e.g. by clicking on the map).
    * The following dragging will be relative to the pivot.

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -47,7 +47,6 @@ class MapboxMap internal constructor(
   private val nativeMapWeakRef = WeakReference(nativeMap)
   internal lateinit var style: Style
 
-  private var terrainEnabled = false
   private val handlerMain = Handler(Looper.getMainLooper())
 
   @VisibleForTesting(otherwise = PRIVATE)
@@ -135,7 +134,6 @@ class MapboxMap internal constructor(
     onStyleLoaded: Style.OnStyleLoaded? = null,
     onMapLoadErrorListener: OnMapLoadErrorListener? = null
   ) {
-    terrainEnabled = false
     this.loadStyleUri(
       styleExtension.styleUri,
       { style -> onFinishLoadingStyleExtension(style, styleExtension, onStyleLoaded) },
@@ -170,10 +168,7 @@ class MapboxMap internal constructor(
       it.first.bindTo(style, it.second)
     }
     styleExtension.light?.bindTo(style)
-    styleExtension.terrain?.let {
-      terrainEnabled = true
-      it.bindTo(style)
-    }
+    styleExtension.terrain?.bindTo(style)
     onStyleLoaded?.onStyleLoaded(style)
   }
 
@@ -1170,12 +1165,6 @@ class MapboxMap internal constructor(
   ): CameraOptions {
     return nativeMapWeakRef.call { this.getDragCameraOptions(fromPoint, toPoint) }
   }
-
-  /**
-   * Is terrain enabled for loaded style of the map.
-   * @return True if terrain is enabled for given style and false otherwise.
-   */
-  override fun terrainEnabled() = terrainEnabled
 
   internal fun setCameraAnimationPlugin(cameraAnimationsPlugin: CameraAnimationsPlugin?) {
     cameraAnimationsPlugin?.let {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[gestures] Introduce platform-driven drag API to move a map</changelog>`.

### Summary of changes

All gestures related to moving a map following if necessary with fling animation afterwards are now considered to use __drag API__. This API is designed to work both with or without 3D Terrain and should use following functions:
 - `dragStart` - must be called before map starts dragging
 - `getDragCameraOptions` - used to calculate correctly elevated `CameraOptions` that is used as target point for `easeTo` animation
 - `dragEnd` - must be called when dragging a map has finished.

Dragging means operating with `center` animator only as part of `CameraOptions`.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->