### PR TITLE
Fix runtime crash if logo / attribution not enabled

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -262,6 +262,11 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     try {
       val logoPluginClass = Class.forName(PLUGIN_LOGO_CLASS_NAME) as Class<LogoPlugin>
       createPlugin(mapView, logoPluginClass)
+    } catch (ex: ClassNotFoundException) {
+      Logger.d(
+        TAG,
+        "The Mapbox logo wordmark must remain enabled in accordance with our Terms of Service. See https://www.mapbox.com/legal/tos for more details."
+      )
     } catch (ex: InvalidViewPluginHostException) {
       Logger.d(
         TAG,
@@ -302,10 +307,15 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       val attributionPluginClass =
         Class.forName(PLUGIN_ATTRIBUTION_CLASS_NAME) as Class<AttributionPlugin>
       createPlugin(mapView, attributionPluginClass)
+    } catch (ex: ClassNotFoundException) {
+      Logger.d(
+        TAG,
+        "Attribution must be enabled if you use data from sources that require it. See https://docs.mapbox.com/help/getting-started/attribution/ for more details."
+      )
     } catch (ex: InvalidViewPluginHostException) {
       Logger.d(
         TAG,
-        "Compass plugin requires a View hierarchy to be injected, plugin is ignored."
+        "Attribution plugin requires a View hierarchy to be injected, plugin is ignored."
       )
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix runtime crash if logo / attribution not enabled</changelog>`.

### Summary of changes

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->