### PR TITLE
[test] add integration testing of MapView through fragments

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,10 @@ android {
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8.toString()
+  }
+
   testOptions {
     animationsDisabled = true
     if (!project.hasProperty("android.injected.invoked.from.ide")) {
@@ -69,6 +73,7 @@ dependencies {
   implementation(Dependencies.androidxMultidex)
   implementation(Dependencies.googleMaterialDesign)
   implementation(Dependencies.squareRetrofit)
+  implementation(Dependencies.androidxFragmentTest)
   implementation(Dependencies.squareRetrofitGsonConverter)
   debugImplementation(Dependencies.squareLeakCanary)
   androidTestUtil(Dependencies.androidxOrchestrator)

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/integration/fragment/EmptyFragment.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/integration/fragment/EmptyFragment.kt
@@ -1,0 +1,32 @@
+package com.mapbox.maps.testapp.integration.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.fragment.app.Fragment
+
+class EmptyFragment : Fragment() {
+
+  var onViewCreated: OnFragmentResumed? = null
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    val view = FrameLayout(inflater.context)
+    view.setBackgroundColor(android.R.color.white)
+    return view
+  }
+
+  override fun onResume() {
+    super.onResume()
+    onViewCreated?.onResume()
+  }
+
+  fun interface OnFragmentResumed {
+    fun onResume()
+  }
+}

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/integration/fragment/FragmentScenarioTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/integration/fragment/FragmentScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.mapbox.maps.testapp.integration.fragment
+
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Integration tests using fragment and the AndroidX fragment test library.
+ */
+@RunWith(AndroidJUnit4::class)
+class FragmentScenarioTest {
+
+  @Test
+  fun resumed() {
+    val latch = CountDownLatch(1)
+    val scenario = launchFragmentInContainer<MapFragment>()
+    scenario.onFragment {
+      it.activity!!.runOnUiThread {
+        it.loadMap {
+          latch.countDown()
+        }
+      }
+    }
+    if (!latch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun backToCreated() {
+    val latch = CountDownLatch(1)
+    val scenario = launchFragmentInContainer<MapFragment>()
+    scenario.onFragment {
+      it.activity!!.runOnUiThread {
+        it.loadMap {
+          latch.countDown()
+        }
+      }
+    }
+    if (!latch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+    scenario.moveToState(Lifecycle.State.CREATED)
+  }
+
+  @Test
+  fun backToResumed() {
+    val latch = CountDownLatch(1)
+    val scenario = launchFragmentInContainer<MapFragment>()
+    scenario.onFragment {
+      it.activity!!.runOnUiThread {
+        it.loadMap {
+          latch.countDown()
+        }
+      }
+    }
+    if (!latch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+    scenario.moveToState(Lifecycle.State.CREATED)
+    scenario.moveToState(Lifecycle.State.RESUMED)
+  }
+
+  @Test
+  fun recreated() {
+    val latch = CountDownLatch(1)
+    val scenario = launchFragmentInContainer<MapFragment>()
+    scenario.onFragment {
+      it.activity!!.runOnUiThread {
+        it.loadMap {
+          latch.countDown()
+        }
+      }
+    }
+    if (!latch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+    scenario.recreate()
+  }
+
+  @Test
+  fun destroyed() {
+    val latch = CountDownLatch(1)
+    val scenario = launchFragmentInContainer<MapFragment>()
+    scenario.onFragment {
+      it.activity!!.runOnUiThread {
+        it.loadMap {
+          latch.countDown()
+        }
+      }
+    }
+    if (!latch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+    scenario.moveToState(Lifecycle.State.DESTROYED)
+  }
+
+  @Test
+  fun stressTestRecreate() {
+    val latch = CountDownLatch(1)
+    val scenario = launchFragmentInContainer<MapFragment>()
+    scenario.onFragment {
+      it.activity!!.runOnUiThread {
+        it.loadMap {
+          latch.countDown()
+        }
+      }
+    }
+    if (!latch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+    repeat(10) {
+      scenario.recreate()
+    }
+  }
+
+  @Test
+  fun stressTestRecreateWithLoad() {
+    val scenario = launchFragmentInContainer<MapFragment>()
+    repeat(10) {
+      val latch = CountDownLatch(1)
+      scenario.onFragment {
+        it.activity!!.runOnUiThread {
+          it.loadMap {
+            latch.countDown()
+          }
+        }
+      }
+      if (!latch.await(10, TimeUnit.SECONDS)) {
+        throw TimeoutException()
+      }
+      scenario.recreate()
+    }
+  }
+
+  @Test
+  fun stressTestResumed() {
+    val scenario = launchFragmentInContainer<MapFragment>()
+    scenario.recreate()
+    repeat(20) {
+      scenario.moveToState(Lifecycle.State.CREATED)
+      scenario.moveToState(Lifecycle.State.RESUMED)
+    }
+    scenario.recreate()
+    scenario.moveToState(Lifecycle.State.DESTROYED)
+  }
+}

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/integration/fragment/FragmentTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/integration/fragment/FragmentTest.kt
@@ -1,0 +1,133 @@
+package com.mapbox.maps.testapp.integration.fragment
+
+import android.R
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.mapbox.maps.testapp.EmptyActivity
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Integration test for fragments
+ */
+class FragmentTest {
+
+  @get:Rule
+  var rule: ActivityScenarioRule<EmptyActivity> = ActivityScenarioRule(EmptyActivity::class.java)
+
+  lateinit var container: FrameLayout
+  lateinit var countDownLatch: CountDownLatch
+
+  @Before
+  fun setUp() {
+    rule.scenario.onActivity {
+      container = FrameLayout(it)
+      container.id = R.id.content
+      it.setContentView(container)
+    }
+  }
+
+  @Test
+  fun transactionAdd() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      val fragment = addMapFragment(it)
+      fragment.getViewAsync {
+        fragment.loadMap {
+          countDownLatch.countDown()
+        }
+      }
+    }
+    if (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun transactionRemove() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      val fragment = addMapFragment(it)
+      fragment.getViewAsync {
+        fragment.loadMap {
+          val fragmentTransaction = it.supportFragmentManager.beginTransaction()
+          fragmentTransaction.remove(fragment)
+          fragmentTransaction.commit()
+          countDownLatch.countDown()
+        }
+      }
+    }
+    if (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun transactionReplace() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      val fragment = addMapFragment(it)
+      fragment.getViewAsync {
+        fragment.loadMap {
+          val emptyFragment = EmptyFragment()
+          emptyFragment.onViewCreated = EmptyFragment.OnFragmentResumed {
+            countDownLatch.countDown()
+          }
+          val fragmentTransaction = it.supportFragmentManager.beginTransaction()
+          fragmentTransaction.replace(R.id.content, emptyFragment)
+          fragmentTransaction.commit()
+        }
+      }
+    }
+    if (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun transactionBackstack() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      val fragment = addMapFragment(it)
+      fragment.getViewAsync {
+        fragment.loadMap {
+          val mapFragment = MapFragment()
+          val fragmentTransaction: FragmentTransaction = it.supportFragmentManager.beginTransaction()
+          fragmentTransaction.replace(R.id.content, mapFragment)
+          fragmentTransaction.addToBackStack(FRAGMENT_TAG)
+          fragmentTransaction.commit()
+
+          mapFragment.getViewAsync {
+            mapFragment.loadMap {
+              it.supportFragmentManager.popBackStack(FRAGMENT_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+              countDownLatch.countDown()
+            }
+          }
+        }
+      }
+    }
+    if (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  private fun addMapFragment(activity: AppCompatActivity): MapFragment {
+    val fragment = MapFragment()
+    val fragmentTransaction: FragmentTransaction =
+      activity.supportFragmentManager.beginTransaction()
+    fragmentTransaction.add(R.id.content, fragment)
+    fragmentTransaction.commit()
+    return fragment
+  }
+
+  companion object {
+    const val FRAGMENT_TAG = "foo"
+  }
+}

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/integration/fragment/MapFragment.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/integration/fragment/MapFragment.kt
@@ -1,0 +1,64 @@
+package com.mapbox.maps.testapp.integration.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.mapbox.maps.MapView
+import com.mapbox.maps.Style
+
+class MapFragment : Fragment() {
+
+  private var viewCreated: OnViewCreated? = null
+  lateinit var mapView: MapView
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View {
+    mapView = MapView(inflater.context)
+    return mapView
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    viewCreated?.onViewCreated()
+  }
+
+  override fun onStart() {
+    super.onStart()
+    mapView.onStart()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView.onStop()
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    mapView.onDestroy()
+  }
+
+  fun getViewAsync(onViewCreated: OnViewCreated) {
+    this.viewCreated = onViewCreated
+  }
+
+  fun loadMap(idleListener: OnMapIdle) {
+    val map = mapView.getMapboxMap()
+    map.loadStyleUri(Style.MAPBOX_STREETS)
+    map.addOnMapIdleListener {
+      idleListener.onIdle()
+    }
+  }
+
+  fun interface OnViewCreated {
+    fun onViewCreated()
+  }
+
+  fun interface OnMapIdle {
+    fun onIdle()
+  }
+}

--- a/app/src/main/res/layout/activity_multi_map.xml
+++ b/app/src/main/res/layout/activity_multi_map.xml
@@ -14,16 +14,16 @@
         android:baselineAligned="false"
         android:orientation="horizontal">
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/map1"
-            class="com.mapbox.maps.testapp.examples.fragment.MapFragment"
+            android:name="com.mapbox.maps.testapp.examples.fragment.MapFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="0.5" />
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/map2"
-            class="com.mapbox.maps.testapp.examples.fragment.MapFragment"
+            android:name="com.mapbox.maps.testapp.examples.fragment.MapFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="0.5" />
@@ -36,16 +36,16 @@
         android:baselineAligned="false"
         android:orientation="horizontal">
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/map3"
-            class="com.mapbox.maps.testapp.examples.fragment.MapFragment"
+            android:name="com.mapbox.maps.testapp.examples.fragment.MapFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="0.5" />
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/map4"
-            class="com.mapbox.maps.testapp.examples.fragment.MapFragment"
+            android:name="com.mapbox.maps.testapp.examples.fragment.MapFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="0.5" />

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -40,6 +40,7 @@ object Dependencies {
   const val androidxTestRunner = "androidx.test:runner:${Versions.androidxTest}"
   const val androidxTestCore = "androidx.test:core:${Versions.androidxTest}"
   const val androidxUiAutomator = "androidx.test.uiautomator:uiautomator:${Versions.androidxUiAutomator}"
+  const val androidxFragmentTest = "androidx.fragment:fragment-testing:${Versions.androidxCore}"
   const val androidxOrchestrator = "androidx.test:orchestrator:${Versions.androidxTest}"
   const val androidxMultidex = "androidx.multidex:multidex:${Versions.androidxMultidex}"
   const val googleMaterialDesign = "com.google.android.material:material:${Versions.materialDesign}"


### PR DESCRIPTION
We recently had a regression with #191. This wasn't noticed directly in this repository but only in a downstream project we use for running benchmarks. To make sure we don't regress these use-cases, this PR adds a bunch of fragment integration tests. 

2 files with tests were added:
 - **FragmentTest**: contains traditional testing of fragments
 - **FragmentScenarioTest**: contains tests using the [fragment test library](https://developer.android.com/guide/fragments/test)
