### PR TITLE
Remove usage of MapSnapshotterObserver and use Observerable API instead.

### DIFF
--- a/sdk/src/test/java/com/mapbox/maps/SnapshotterDelegateTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/SnapshotterDelegateTest.kt
@@ -22,7 +22,7 @@ class SnapshotterDelegateTest {
   @Before
   fun setUp() {
     coreSnapshotter = mockk(relaxed = true)
-    snapshotter = Snapshotter(mockk(relaxed = true), coreSnapshotter)
+    snapshotter = Snapshotter(mockk(relaxed = true), coreSnapshotter, mockk(relaxed = true), mockk(relaxed = true))
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/SnapshotterTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/SnapshotterTest.kt
@@ -21,7 +21,7 @@ class SnapshotterTest {
   @Before
   fun setUp() {
     coreSnapshotter = mockk(relaxed = true)
-    snapshotter = Snapshotter(mockk(relaxed = true), coreSnapshotter)
+    snapshotter = Snapshotter(mockk(relaxed = true), coreSnapshotter, mockk(relaxed = true), mockk(relaxed = true))
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

This PR removes the usage of MapSnapshotterObserver and use Observerable API instead.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->