### PR TITLE
[example] Fix IndexOutOfBoundsException in test app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         tools:ignore="GoogleAppIndexingWarning,UnusedAttribute">
         <activity
             android:name=".ExampleOverviewActivity"
+            android:launchMode="singleTop"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/mapbox/maps/testapp/ExampleOverviewActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/ExampleOverviewActivity.kt
@@ -56,9 +56,9 @@ class ExampleOverviewActivity : AppCompatActivity(), CoroutineScope {
           if (!sectionAdapter.isSectionHeaderPosition(position)) {
             val itemPosition = sectionAdapter.getConvertedPosition(position)
             if (currentlyDisplayedExampleList.isNotEmpty()) {
-              startExample(currentlyDisplayedExampleList[itemPosition])
+              startExample(currentlyDisplayedExampleList.elementAtOrNull(itemPosition))
             } else {
-              startExample(allExampleList[itemPosition])
+              startExample(allExampleList.elementAtOrNull(itemPosition))
             }
           }
         }
@@ -100,7 +100,8 @@ class ExampleOverviewActivity : AppCompatActivity(), CoroutineScope {
           if (clear_search_imageview.visibility == View.INVISIBLE) {
             clear_search_imageview.visibility = View.VISIBLE
           }
-          val lowercaseSearchText = currentTextInEditText.toString().toLowerCase(Locale.getDefault())
+          val lowercaseSearchText =
+            currentTextInEditText.toString().toLowerCase(Locale.getDefault())
           val filteredList = allExampleList.filter {
             // Set search criteria
             it.getSimpleName().toLowerCase(Locale.getDefault()).contains(lowercaseSearchText) ||
@@ -110,7 +111,6 @@ class ExampleOverviewActivity : AppCompatActivity(), CoroutineScope {
           }
           if (filteredList.isNotEmpty()) {
             displayExampleList(filteredList)
-            currentlyDisplayedExampleList = filteredList
           } else {
             Snackbar.make(
               root_layout,
@@ -151,10 +151,13 @@ class ExampleOverviewActivity : AppCompatActivity(), CoroutineScope {
       sectionAdapter.setSections(sections.toTypedArray())
       recyclerView.adapter = sectionAdapter
     }
+    currentlyDisplayedExampleList = specificExamplesList
   }
 
-  private fun startExample(specificExample: SpecificExample) {
-    startActivity(Intent().withComponent(packageName, specificExample.name))
+  private fun startExample(specificExample: SpecificExample?) {
+    specificExample?.let {
+      startActivity(Intent().withComponent(packageName, it.name))
+    }
   }
 
   private fun Intent.withComponent(packageName: String, exampleName: String): Intent {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #114 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes
Root cause for the crash is that if we searched some text, the example list will show the searched result. Then if the search text is deleted, although it will show all examples, the `currentlyDisplayedExampleList` isn't updated and keeps the previous searched result. At this time if click an item with a bigger index the crash will occur.

This pr also fix the scenario that if we click the back arrow on the left top of an example back to the example list activity, the example list activity will be recreated and not be able to keep the previous state.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->