### PR TITLE
[plugin] refactor plugin setup

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
@@ -5,6 +5,7 @@ import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
+import com.mapbox.maps.plugin.*
 import com.mapbox.maps.testapp.R
 import kotlinx.android.synthetic.main.activity_map_view_customization.*
 
@@ -40,6 +41,12 @@ class MapViewCustomizationActivity : AppCompatActivity() {
       )
       .build()
 
+    // plugins configuration
+    val plugins = listOf(
+      PLUGIN_LOGO_CLASS_NAME,
+      PLUGIN_ATTRIBUTION_CLASS_NAME
+    )
+
     // set token and cache size for this particular map view
     val resourceOptions = ResourceOptions.Builder()
       .accessToken(getString(R.string.mapbox_access_token))
@@ -50,10 +57,11 @@ class MapViewCustomizationActivity : AppCompatActivity() {
     val initialCameraOptions = CameraOptions.Builder()
       .center(Point.fromLngLat(-122.4194, 37.7749))
       .zoom(9.0)
+      .bearing(120.0)
       .build()
 
-    val mapInitOptions =
-      MapInitOptions(this, resourceOptions, mapOptions, initialCameraOptions, true)
+    val mapInitOptions = MapInitOptions(this, resourceOptions, mapOptions, plugins, initialCameraOptions, true)
+
     // create view programmatically and add to root layout
     customMapView = MapView(this, mapInitOptions)
     val params = LinearLayout.LayoutParams(

--- a/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps
 
 import android.content.Context
 import android.util.AttributeSet
+import com.mapbox.maps.plugin.*
 
 /**
  * Defines configuration [MapInitOptions] for a [MapboxMap]. These options can be used when adding a
@@ -11,9 +12,10 @@ import android.util.AttributeSet
  * MapView(Context, MapboxMapOptions). If you add a map using XML, then you can apply these options
  * using custom XML tags.
  *
- * @property context the context of the application.
+ * @property context The context of the MapView.
  * @property resourceOptions Resource options when using a MapView. Access token required when using a Mapbox service. Please see [https://www.mapbox.com/help/create-api-access-token/](https://www.mapbox.com/help/create-api-access-token/) to learn how to create one.More information in this guide [https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens](https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens).
  * @property mapOptions Describes the map options value when using a MapView.
+ * @property plugins The plugins, a list of strings representing class names, that will be loaded as part of MapView initialisation,
  * @property cameraOptions The Initial Camera options when creating a MapView.
  * @property textureView Flag indicating to use a TextureView as render surface for the MapView. Default is false.
  * @property styleUri The styleUri will applied for the MapView in the onStart lifecycle event if no style is set. Default is [Style.MAPBOX_STREETS]. If set to null, then there is no default style will be loaded.
@@ -23,6 +25,7 @@ data class MapInitOptions constructor(
   val context: Context,
   var resourceOptions: ResourceOptions = getDefaultResourceOptions(context),
   var mapOptions: MapOptions = getDefaultMapOptions(context),
+  var plugins: List<String> = getDefaultPlugins(),
   var cameraOptions: CameraOptions? = null,
   var textureView: Boolean = false,
   val styleUri: String? = Style.MAPBOX_STREETS,
@@ -67,5 +70,22 @@ data class MapInitOptions constructor(
       .viewportMode(ViewportMode.DEFAULT)
       .crossSourceCollisions(true)
       .build()
+
+    /**
+     * Get a default selection of Mapbox created plugins.
+     */
+    fun getDefaultPlugins(): List<String> {
+      return listOf(
+        PLUGIN_CAMERA_ANIMATIONS_CLASS_NAME,
+        PLUGIN_COMPASS_CLASS_NAME,
+        PLUGIN_LOGO_CLASS_NAME,
+        PLUGIN_GESTURE_CLASS_NAME,
+        PLUGIN_ATTRIBUTION_CLASS_NAME,
+        PLUGIN_LOCATION_COMPONENT_CLASS_NAME,
+        PLUGIN_SCALE_BAR_CLASS_NAME,
+        PLUGIN_MAPOVERLAY_CLASS_NAME,
+        PLUGIN_ANNOTATION_CLASS_NAME
+      )
+    }
   }
 }

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -38,7 +38,7 @@ class MapSurface(
       renderer,
       mapInitOptions
     )
-    mapController.initializePlugins(null)
+    mapController.initializePlugins(mapInitOptions)
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -97,8 +97,7 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
       resolvedMapInitOptions
     )
     addView(view, 0)
-
-    mapController.initializePlugins(this)
+    mapController.initializePlugins(resolvedMapInitOptions, this)
   }
 
   @SuppressLint("CustomViewStyleable")

--- a/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.maps
 import android.content.Context
 import android.util.DisplayMetrics
 import com.mapbox.common.ShadowLogger
+import com.mapbox.maps.plugin.*
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -79,5 +80,71 @@ class MapInitOptionsTest {
     assertTrue(mapboxMapOptions.resourceOptions.cachePath!!.endsWith("foobar/mbx.db"))
     assertTrue(mapboxMapOptions.resourceOptions.assetPath!!.endsWith("foobar"))
     assertEquals(MapInitOptions.DEFAULT_CACHE_SIZE, mapboxMapOptions.resourceOptions.cacheSize)
+  }
+
+  @Test
+  fun defaultPlugins() {
+    val mapboxMapOptions = MapInitOptions(context)
+    val plugins = mapboxMapOptions.plugins
+    assertTrue(
+      plugins.contains(
+        PLUGIN_CAMERA_ANIMATIONS_CLASS_NAME
+      )
+    )
+    assertTrue(
+      plugins.contains(
+        PLUGIN_COMPASS_CLASS_NAME
+      )
+    )
+    assertTrue(
+      plugins.contains(
+        PLUGIN_LOGO_CLASS_NAME
+      )
+    )
+    assertTrue(
+      plugins.contains(
+        PLUGIN_GESTURE_CLASS_NAME
+      )
+    )
+    assertTrue(
+      plugins.contains(
+        PLUGIN_ATTRIBUTION_CLASS_NAME
+      )
+    )
+    assertTrue(
+      plugins.contains(
+        PLUGIN_LOCATION_COMPONENT_CLASS_NAME
+      )
+    )
+    assertTrue(
+      plugins.contains(
+        PLUGIN_SCALE_BAR_CLASS_NAME
+      )
+    )
+    assertTrue(
+      plugins.contains(
+        PLUGIN_MAPOVERLAY_CLASS_NAME
+      )
+    )
+    assertTrue(
+      plugins.contains(
+        PLUGIN_ANNOTATION_CLASS_NAME
+      )
+    )
+  }
+
+  @Test
+  fun emptyPlugins() {
+    val mapboxMapOptions = MapInitOptions(context, plugins = listOf())
+    val plugins = mapboxMapOptions.plugins
+    assertTrue(plugins.isEmpty())
+  }
+
+  @Test
+  fun customPlugins() {
+    val mapboxMapOptions = MapInitOptions(context, plugins = listOf("foobar"))
+    val plugins = mapboxMapOptions.plugins
+    assertTrue(plugins.size == 1)
+    assertEquals("foobar", plugins[0])
   }
 }


### PR DESCRIPTION
closes #195 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Refactored plugin system to have more granular control over which plugins are loaded when creating a MapView programmatically.</changelog>`.

### Summary of changes
This PR refactors the plugin setup to avoid the boiler plate of try/catch blocks and allowing developers to provide their own set of plugin classes to be initialized. This allows them to avoid using underlying reflection calls and limit them to only the plugins needed.

### User impact (optional)
Users have the ability when creating a MapView programmatically to limit the amount of plugins we attempt to load. 