### PR TITLE
[animations] Fix interpolation for flyTo

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
@@ -318,9 +318,11 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
     // w₀: Initial visible span, measured in pixels at the initial scale.
     // Known henceforth as a <i>screenful</i>.
 
+    val size = mapTransformDelegate.getSize()
+    val pixelRatio = mapTransformDelegate.getMapOptions().pixelRatio
     val w0 = max(
-      mapTransformDelegate.getSize().width - endPadding.left - endPadding.right,
-      mapTransformDelegate.getSize().height - endPadding.top - endPadding.bottom
+      (size.width - endPadding.left - endPadding.right) / pixelRatio,
+      (size.height - endPadding.top - endPadding.bottom) / pixelRatio
     )
     // w₁: Final visible span, measured in pixels with respect to the initial
     // scale.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[animations] Fix interpolation for flyTo</changelog>`.

### Summary of changes

We were using regular pixels instead of dpi that actually made zoom and center interpolation not work as designed.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->