### PR TITLE
Keep CompassPlugin enabled/disabled state after other properties update

### DIFF
--- a/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
+++ b/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
@@ -82,6 +82,7 @@ open class CompassViewPlugin(
   override var enabled: Boolean
     get() = compassView.isCompassEnabled
     set(value) {
+      internalSettings.enabled = value
       compassView.isCompassEnabled = value
       update(mapCameraDelegate.getBearing())
       if (value && !shouldHideCompass()) {

--- a/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
+++ b/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
@@ -206,6 +206,19 @@ class CompassViewPluginTest {
   }
 
   @Test
+  fun setEnabledWithMarginUpdate_false() {
+    every { mapCameraDelegate.getBearing() } returns 0.0
+    val enabledSlot = slot<Boolean>()
+    every { compassView.isCompassEnabled = capture(enabledSlot) } answers { }
+    compassPlugin.enabled = false
+    verify { compassView.isCompassEnabled = false }
+    verify { compassView.compassRotation = (-0.0).toFloat() }
+    verify { compassView.setCompassAlpha(0.0f) }
+    compassPlugin.marginLeft = 1f
+    assertEquals(false, enabledSlot.captured)
+  }
+
+  @Test
   fun bind() {
     val mapView = mockk<FrameLayout>()
     every { mapView.context } returns mockk(relaxed = true)


### PR DESCRIPTION
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Keep CompassPlugin enabled/disabled state after other properties update</changelog>`.

### Summary of changes
Keep CompassPlugin enabled/disabled state after other properties update (margin, opacity, etc.)