### PR TITLE
Introduce StyleInterface, expose pixelRatio and addImage with correct scale on secondary displays.

### DIFF
--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/image/ImageExtensionImpl.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/image/ImageExtensionImpl.kt
@@ -1,12 +1,11 @@
 package com.mapbox.maps.extension.style.image
 
-import android.content.res.Resources
 import android.graphics.Bitmap
 import com.mapbox.maps.Image
 import com.mapbox.maps.ImageContent
 import com.mapbox.maps.ImageStretches
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.extension.style.StyleContract
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.utils.check
 import java.nio.ByteBuffer
 
@@ -25,10 +24,10 @@ class ImageExtensionImpl(private val builder: Builder) : StyleContract.StyleImag
   /**
    * Add the image to the style.
    */
-  override fun bindTo(delegate: StyleManagerInterface) {
+  override fun bindTo(delegate: StyleInterface) {
     delegate.addStyleImage(
       builder.imageId,
-      builder.scale,
+      builder.scale ?: delegate.pixelRatio,
       builder.internalImage,
       builder.sdf,
       builder.stretchX,
@@ -54,7 +53,7 @@ class ImageExtensionImpl(private val builder: Builder) : StyleContract.StyleImag
     /**
      * Scale factor for the image.
      */
-    internal var scale: Float = Resources.getSystem().displayMetrics.density
+    internal var scale: Float? = null
 
     /**
      * Option to treat whether image is SDF(signed distance field) or not.
@@ -163,6 +162,6 @@ fun image(imageId: String, block: ImageExtensionImpl.Builder.() -> Unit): ImageE
  *
  * @param image The image to be added
  */
-fun StyleManagerInterface.addImage(image: StyleContract.StyleImageExtension) {
+fun StyleInterface.addImage(image: StyleContract.StyleImageExtension) {
   image.bindTo(this)
 }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/Layer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/Layer.kt
@@ -6,6 +6,7 @@ import com.mapbox.common.Logger
 import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.extension.style.StyleContract
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.layers.generated.*
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
@@ -96,7 +97,7 @@ abstract class Layer : StyleContract.StyleLayerExtension {
    *
    * @param delegate The style controller
    */
-  fun bindTo(delegate: StyleManagerInterface) {
+  fun bindTo(delegate: StyleInterface) {
     bindTo(delegate, null)
   }
 
@@ -106,7 +107,7 @@ abstract class Layer : StyleContract.StyleLayerExtension {
    * @param delegate The style controller
    * @param position the position that the current layer is added to
    */
-  override fun bindTo(delegate: StyleManagerInterface, position: LayerPosition?) {
+  override fun bindTo(delegate: StyleInterface, position: LayerPosition?) {
     this.delegate = delegate
 
     val expected = delegate.addStyleLayer(getCachedLayerProperties(), position)
@@ -227,7 +228,7 @@ fun <T : Layer> StyleManagerInterface.getLayerAs(layerId: String): T {
  * @param layer The layer to be added
  * @param below the layer id that the current layer is added below
  */
-fun StyleManagerInterface.addLayerBelow(layer: StyleContract.StyleLayerExtension, below: String?) {
+fun StyleInterface.addLayerBelow(layer: StyleContract.StyleLayerExtension, below: String?) {
   layer.bindTo(this, LayerPosition(null, below, null))
 }
 
@@ -237,7 +238,7 @@ fun StyleManagerInterface.addLayerBelow(layer: StyleContract.StyleLayerExtension
  * @param layer The layer to be added
  * @param above the layer id that the current layer is added above
  */
-fun StyleManagerInterface.addLayerAbove(layer: StyleContract.StyleLayerExtension, above: String?) {
+fun StyleInterface.addLayerAbove(layer: StyleContract.StyleLayerExtension, above: String?) {
   layer.bindTo(this, LayerPosition(above, null, null))
 }
 
@@ -247,7 +248,7 @@ fun StyleManagerInterface.addLayerAbove(layer: StyleContract.StyleLayerExtension
  * @param layer The layer to be added
  * @param index the index that the current layer is added on
  */
-fun StyleManagerInterface.addLayerAt(layer: StyleContract.StyleLayerExtension, index: Int?) {
+fun StyleInterface.addLayerAt(layer: StyleContract.StyleLayerExtension, index: Int?) {
   layer.bindTo(this, LayerPosition(null, null, index))
 }
 
@@ -256,6 +257,6 @@ fun StyleManagerInterface.addLayerAt(layer: StyleContract.StyleLayerExtension, i
  *
  * @param layer The layer to be added
  */
-fun StyleManagerInterface.addLayer(layer: StyleContract.StyleLayerExtension) {
+fun StyleInterface.addLayer(layer: StyleContract.StyleLayerExtension) {
   layer.bindTo(this)
 }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/light/generated/Light.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/light/generated/Light.kt
@@ -6,8 +6,8 @@ import android.util.Log
 import androidx.annotation.ColorInt
 import androidx.annotation.UiThread
 import com.mapbox.bindgen.Value
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.extension.style.StyleContract
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.layers.properties.generated.Anchor
@@ -28,7 +28,7 @@ import kotlin.collections.HashMap
  */
 @UiThread
 class Light : LightDslReceiver, StyleContract.StyleLightExtension {
-  private var delegate: StyleManagerInterface? = null
+  private var delegate: StyleInterface? = null
   private val properties = HashMap<String, PropertyValue<*>>()
 
   /**
@@ -367,7 +367,7 @@ class Light : LightDslReceiver, StyleContract.StyleLightExtension {
    *
    * @param delegate The map controller
    */
-  override fun bindTo(delegate: StyleManagerInterface) {
+  override fun bindTo(delegate: StyleInterface) {
     this.delegate = delegate
     val lightParams = HashMap<String, Value>()
     properties.forEach {
@@ -564,7 +564,7 @@ fun light(block: LightDslReceiver.() -> Unit): Light = Light().apply(block)
  *
  * @return Light
  */
-fun StyleManagerInterface.getLight(): Light {
+fun StyleInterface.getLight(): Light {
   return Light().also { it.bindTo(this) }
 }
 
@@ -573,7 +573,7 @@ fun StyleManagerInterface.getLight(): Light {
  *
  * @param light The light to be added
  */
-fun StyleManagerInterface.addLight(light: StyleContract.StyleLightExtension) {
+fun StyleInterface.addLight(light: StyleContract.StyleLightExtension) {
   light.bindTo(this)
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/CustomGeometrySource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/CustomGeometrySource.kt
@@ -6,6 +6,7 @@ import com.mapbox.maps.CoordinateBounds
 import com.mapbox.maps.CustomGeometrySourceOptions
 import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.extension.style.StyleContract
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.utils.check
 
 /**
@@ -60,7 +61,7 @@ class CustomGeometrySource(
    *
    * @param delegate The style delegate
    */
-  override fun bindTo(delegate: StyleManagerInterface) {
+  override fun bindTo(delegate: StyleInterface) {
     this.delegate = delegate
     delegate.addStyleCustomGeometrySource(id, options).check()
   }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/Source.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/Source.kt
@@ -5,6 +5,7 @@ import com.mapbox.bindgen.Value
 import com.mapbox.common.Logger
 import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.extension.style.StyleContract
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.sources.generated.*
 import com.mapbox.maps.extension.style.utils.unwrap
@@ -51,7 +52,7 @@ abstract class Source(
    *
    * @param delegate The style delegate
    */
-  override fun bindTo(delegate: StyleManagerInterface) {
+  override fun bindTo(delegate: StyleInterface) {
     this.delegate = delegate
     val expected = delegate.addStyleSource(sourceId, getCachedSourceProperties())
     expected.error?.let {
@@ -180,6 +181,6 @@ inline fun <reified T : Source> StyleManagerInterface.getSourceAs(sourceId: Stri
  *
  * @param source The light to be added
  */
-fun StyleManagerInterface.addSource(source: StyleContract.StyleSourceExtension) {
+fun StyleInterface.addSource(source: StyleContract.StyleSourceExtension) {
   source.bindTo(this)
 }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/terrain/generated/Terrain.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/terrain/generated/Terrain.kt
@@ -5,8 +5,8 @@ package com.mapbox.maps.extension.style.terrain.generated
 import android.util.Log
 import androidx.annotation.UiThread
 import com.mapbox.bindgen.Value
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.extension.style.StyleContract
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.types.TerrainDsl
@@ -20,7 +20,7 @@ import kotlin.collections.HashMap
  */
 @UiThread
 class Terrain(private val sourceId: String) : TerrainDslReceiver, StyleContract.StyleTerrainExtension {
-  private var delegate: StyleManagerInterface? = null
+  private var delegate: StyleInterface? = null
   private val properties = HashMap<String, PropertyValue<*>>()
 
   /**
@@ -82,7 +82,7 @@ class Terrain(private val sourceId: String) : TerrainDslReceiver, StyleContract.
    *
    * @param delegate The map controller
    */
-  override fun bindTo(delegate: StyleManagerInterface) {
+  override fun bindTo(delegate: StyleInterface) {
     this.delegate = delegate
     val terrainParams = HashMap<String, Value>()
     terrainParams["source"] = Value(sourceId)
@@ -172,7 +172,7 @@ fun terrain(sourceId: String, block: (TerrainDslReceiver.() -> Unit)? = null): T
  *
  * @return Terrain
  */
-fun StyleManagerInterface.getTerrain(sourceId: String): Terrain {
+fun StyleInterface.getTerrain(sourceId: String): Terrain {
   return Terrain(sourceId).also { it.bindTo(this) }
 }
 
@@ -181,7 +181,7 @@ fun StyleManagerInterface.getTerrain(sourceId: String): Terrain {
  *
  * @param terrain The terrain to be added
  */
-fun StyleManagerInterface.addTerrain(terrain: StyleContract.StyleTerrainExtension) {
+fun StyleInterface.addTerrain(terrain: StyleContract.StyleTerrainExtension) {
   terrain.bindTo(this)
 }
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/image/ImagePluginImplTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/image/ImagePluginImplTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.maps.extension.style.image
 
-import android.content.res.Resources
 import android.graphics.Bitmap
 import com.mapbox.bindgen.Expected
 import com.mapbox.maps.Image
@@ -18,11 +17,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ImagePluginImplTest {
   private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
+  private val pixelRatio = mockk<Float>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
-  private val defaultScale = Resources.getSystem().displayMetrics.density
 
   @Before
   fun prepareTest() {
+    every { style.pixelRatio } returns pixelRatio
     every { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) } returns expected
     every { expected.error } returns null
   }
@@ -39,7 +39,7 @@ class ImagePluginImplTest {
       image(image)
     }
     style.addImage(imagePlugin)
-    verify { style.addStyleImage("imageId", defaultScale, image, false, listOf(), listOf(), null) }
+    verify { style.addStyleImage("imageId", pixelRatio, image, false, listOf(), listOf(), null) }
   }
 
   @Test
@@ -68,7 +68,7 @@ class ImagePluginImplTest {
     verify {
       style.addStyleImage(
         "imageId",
-        defaultScale,
+        pixelRatio,
         capture(imageSlot),
         false,
         listOf(),
@@ -151,7 +151,7 @@ class ImagePluginImplTest {
       sdf(true)
     }
     style.addImage(imagePlugin)
-    verify { style.addStyleImage("imageId", defaultScale, image, true, listOf(), listOf(), null) }
+    verify { style.addStyleImage("imageId", pixelRatio, image, true, listOf(), listOf(), null) }
   }
 
   /**
@@ -167,7 +167,7 @@ class ImagePluginImplTest {
       stretchX(stretchX)
     }
     style.addImage(imagePlugin)
-    verify { style.addStyleImage("imageId", defaultScale, image, false, stretchX, listOf(), null) }
+    verify { style.addStyleImage("imageId", pixelRatio, image, false, stretchX, listOf(), null) }
   }
 
   /**
@@ -183,7 +183,7 @@ class ImagePluginImplTest {
       stretchY(stretchY)
     }
     style.addImage(imagePlugin)
-    verify { style.addStyleImage("imageId", defaultScale, image, false, listOf(), stretchY, null) }
+    verify { style.addStyleImage("imageId", pixelRatio, image, false, listOf(), stretchY, null) }
   }
 
   /**
@@ -200,6 +200,6 @@ class ImagePluginImplTest {
       content(content)
     }
     style.addImage(imagePlugin)
-    verify { style.addStyleImage("imageId", defaultScale, image, false, listOf(), listOf(), content) }
+    verify { style.addStyleImage("imageId", pixelRatio, image, false, listOf(), listOf(), content) }
   }
 }

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/image/ImagePluginImplTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/image/ImagePluginImplTest.kt
@@ -6,7 +6,7 @@ import com.mapbox.bindgen.Expected
 import com.mapbox.maps.Image
 import com.mapbox.maps.ImageContent
 import com.mapbox.maps.ImageStretches
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import io.mockk.*
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -17,7 +17,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class ImagePluginImplTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val defaultScale = Resources.getSystem().displayMetrics.density
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayerTest.kt
@@ -6,10 +6,10 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -27,7 +27,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class BackgroundLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/CircleLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/CircleLayerTest.kt
@@ -6,10 +6,10 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -27,7 +27,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class CircleLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayerTest.kt
@@ -6,10 +6,10 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -27,7 +27,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class FillExtrusionLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillLayerTest.kt
@@ -6,10 +6,10 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -27,7 +27,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class FillLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/HeatmapLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/HeatmapLayerTest.kt
@@ -5,10 +5,10 @@ package com.mapbox.maps.extension.style.layers.generated
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -26,7 +26,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class HeatmapLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/HillshadeLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/HillshadeLayerTest.kt
@@ -6,10 +6,10 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -27,7 +27,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class HillshadeLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LineLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LineLayerTest.kt
@@ -6,10 +6,10 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -27,7 +27,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class LineLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayerTest.kt
@@ -6,10 +6,10 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -27,7 +27,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class LocationIndicatorLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/RasterLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/RasterLayerTest.kt
@@ -5,10 +5,10 @@ package com.mapbox.maps.extension.style.layers.generated
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -26,7 +26,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class RasterLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/SkyLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/SkyLayerTest.kt
@@ -6,10 +6,10 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -27,7 +27,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class SkyLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/SymbolLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/SymbolLayerTest.kt
@@ -6,10 +6,10 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
@@ -27,7 +27,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class SymbolLayerTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueExpected = mockk<Expected<Value, String>>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/light/generated/LightTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/light/generated/LightTest.kt
@@ -5,9 +5,9 @@ package com.mapbox.maps.extension.style.light.generated
 import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.rgba
 import com.mapbox.maps.extension.style.layers.properties.generated.Anchor
 import com.mapbox.maps.extension.style.light.LightPosition
@@ -23,7 +23,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class LightTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueSlot = slot<Value>()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/CustomGeometrySourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/CustomGeometrySourceTest.kt
@@ -4,6 +4,7 @@ import com.mapbox.bindgen.Expected
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
+import com.mapbox.maps.extension.style.StyleInterface
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -11,7 +12,7 @@ import org.junit.Before
 import org.junit.Test
 
 class CustomGeometrySourceTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
 
   private val fetchTileFunctionCallback: FetchTileFunctionCallback = mockk()

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/GeoJsonSourceExtTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/GeoJsonSourceExtTest.kt
@@ -5,8 +5,8 @@ import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.bindgen.Value
 import com.mapbox.common.ValueConverter
 import com.mapbox.geojson.Feature
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.extension.style.ShadowValueConverter
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
 import io.mockk.every
 import io.mockk.mockk
@@ -21,7 +21,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowValueConverter::class])
 class GeoJsonSourceExtTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val expectedByte = mockk<Expected<Byte, String>>(relaxUnitFun = true, relaxed = true)
   private val expectedFeatureList =

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/ImageSourceExtTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/ImageSourceExtTest.kt
@@ -2,7 +2,7 @@ package com.mapbox.maps.extension.style.sources
 
 import com.mapbox.bindgen.Expected
 import com.mapbox.maps.Image
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.sources.generated.imageSource
 import io.mockk.every
 import io.mockk.mockk
@@ -11,7 +11,7 @@ import org.junit.Before
 import org.junit.Test
 
 class ImageSourceExtTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val image = mockk<Image>(relaxed = true, relaxUnitFun = true)
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
@@ -7,10 +7,10 @@ import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.get
 import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
 import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
@@ -26,7 +26,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class GeoJsonSourceTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val valueSlot = slot<Value>()
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val expectedDelta = mockk<Expected<Byte, String>>(relaxUnitFun = true, relaxed = true)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/ImageSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/ImageSourceTest.kt
@@ -5,10 +5,10 @@ package com.mapbox.maps.extension.style.sources.generated
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import io.mockk.*
@@ -22,7 +22,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class ImageSourceTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val valueSlot = slot<Value>()
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val expectedDelta = mockk<Expected<Byte, String>>(relaxUnitFun = true, relaxed = true)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSourceTest.kt
@@ -5,10 +5,10 @@ package com.mapbox.maps.extension.style.sources.generated
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.utils.TypeUtils
@@ -23,7 +23,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class RasterDemSourceTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val valueSlot = slot<Value>()
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val expectedDelta = mockk<Expected<Byte, String>>(relaxUnitFun = true, relaxed = true)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterSourceTest.kt
@@ -5,10 +5,10 @@ package com.mapbox.maps.extension.style.sources.generated
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.utils.TypeUtils
@@ -23,7 +23,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class RasterSourceTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val valueSlot = slot<Value>()
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val expectedDelta = mockk<Expected<Byte, String>>(relaxUnitFun = true, relaxed = true)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/VectorSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/VectorSourceTest.kt
@@ -5,10 +5,10 @@ package com.mapbox.maps.extension.style.sources.generated
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.utils.TypeUtils
@@ -23,7 +23,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowStyleManager::class])
 class VectorSourceTest {
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val valueSlot = slot<Value>()
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val expectedDelta = mockk<Expected<Byte, String>>(relaxUnitFun = true, relaxed = true)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/terrain/generated/TerrainTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/terrain/generated/TerrainTest.kt
@@ -4,9 +4,9 @@ package com.mapbox.maps.extension.style.terrain.generated
 
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
-import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import io.mockk.*
 import org.junit.After
@@ -19,7 +19,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class TerrainTest {
   private val sourceId = "1"
-  private val style = mockk<StyleManagerInterface>(relaxUnitFun = true, relaxed = true)
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
   private val styleProperty = mockk<StylePropertyValue>()
   private val expected = mockk<Expected<Void, String>>(relaxUnitFun = true, relaxed = true)
   private val valueSlot = slot<Value>()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -10,7 +10,7 @@ import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
 import com.mapbox.maps.RenderedQueryOptions
 import com.mapbox.maps.ScreenCoordinate
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.all
@@ -54,7 +54,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   final override val delegateProvider: MapDelegateProvider,
   private val annotationConfig: AnnotationConfig?
 ) : AnnotationManager<G, T, S, D, U, V> {
-  protected lateinit var style: StyleManagerInterface
+  protected lateinit var style: StyleInterface
   private var mapProjectionDelegate: MapProjectionDelegate = delegateProvider.mapProjectionDelegate
   private var mapFeatureQueryDelegate: MapFeatureQueryDelegate =
     delegateProvider.mapFeatureQueryDelegate
@@ -252,7 +252,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   /**
    * Invoked when the style is loaded
    */
-  override fun onStyleLoaded(styleDelegate: StyleManagerInterface) {
+  override fun onStyleLoaded(styleDelegate: StyleInterface) {
     style = styleDelegate
     initLayerAndSource()
   }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
@@ -1,7 +1,7 @@
 package com.mapbox.maps.plugin.annotation
 
 import android.view.View
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
@@ -54,7 +54,7 @@ class AnnotationPluginImpl : AnnotationPlugin {
   /**
    * Called when a new Style is loaded.
    */
-  override fun onStyleChanged(styleDelegate: StyleManagerInterface) {
+  override fun onStyleChanged(styleDelegate: StyleInterface) {
     managerList.forEach { it.get()?.onStyleLoaded(styleDelegate) }
   }
 

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -82,6 +82,7 @@ class CircleAnnotationManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.pixelRatio } returns 1.0f
     every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -17,7 +17,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.QueriedFeature
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.addLayerBelow
@@ -47,7 +47,7 @@ import org.robolectric.annotation.Config
 @Config(shadows = [ShadowValueConverter::class, ShadowLogger::class])
 class CircleAnnotationManagerTest {
   private val delegateProvider: MapDelegateProvider = mockk()
-  private val style: StyleManagerInterface = mockk()
+  private val style: StyleInterface = mockk()
   private val mapProjectionDelegate: MapProjectionDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
@@ -69,7 +69,7 @@ class CircleAnnotationManagerTest {
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )
-    val captureCallback = slot<(StyleManagerInterface) -> Unit>()
+    val captureCallback = slot<(StyleInterface) -> Unit>()
     every { delegateProvider.getStyle(capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -85,6 +85,7 @@ class PointAnnotationManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.pixelRatio } returns 1.0f
     every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -18,7 +18,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.QueriedFeature
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.addLayerBelow
@@ -49,7 +49,7 @@ import org.robolectric.annotation.Config
 @Config(shadows = [ShadowValueConverter::class, ShadowLogger::class])
 class PointAnnotationManagerTest {
   private val delegateProvider: MapDelegateProvider = mockk()
-  private val style: StyleManagerInterface = mockk()
+  private val style: StyleInterface = mockk()
   private val mapProjectionDelegate: MapProjectionDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
@@ -72,7 +72,7 @@ class PointAnnotationManagerTest {
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )
-    val captureCallback = slot<(StyleManagerInterface) -> Unit>()
+    val captureCallback = slot<(StyleInterface) -> Unit>()
     every { delegateProvider.getStyle(capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -18,7 +18,7 @@ import com.mapbox.geojson.Polygon
 import com.mapbox.maps.QueriedFeature
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.addLayerBelow
@@ -48,7 +48,7 @@ import org.robolectric.annotation.Config
 @Config(shadows = [ShadowValueConverter::class, ShadowLogger::class])
 class PolygonAnnotationManagerTest {
   private val delegateProvider: MapDelegateProvider = mockk()
-  private val style: StyleManagerInterface = mockk()
+  private val style: StyleInterface = mockk()
   private val mapProjectionDelegate: MapProjectionDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
@@ -70,7 +70,7 @@ class PolygonAnnotationManagerTest {
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )
-    val captureCallback = slot<(StyleManagerInterface) -> Unit>()
+    val captureCallback = slot<(StyleInterface) -> Unit>()
     every { delegateProvider.getStyle(capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -83,6 +83,7 @@ class PolygonAnnotationManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.pixelRatio } returns 1.0f
     every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -18,7 +18,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.QueriedFeature
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.addLayerBelow
@@ -49,7 +49,7 @@ import org.robolectric.annotation.Config
 @Config(shadows = [ShadowValueConverter::class, ShadowLogger::class])
 class PolylineAnnotationManagerTest {
   private val delegateProvider: MapDelegateProvider = mockk()
-  private val style: StyleManagerInterface = mockk()
+  private val style: StyleInterface = mockk()
   private val mapProjectionDelegate: MapProjectionDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
@@ -71,7 +71,7 @@ class PolylineAnnotationManagerTest {
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
       Value(1)
     )
-    val captureCallback = slot<(StyleManagerInterface) -> Unit>()
+    val captureCallback = slot<(StyleInterface) -> Unit>()
     every { delegateProvider.getStyle(capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -84,6 +84,7 @@ class PolylineAnnotationManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.pixelRatio } returns 1.0f
     every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs

--- a/plugin-location/src/main/java/com/mapbox/maps/plugin/location/IndicatorLocationLayerRenderer.kt
+++ b/plugin-location/src/main/java/com/mapbox/maps/plugin/location/IndicatorLocationLayerRenderer.kt
@@ -4,8 +4,7 @@ import android.graphics.Bitmap
 import androidx.annotation.ColorInt
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
-import com.mapbox.maps.extension.style.addStyleImage
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapStyleStateDelegate
 import com.mapbox.maps.plugin.location.LocationComponentConstants.*
 import com.mapbox.maps.plugin.location.modes.RenderMode
@@ -16,7 +15,7 @@ import java.util.Locale
 
 internal class IndicatorLocationLayerRenderer(layerSourceProvider: LayerSourceProvider) :
   LocationLayerRenderer {
-  private var style: StyleManagerInterface? = null
+  private var style: StyleInterface? = null
   private var styleStateDelegate: MapStyleStateDelegate? = null
   private var layer = layerSourceProvider.getIndicatorLocationLayer()
   private var lastLatLng: Point? = null
@@ -24,7 +23,7 @@ internal class IndicatorLocationLayerRenderer(layerSourceProvider: LayerSourcePr
   private var lastAccuracy = 0f
   private lateinit var locationComponentOptions: LocationComponentOptions
 
-  override fun initializeComponents(style: StyleManagerInterface, styleStateDelegate: MapStyleStateDelegate) {
+  override fun initializeComponents(style: StyleInterface, styleStateDelegate: MapStyleStateDelegate) {
     this.style = style
     this.styleStateDelegate = styleStateDelegate
     lastLatLng?.let {
@@ -109,16 +108,16 @@ internal class IndicatorLocationLayerRenderer(layerSourceProvider: LayerSourcePr
     foregroundStaleBitmap: Bitmap
   ) {
     if (shadowBitmap != null) {
-      style?.addStyleImage(SHADOW_ICON, shadowBitmap)
+      style?.addImage(SHADOW_ICON, shadowBitmap)
     } else {
       style?.removeStyleImage(SHADOW_ICON)
     }
-    style?.addStyleImage(FOREGROUND_ICON, foregroundBitmap)
-    style?.addStyleImage(FOREGROUND_STALE_ICON, foregroundStaleBitmap)
+    style?.addImage(FOREGROUND_ICON, foregroundBitmap)
+    style?.addImage(FOREGROUND_STALE_ICON, foregroundStaleBitmap)
     if (renderMode == RenderMode.COMPASS) {
       val leftOffset = (bearingBitmap.width - backgroundBitmap.width) / 2f
       val topOffset = (bearingBitmap.height - backgroundBitmap.height) / 2f
-      style?.addStyleImage(
+      style?.addImage(
         BEARING_ICON,
         BitmapUtils.mergeBitmap(bearingBitmap, backgroundBitmap, leftOffset, topOffset)
       )
@@ -126,7 +125,7 @@ internal class IndicatorLocationLayerRenderer(layerSourceProvider: LayerSourcePr
         (bearingBitmap.width - backgroundStaleBitmap.width) / 2f
       val staleTopOffset =
         (bearingBitmap.height - backgroundStaleBitmap.height) / 2f
-      style?.addStyleImage(
+      style?.addImage(
         BEARING_STALE_ICON,
         BitmapUtils.mergeBitmap(
           bearingBitmap,
@@ -136,9 +135,9 @@ internal class IndicatorLocationLayerRenderer(layerSourceProvider: LayerSourcePr
         )
       )
     } else {
-      style?.addStyleImage(BACKGROUND_ICON, backgroundBitmap)
-      style?.addStyleImage(BACKGROUND_STALE_ICON, backgroundStaleBitmap)
-      style?.addStyleImage(BEARING_ICON, bearingBitmap)
+      style?.addImage(BACKGROUND_ICON, backgroundBitmap)
+      style?.addImage(BACKGROUND_STALE_ICON, backgroundStaleBitmap)
+      style?.addImage(BEARING_ICON, bearingBitmap)
     }
   }
 

--- a/plugin-location/src/main/java/com/mapbox/maps/plugin/location/LocationComponentActivationOptions.java
+++ b/plugin-location/src/main/java/com/mapbox/maps/plugin/location/LocationComponentActivationOptions.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
 
 import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineRequest;
-import com.mapbox.maps.StyleManagerInterface;
+import com.mapbox.maps.extension.style.StyleInterface;
 
 /**
  * A class which holds the various options for activating the Maps SDK's {@link LocationPluginImpl} to eventually
@@ -19,7 +19,7 @@ import com.mapbox.maps.StyleManagerInterface;
 public class LocationComponentActivationOptions {
 
   private final Context context;
-  private final StyleManagerInterface style;
+  private final StyleInterface style;
   private final LocationEngine locationEngine;
   private final LocationEngineRequest locationEngineRequest;
   private final LocationComponentOptions locationComponentOptions;
@@ -27,7 +27,7 @@ public class LocationComponentActivationOptions {
   private final boolean useDefaultLocationEngine;
   private final LocationModelLayerOptions locationModelLayerOptions;
 
-  private LocationComponentActivationOptions(@NonNull Context context, @NonNull StyleManagerInterface style,
+  private LocationComponentActivationOptions(@NonNull Context context, @NonNull StyleInterface style,
                                              @Nullable LocationEngine locationEngine,
                                              @Nullable LocationEngineRequest locationEngineRequest,
                                              @Nullable LocationComponentOptions locationComponentOptions,
@@ -50,7 +50,7 @@ public class LocationComponentActivationOptions {
    * @return a builder object
    */
   @NonNull
-  public static Builder builder(@NonNull Context context, @NonNull StyleManagerInterface fullyLoadedMapMapStyleDelegate) {
+  public static Builder builder(@NonNull Context context, @NonNull StyleInterface fullyLoadedMapMapStyleDelegate) {
     return new LocationComponentActivationOptions.Builder(context, fullyLoadedMapMapStyleDelegate);
   }
 
@@ -65,12 +65,12 @@ public class LocationComponentActivationOptions {
   }
 
   /**
-   * The proxy object for current map style. More info at {@link StyleManagerInterface}
+   * The proxy object for current map style. More info at {@link StyleInterface}
    *
    * @return the map's fully loaded MapStyleDelegate object
    */
   @NonNull
-  public StyleManagerInterface style() {
+  public StyleInterface style() {
     return style;
   }
 
@@ -133,7 +133,7 @@ public class LocationComponentActivationOptions {
    */
   public static class Builder {
     private final Context context;
-    private final StyleManagerInterface style;
+    private final StyleInterface style;
     private LocationEngine locationEngine;
     private LocationEngineRequest locationEngineRequest;
     private LocationComponentOptions locationComponentOptions;
@@ -153,10 +153,10 @@ public class LocationComponentActivationOptions {
     /**
      * Constructor for the {@link LocationComponentActivationOptions} builder class.
      * While other activation options are optional, the activation process always requires
-     * context and a fully-loaded map {@link StyleManagerInterface} object, which is why the two are in this
+     * context and a fully-loaded map {@link StyleInterface} object, which is why the two are in this
      * constructor.
      */
-    public Builder(@NonNull Context context, @NonNull StyleManagerInterface style) {
+    public Builder(@NonNull Context context, @NonNull StyleInterface style) {
       this.context = context;
       this.style = style;
     }

--- a/plugin-location/src/main/java/com/mapbox/maps/plugin/location/LocationLayerController.kt
+++ b/plugin-location/src/main/java/com/mapbox/maps/plugin/location/LocationLayerController.kt
@@ -5,7 +5,7 @@ import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.RenderedQueryOptions
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.location.LocationComponentConstants.*
 import com.mapbox.maps.plugin.location.MapboxAnimator.AnimationsValueChangeListener
@@ -14,7 +14,7 @@ import com.mapbox.maps.plugin.location.modes.RenderMode
 
 internal class LocationLayerController(
   private val delegateProvider: MapDelegateProvider,
-  style: StyleManagerInterface,
+  style: StyleInterface,
   layerSourceProvider: LayerSourceProvider,
   locationModelLayerOptions: LocationModelLayerOptions?,
   private val bitmapProvider: LayerBitmapProvider,
@@ -39,7 +39,7 @@ internal class LocationLayerController(
     initializeComponents(style, options)
   }
 
-  fun initializeComponents(style: StyleManagerInterface, options: LocationComponentOptions) {
+  fun initializeComponents(style: StyleInterface, options: LocationComponentOptions) {
     locationLayerRenderer.addLayers(positionManager)
     locationLayerRenderer.initializeComponents(style, delegateProvider.styleStateDelegate)
     applyStyle(options)

--- a/plugin-location/src/main/java/com/mapbox/maps/plugin/location/LocationLayerRenderer.kt
+++ b/plugin-location/src/main/java/com/mapbox/maps/plugin/location/LocationLayerRenderer.kt
@@ -3,12 +3,12 @@ package com.mapbox.maps.plugin.location
 import android.graphics.Bitmap
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapStyleStateDelegate
 import com.mapbox.maps.plugin.location.modes.RenderMode
 
 internal interface LocationLayerRenderer {
-  fun initializeComponents(style: StyleManagerInterface, styleStateDelegate: MapStyleStateDelegate)
+  fun initializeComponents(style: StyleInterface, styleStateDelegate: MapStyleStateDelegate)
 
   fun addLayers(positionManager: LocationComponentPositionManager)
 

--- a/plugin-location/src/main/java/com/mapbox/maps/plugin/location/LocationPluginImpl.kt
+++ b/plugin-location/src/main/java/com/mapbox/maps/plugin/location/LocationPluginImpl.kt
@@ -16,7 +16,7 @@ import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.common.Logger
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.InvalidPluginConfigurationException
 import com.mapbox.maps.plugin.PLUGIN_CAMERA_ANIMATIONS_CLASS_NAME
 import com.mapbox.maps.plugin.PLUGIN_GESTURE_CLASS_NAME
@@ -91,7 +91,7 @@ import java.util.concurrent.CopyOnWriteArrayList
  */
 @Deprecated("Use LocationComponentPlugin instead.")
 class LocationPluginImpl : LocationPlugin {
-  private lateinit var style: StyleManagerInterface
+  private lateinit var style: StyleInterface
   private lateinit var delegateProvider: MapDelegateProvider
 
   private lateinit var options: LocationComponentOptions
@@ -208,7 +208,7 @@ class LocationPluginImpl : LocationPlugin {
   @VisibleForTesting
   internal fun activateLocationComponent(
     context: Context,
-    style: StyleManagerInterface,
+    style: StyleInterface,
     locationModelLayerOptions: LocationModelLayerOptions?,
     locationEngine: LocationEngine?,
     locationEngineRequest: LocationEngineRequest,
@@ -1203,7 +1203,7 @@ class LocationPluginImpl : LocationPlugin {
 
   private fun initialize(
     context: Context,
-    style: StyleManagerInterface,
+    style: StyleInterface,
     locationModelLayerOptions: LocationModelLayerOptions?,
     options: LocationComponentOptions
   ) {
@@ -1630,7 +1630,7 @@ class LocationPluginImpl : LocationPlugin {
   /**
    * Called when a new Style is loaded.
    */
-  override fun onStyleChanged(styleDelegate: StyleManagerInterface) {
+  override fun onStyleChanged(styleDelegate: StyleInterface) {
     Logger.d(TAG, "onStyleChanged")
     onStartLoadingMap()
     onFinishLoadingStyle()

--- a/plugin-location/src/main/java/com/mapbox/maps/plugin/location/ModelLocationLayerRenderer.kt
+++ b/plugin-location/src/main/java/com/mapbox/maps/plugin/location/ModelLocationLayerRenderer.kt
@@ -3,7 +3,7 @@ package com.mapbox.maps.plugin.location
 import android.graphics.Bitmap
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapStyleStateDelegate
 import com.mapbox.maps.plugin.location.modes.RenderMode
 import kotlin.math.pow
@@ -13,7 +13,7 @@ internal class ModelLocationLayerRenderer(
   private val locationModelLayerOptions: LocationModelLayerOptions
 ) :
   LocationLayerRenderer {
-  private lateinit var style: StyleManagerInterface
+  private lateinit var style: StyleInterface
   private var modelLayer = layerSourceProvider.getModelLayer(locationModelLayerOptions)
   private var source = layerSourceProvider.getModelSource(locationModelLayerOptions)
   private var lastLatLng: Point? = null
@@ -21,7 +21,7 @@ internal class ModelLocationLayerRenderer(
   private var lastAccuracy = 0f
   private var renderMode = RenderMode.NORMAL
 
-  override fun initializeComponents(style: StyleManagerInterface, styleStateDelegate: MapStyleStateDelegate) {
+  override fun initializeComponents(style: StyleInterface, styleStateDelegate: MapStyleStateDelegate) {
     this.style = style
     source.bindTo(style, styleStateDelegate)
     lastLatLng?.let {

--- a/plugin-location/src/test/java/com/mapbox/maps/plugin/location/IndicatorLocationLayerRendererTest.kt
+++ b/plugin-location/src/test/java/com/mapbox/maps/plugin/location/IndicatorLocationLayerRendererTest.kt
@@ -223,14 +223,9 @@ class IndicatorLocationLayerRendererTest {
   fun addBitmaps_shadow() {
     addBitmaps(withShadow = true, renderMode = RenderMode.NORMAL)
     verify {
-      style.addStyleImage(
+      style.addImage(
         SHADOW_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
   }
@@ -245,58 +240,33 @@ class IndicatorLocationLayerRendererTest {
   fun addBitmaps_normal() {
     addBitmaps(withShadow = true, renderMode = RenderMode.NORMAL)
     verify {
-      style.addStyleImage(
+      style.addImage(
         FOREGROUND_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         FOREGROUND_STALE_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         BACKGROUND_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         BACKGROUND_STALE_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         BEARING_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
   }
@@ -337,25 +307,15 @@ class IndicatorLocationLayerRendererTest {
     addBitmaps(withShadow = true, renderMode = RenderMode.COMPASS)
 
     verify {
-      style.addStyleImage(
+      style.addImage(
         BEARING_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         BEARING_STALE_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
 
@@ -372,25 +332,25 @@ class IndicatorLocationLayerRendererTest {
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         FOREGROUND_STALE_ICON,
         any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         BACKGROUND_ICON,
         any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         BACKGROUND_STALE_ICON,
         any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         BEARING_ICON,
         any()
       )

--- a/plugin-location/src/test/java/com/mapbox/maps/plugin/location/IndicatorLocationLayerRendererTest.kt
+++ b/plugin-location/src/test/java/com/mapbox/maps/plugin/location/IndicatorLocationLayerRendererTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.maps.plugin.location
 
-import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Color
 import com.mapbox.bindgen.Expected
@@ -29,11 +28,13 @@ class IndicatorLocationLayerRendererTest {
   private val expressionSlot = CapturingSlot<List<Value>>()
   private val doubleListSlot = CapturingSlot<List<Double>>()
 
+  private val defaultPixelRatio = mockk<Float>(relaxed = true)
+
   private lateinit var locationLayerRenderer: IndicatorLocationLayerRenderer
 
   @Before
   fun setup() {
-
+    every { style.pixelRatio } returns defaultPixelRatio
     every { style.removeStyleLayer(any()) } returns expected
     every { expected.error } returns null
     every { layerSourceProvider.getIndicatorLocationLayer() } returns layerWrapper
@@ -365,58 +366,33 @@ class IndicatorLocationLayerRendererTest {
   fun addBitmaps_gps() {
     addBitmaps(withShadow = true, renderMode = RenderMode.GPS)
     verify {
-      style.addStyleImage(
+      style.addImage(
         FOREGROUND_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
       style.addStyleImage(
         FOREGROUND_STALE_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
       style.addStyleImage(
         BACKGROUND_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
       style.addStyleImage(
         BACKGROUND_STALE_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
       style.addStyleImage(
         BEARING_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
   }
@@ -441,6 +417,4 @@ class IndicatorLocationLayerRendererTest {
   }
 
   private fun Point.toLocationList() = listOf(latitude(), longitude(), 0.0)
-
-  private val defaultPixelRatio = Resources.getSystem().displayMetrics.density
 }

--- a/plugin-location/src/test/java/com/mapbox/maps/plugin/location/IndicatorLocationLayerRendererTest.kt
+++ b/plugin-location/src/test/java/com/mapbox/maps/plugin/location/IndicatorLocationLayerRendererTest.kt
@@ -6,7 +6,7 @@ import android.graphics.Color
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.location.LocationComponentConstants.*
 import com.mapbox.maps.plugin.location.modes.RenderMode
 import com.mapbox.maps.plugin.location.utils.BitmapUtils
@@ -21,7 +21,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class IndicatorLocationLayerRendererTest {
 
-  private val style: StyleManagerInterface = mockk(relaxed = true)
+  private val style: StyleInterface = mockk(relaxed = true)
   private val layerSourceProvider: LayerSourceProvider = mockk(relaxed = true)
   private val layerWrapper: IndicatorLocationLayerWrapper = mockk(relaxed = true)
   private val expected: Expected<Void, String> = mockk(relaxed = true)

--- a/plugin-location/src/test/java/com/mapbox/maps/plugin/location/LocationComponentActivationOptionsTest.kt
+++ b/plugin-location/src/test/java/com/mapbox/maps/plugin/location/LocationComponentActivationOptionsTest.kt
@@ -5,7 +5,7 @@ import android.content.res.Resources
 import android.content.res.TypedArray
 import android.graphics.Color
 import android.view.animation.LinearInterpolator
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertNotNull
@@ -19,7 +19,7 @@ class LocationComponentActivationOptionsTest {
   private val context: Context = mockk()
   private val array: TypedArray = mockk(relaxed = true)
   private val resources: Resources = mockk(relaxed = true)
-  private val style: StyleManagerInterface = mockk()
+  private val style: StyleInterface = mockk()
 
   @Before
   fun setUp() {

--- a/plugin-location/src/test/java/com/mapbox/maps/plugin/location/LocationComponentTest.kt
+++ b/plugin-location/src/test/java/com/mapbox/maps/plugin/location/LocationComponentTest.kt
@@ -8,7 +8,7 @@ import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.common.ShadowLogger
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapStyleStateDelegate
 import com.mapbox.maps.plugin.delegates.MapTransformDelegate
@@ -66,7 +66,7 @@ class LocationComponentTest {
   private val locationEngineProviderImpl: LocationPluginImpl.InternalLocationEngineProvider =
     mockk(relaxed = true)
 
-  private val style: StyleManagerInterface = mockk(relaxed = true)
+  private val style: StyleInterface = mockk(relaxed = true)
 
   private val gesturesPlugin: GesturesPlugin = mockk(relaxed = true)
 
@@ -77,7 +77,7 @@ class LocationComponentTest {
     every { delegateProvider.mapPluginProviderDelegate.getPlugin(any<Class<GesturesPlugin>>()) } returns gesturesPlugin
     every { locationEngineProviderImpl.getBestLocationEngine(context) } returns locationEngine
     every { delegateProvider.getStyle(any()) } answers {
-      firstArg<(StyleManagerInterface) -> Unit>().invoke(style)
+      firstArg<(StyleInterface) -> Unit>().invoke(style)
     }
     val styleStateDelegate = mockk<MapStyleStateDelegate>()
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate

--- a/plugin-location/src/test/java/com/mapbox/maps/plugin/location/LocationLayerControllerTest.kt
+++ b/plugin-location/src/test/java/com/mapbox/maps/plugin/location/LocationLayerControllerTest.kt
@@ -1,7 +1,7 @@
 package com.mapbox.maps.plugin.location
 
 import android.graphics.Bitmap
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.location.LocationComponentConstants.FOREGROUND_ICON
 import com.mapbox.maps.plugin.location.LocationComponentConstants.FOREGROUND_LAYER
@@ -16,7 +16,7 @@ import org.junit.Test
 class LocationLayerControllerTest {
 
   private val delegateProvider: MapDelegateProvider = mockk(relaxed = true)
-  private val style: StyleManagerInterface = mockk(relaxed = true)
+  private val style: StyleInterface = mockk(relaxed = true)
   private val indicatorRenderer: IndicatorLocationLayerRenderer = mockk(relaxed = true)
   private val layerSourceProvider: LayerSourceProvider = mockk(relaxed = true)
 
@@ -29,7 +29,7 @@ class LocationLayerControllerTest {
   @Before
   fun before() {
     every { delegateProvider.getStyle(any()) } answers {
-      firstArg<(StyleManagerInterface) -> Unit>().invoke(style)
+      firstArg<(StyleInterface) -> Unit>().invoke(style)
     }
     every { layerSourceProvider.getIndicatorLocationLayerRenderer() } returns indicatorRenderer
 

--- a/plugin-location/src/test/java/com/mapbox/maps/plugin/location/ModelLocationLayerRendererTest.kt
+++ b/plugin-location/src/test/java/com/mapbox/maps/plugin/location/ModelLocationLayerRendererTest.kt
@@ -2,7 +2,7 @@ package com.mapbox.maps.plugin.location
 
 import com.mapbox.bindgen.Expected
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.location.modes.RenderMode
 import io.mockk.*
 import org.junit.Before
@@ -10,7 +10,7 @@ import org.junit.Test
 
 class ModelLocationLayerRendererTest {
 
-  private val style: StyleManagerInterface = mockk(relaxed = true)
+  private val style: StyleInterface = mockk(relaxed = true)
   private val layerSourceProvider: LayerSourceProvider = mockk(relaxed = true)
   private val layerWrapper: ModelLocationLayerWrapper = mockk(relaxed = true)
   private val sourceWrapper: ModelLocationSourceWrapper = mockk(relaxUnitFun = true, relaxed = true)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
@@ -7,7 +7,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import com.mapbox.geojson.Point
 import com.mapbox.maps.RenderedQueryOptions
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.LOCATION_INDICATOR_LAYER
@@ -147,7 +147,7 @@ class LocationComponentPluginImpl : LocationComponentPlugin, LocationConsumer,
   /**
    * Called when a new Style is loaded.
    */
-  override fun onStyleChanged(styleDelegate: StyleManagerInterface) {
+  override fun onStyleChanged(styleDelegate: StyleInterface) {
     locationPuckManager?.let {
       if (!it.isLayerInitialised()) {
         it.initialize(styleDelegate)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerRenderer.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerRenderer.kt
@@ -3,8 +3,7 @@ package com.mapbox.maps.plugin.locationcomponent
 import androidx.annotation.ColorInt
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
-import com.mapbox.maps.extension.style.addStyleImage
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.BEARING_ICON
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.LOCATION_INDICATOR_LAYER
@@ -20,10 +19,10 @@ internal class LocationIndicatorLayerRenderer(
   layerSourceProvider: LayerSourceProvider
 ) :
   LocationLayerRenderer {
-  private var style: StyleManagerInterface? = null
+  private var style: StyleInterface? = null
   private var layer = layerSourceProvider.getLocationIndicatorLayer()
 
-  override fun initializeComponents(style: StyleManagerInterface) {
+  override fun initializeComponents(style: StyleInterface) {
     this.style = style
     setupBitmaps()
   }
@@ -76,11 +75,11 @@ internal class LocationIndicatorLayerRenderer(
 
   private fun setupBitmaps() {
     puckOptions.topImage?.let { BitmapUtils.getBitmapFromDrawable(it) }
-      ?.let { style?.addStyleImage(TOP_ICON, it) }
+      ?.let { style?.addImage(TOP_ICON, it) }
     puckOptions.bearingImage?.let { BitmapUtils.getBitmapFromDrawable(it) }
-      ?.let { style?.addStyleImage(BEARING_ICON, it) }
+      ?.let { style?.addImage(BEARING_ICON, it) }
     puckOptions.shadowImage?.let { BitmapUtils.getBitmapFromDrawable(it) }
-      ?.let { style?.addStyleImage(SHADOW_ICON, it) }
+      ?.let { style?.addImage(SHADOW_ICON, it) }
     layer.topImage(TOP_ICON)
     layer.bearingImage(BEARING_ICON)
     layer.shadowImage(SHADOW_ICON)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationLayerRenderer.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationLayerRenderer.kt
@@ -3,10 +3,10 @@ package com.mapbox.maps.plugin.locationcomponent
 import androidx.annotation.ColorInt
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 
 internal interface LocationLayerRenderer {
-  fun initializeComponents(style: StyleManagerInterface)
+  fun initializeComponents(style: StyleInterface)
 
   fun isRendererInitialised(): Boolean
 

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -6,7 +6,7 @@ import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.common.ValueConverter
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.LocationPuck3D
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
@@ -48,7 +48,7 @@ internal class LocationPuckManager(
       }
     }
 
-  fun initialize(style: StyleManagerInterface) {
+  fun initialize(style: StyleInterface) {
     animationManager.setUpdateListeners(onLocationUpdated, onBearingUpdated)
     animationManager.setLocationLayerRenderer(locationLayerRenderer)
     animationManager.applyPulsingAnimationSettings(settings)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRenderer.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRenderer.kt
@@ -2,7 +2,7 @@ package com.mapbox.maps.plugin.locationcomponent
 
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.LocationPuck3D
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.MODEL_LAYER
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.MODEL_SOURCE
@@ -12,11 +12,11 @@ internal class ModelLayerRenderer(
   private val locationModelLayerOptions: LocationPuck3D
 ) :
   LocationLayerRenderer {
-  private var style: StyleManagerInterface? = null
+  private var style: StyleInterface? = null
   private var modelLayer = layerSourceProvider.getModelLayer(locationModelLayerOptions)
   private var source = layerSourceProvider.getModelSource(locationModelLayerOptions)
 
-  override fun initializeComponents(style: StyleManagerInterface) {
+  override fun initializeComponents(style: StyleInterface) {
     this.style = style
     source.bindTo(style)
   }

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
@@ -11,7 +11,7 @@ import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.common.ShadowLogger
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentAttributeParser
@@ -32,7 +32,7 @@ class LocationComponentPluginImplTest {
   private val locationPuckManager = mockk<LocationPuckManager>(relaxed = true)
   private val locationProvider = mockk<LocationProvider>(relaxed = true)
 
-  private val style = mockk<StyleManagerInterface>(relaxed = true)
+  private val style = mockk<StyleInterface>(relaxed = true)
 
   private val context = mockk<Context>(relaxed = true)
   private val attrs = mockk<AttributeSet>(relaxUnitFun = true)
@@ -42,7 +42,7 @@ class LocationComponentPluginImplTest {
 
   private val locationEngine = mockk<LocationEngine>(relaxed = true)
 
-  private val styleCallbackSlot = slot<(StyleManagerInterface) -> Unit>()
+  private val styleCallbackSlot = slot<(StyleInterface) -> Unit>()
 
   private lateinit var locationComponentPlugin: LocationComponentPluginImpl
 

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerRendererTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerRendererTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.maps.plugin.locationcomponent
 
-import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.Drawable
@@ -158,41 +157,24 @@ class LocationIndicatorLayerRendererTest {
   @Test
   fun testAddBitmaps() {
     verify {
-      style.addStyleImage(
+      style.addImage(
         TOP_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         BEARING_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
     verify {
-      style.addStyleImage(
+      style.addImage(
         SHADOW_ICON,
-        defaultPixelRatio,
-        any(),
-        false,
-        listOf(),
-        listOf(),
-        null
+        any()
       )
     }
   }
 
   private fun Point.toLocationList() = listOf(latitude(), longitude(), 0.0)
-
-  private val defaultPixelRatio = Resources.getSystem().displayMetrics.density
 }

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerRendererTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerRendererTest.kt
@@ -7,7 +7,7 @@ import android.graphics.drawable.Drawable
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.BEARING_ICON
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.SHADOW_ICON
@@ -24,7 +24,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class LocationIndicatorLayerRendererTest {
 
-  private val style: StyleManagerInterface = mockk(relaxed = true)
+  private val style: StyleInterface = mockk(relaxed = true)
   private val layerSourceProvider: LayerSourceProvider = mockk(relaxed = true)
   private val layerWrapper: LocationIndicatorLayerWrapper = mockk(relaxed = true)
   private val expected: Expected<Void, String> = mockk(relaxed = true)

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -6,7 +6,7 @@ import com.mapbox.common.ShadowValueConverter
 import com.mapbox.common.ValueConverter
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.LocationPuck3D
 import com.mapbox.maps.plugin.delegates.MapCameraDelegate
@@ -27,13 +27,13 @@ class LocationPuckManagerTest {
   private val settings = mockk<LocationComponentSettings>(relaxed = true)
   private val delegateProvider = mockk<MapDelegateProvider>(relaxed = true)
   private val mapCameraDelegate = mockk<MapCameraDelegate>(relaxed = true)
-  private val style = mockk<StyleManagerInterface>(relaxed = true)
+  private val style = mockk<StyleInterface>(relaxed = true)
   private val positionManager = mockk<LocationComponentPositionManager>(relaxed = true)
   private val layerSourceProvider = mockk<LayerSourceProvider>(relaxed = true)
   private val locationLayerRenderer = mockk<LocationLayerRenderer>(relaxed = true)
   private val animationManager = mockk<PuckAnimatorManager>(relaxed = true)
 
-  private val callbackSlot = CapturingSlot<(StyleManagerInterface) -> Unit>()
+  private val callbackSlot = CapturingSlot<(StyleInterface) -> Unit>()
   private val valueSlot = CapturingSlot<Value>()
 
   private lateinit var locationPuckManager: LocationPuckManager

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRendererTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRendererTest.kt
@@ -2,7 +2,7 @@ package com.mapbox.maps.plugin.locationcomponent
 
 import com.mapbox.bindgen.Expected
 import com.mapbox.geojson.Point
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.LocationPuck3D
 import io.mockk.*
 import org.junit.Before
@@ -10,7 +10,7 @@ import org.junit.Test
 
 class ModelLayerRendererTest {
 
-  private val style: StyleManagerInterface = mockk(relaxed = true)
+  private val style: StyleInterface = mockk(relaxed = true)
   private val layerSourceProvider: LayerSourceProvider = mockk(relaxed = true)
   private val layerWrapper: ModelLayerWrapper = mockk(relaxed = true)
   private val sourceWrapper: ModelSourceWrapper = mockk(relaxUnitFun = true, relaxed = true)

--- a/sdk-base/src/main/java/com/mapbox/maps/extension/style/StyleContract.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/extension/style/StyleContract.kt
@@ -1,12 +1,6 @@
 package com.mapbox.maps.extension.style
 
-import android.content.res.Resources
-import android.graphics.Bitmap
-import com.mapbox.bindgen.Expected
-import com.mapbox.maps.Image
 import com.mapbox.maps.LayerPosition
-import com.mapbox.maps.StyleManagerInterface
-import java.nio.ByteBuffer
 
 /**
  * Define the common interfaces for the Style component.
@@ -57,7 +51,7 @@ interface StyleContract {
      * @param delegate The style delegate
      * @param position the layer position
      */
-    fun bindTo(delegate: StyleManagerInterface, position: LayerPosition? = null)
+    fun bindTo(delegate: StyleInterface, position: LayerPosition? = null)
   }
 
   /**
@@ -69,7 +63,7 @@ interface StyleContract {
      *
      * @param delegate The style delegate
      */
-    fun bindTo(delegate: StyleManagerInterface)
+    fun bindTo(delegate: StyleInterface)
   }
 
   /**
@@ -81,7 +75,7 @@ interface StyleContract {
      *
      * @param delegate The style delegate
      */
-    fun bindTo(delegate: StyleManagerInterface)
+    fun bindTo(delegate: StyleInterface)
   }
 
   /**
@@ -93,7 +87,7 @@ interface StyleContract {
      *
      * @param delegate The style delegate
      */
-    fun bindTo(delegate: StyleManagerInterface)
+    fun bindTo(delegate: StyleInterface)
   }
 
   /**
@@ -105,30 +99,6 @@ interface StyleContract {
      *
      * @param delegate The style delegate
      */
-    fun bindTo(delegate: StyleManagerInterface)
+    fun bindTo(delegate: StyleInterface)
   }
-}
-
-/**
- * Adds an image to be used in the style. This API can also be used for updating
- * an image. If the image \a id was already added, it gets replaced by the new image.
- *
- * The image can be used in `icon-image`, `fill-pattern`, and `line-pattern`.
- *
- * [layout-symbol-icon-image](https://www.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-image)
- *
- * [paint-line-line-pattern](https://www.mapbox.com/mapbox-gl-js/style-spec/#paint-line-line-pattern)
- *
- * [paint-fill-fill-pattern](https://www.mapbox.com/mapbox-gl-js/style-spec/#paint-fill-fill-pattern)
- *
- * @param imageId ID of the image.
- * @param bitmap Bitmap data of the image.
- *
- * @return A string describing an error if the operation was not successful, empty otherwise.
- */
-fun StyleManagerInterface.addStyleImage(imageId: String, bitmap: Bitmap): Expected<Void, String> {
-  val byteBuffer = ByteBuffer.allocate(bitmap.byteCount)
-  bitmap.copyPixelsToBuffer(byteBuffer)
-  val image = Image(bitmap.width, bitmap.height, byteBuffer.array())
-  return this.addStyleImage(imageId, Resources.getSystem().displayMetrics.density, image, false, listOf(), listOf(), null)
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/extension/style/StyleInterface.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/extension/style/StyleInterface.kt
@@ -1,0 +1,35 @@
+package com.mapbox.maps.extension.style
+
+import android.graphics.Bitmap
+import com.mapbox.bindgen.Expected
+import com.mapbox.maps.StyleManagerInterface
+
+/**
+ * Defines the style interface that can be used to interact with the map's style.
+ */
+interface StyleInterface : StyleManagerInterface {
+  /**
+   * The pixel ratio of the current display for the map to be rendered on, this value is initialised
+   * and can be overwritten at the Map's initialisation period.
+   */
+  val pixelRatio: Float
+
+  /**
+   * Adds an image to be used in the style. This API can also be used for updating
+   * an image. If the image \a id was already added, it gets replaced by the new image.
+   *
+   * The image can be used in `icon-image`, `fill-pattern`, and `line-pattern`.
+   *
+   * [layout-symbol-icon-image](https://www.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-image)
+   *
+   * [paint-line-line-pattern](https://www.mapbox.com/mapbox-gl-js/style-spec/#paint-line-line-pattern)
+   *
+   * [paint-fill-fill-pattern](https://www.mapbox.com/mapbox-gl-js/style-spec/#paint-fill-fill-pattern)
+   *
+   * @param imageId ID of the image.
+   * @param bitmap Bitmap data of the image.
+   *
+   * @return A string describing an error if the operation was not successful, empty otherwise.
+   */
+  fun addImage(imageId: String, bitmap: Bitmap): Expected<Void, String>
+}

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/MapStyleObserverPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/MapStyleObserverPlugin.kt
@@ -1,6 +1,6 @@
 package com.mapbox.maps.plugin
 
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 
 /**
  * Interface for plugins need to be aware of the style change event.
@@ -9,5 +9,5 @@ interface MapStyleObserverPlugin {
   /**
    * Called when a new Style is loaded.
    */
-  fun onStyleChanged(styleDelegate: StyleManagerInterface)
+  fun onStyleChanged(styleDelegate: StyleInterface)
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManager.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManager.kt
@@ -1,7 +1,7 @@
 package com.mapbox.maps.plugin.annotation
 
 import com.mapbox.geojson.Geometry
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 
 /**
@@ -65,7 +65,7 @@ interface AnnotationManager<
   /**
    * Invoked when the style is loaded
    */
-  fun onStyleLoaded(styleDelegate: StyleManagerInterface)
+  fun onStyleLoaded(styleDelegate: StyleInterface)
 
   /**
    * The delegateProvider

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapDelegateProvider.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapDelegateProvider.kt
@@ -1,6 +1,6 @@
 package com.mapbox.maps.plugin.delegates
 
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 
 /**
  * Definition of map delegate transporter. Provides hooks to all map delegate instances.
@@ -30,7 +30,7 @@ interface MapDelegateProvider {
   /**
    * Delegate used to interact with map's plugins.
    */
-  fun getStyle(callback: (StyleManagerInterface) -> Unit)
+  fun getStyle(callback: (StyleInterface) -> Unit)
 
   /**
    * Delegate used to interact with map's plugins.

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Feature
+import com.mapbox.maps.extension.style.StyleInterface
 import java.lang.ref.WeakReference
 import java.nio.ByteBuffer
 
@@ -22,8 +23,8 @@ import java.nio.ByteBuffer
  */
 class Style internal constructor(
   styleManager: StyleManagerInterface,
-  private val pixelRatio: Float
-) : StyleManagerInterface {
+  override val pixelRatio: Float
+) : StyleInterface {
   private val styleManagerRef = WeakReference(styleManager)
   var fullyLoaded = true
 
@@ -493,7 +494,7 @@ class Style internal constructor(
    *
    * @return A string describing an error if the operation was not successful, empty otherwise.
    */
-  fun addImage(
+  override fun addImage(
     imageId: String,
     bitmap: Bitmap
   ): Expected<Void, String> = addImage(imageId, bitmap, false)

--- a/sdk/src/main/java/com/mapbox/maps/plugin/MapDelegateProviderImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/plugin/MapDelegateProviderImpl.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps.plugin
 
 import com.mapbox.maps.*
 import com.mapbox.maps.MapController
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.module.MapTelemetry
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.delegates.MapAttributionDelegate
@@ -16,7 +17,7 @@ internal class MapDelegateProviderImpl constructor(val mapboxMap: MapboxMap, map
   override val mapListenerDelegate: MapListenerDelegate by lazy { mapboxMap }
   override val styleStateDelegate: MapStyleStateDelegate by lazy { mapboxMap }
 
-  override fun getStyle(callback: (StyleManagerInterface) -> Unit) {
+  override fun getStyle(callback: (StyleInterface) -> Unit) {
     mapboxMap.getStyle { style -> callback(style) }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/plugin/MapPluginRegistryTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/plugin/MapPluginRegistryTest.kt
@@ -8,6 +8,7 @@ import android.view.View
 import com.mapbox.common.ShadowLogger
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.loader.MapboxMapStaticInitializer
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
@@ -330,7 +331,7 @@ class MapPluginRegistryTest {
     override fun onDelegateProvider(delegateProvider: MapDelegateProvider) {
     }
 
-    override fun onStyleChanged(styleDelegate: StyleManagerInterface) {
+    override fun onStyleChanged(styleDelegate: StyleInterface) {
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/159

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Introduce StyleInterface that include the current display's pixel ratio, and fix Style#addImage to take the correct pixel ratio from display. </changelog>`.

### Summary of changes
This PR introduces StyleInterface and expose pixelRatio and convenient `addImage` API to add a bitmap to the map with correct scale on secondary displays. 

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->