### PR TITLE
[animation] High-level animations return cancelable interface

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/CameraPredefinedAnimatorsActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/CameraPredefinedAnimatorsActivity.kt
@@ -139,83 +139,73 @@ class CameraPredefinedAnimatorsActivity : AppCompatActivity() {
     cameraAnimationsPlugin.unregisterAnimators(*currentAnimators)
   }
 
-  private fun prepareAnimationOptions(duration: Long): MapAnimationOptions {
-    return mapAnimationOptions {
-      duration(duration)
-      animatorListener(object : AnimatorListenerAdapter() {
+  private fun prepareAnimationOptions(duration: Long) = mapAnimationOptions {
+    duration(duration)
+    animatorListener(object : AnimatorListenerAdapter() {
 
-        override fun onAnimationStart(animation: Animator?) {
-          super.onAnimationStart(animation)
-          runOnUiThread {
-            buttonCancel.visibility = View.VISIBLE
-          }
+      override fun onAnimationStart(animation: Animator?) {
+        super.onAnimationStart(animation)
+        runOnUiThread {
+          buttonCancel.visibility = View.VISIBLE
         }
+      }
 
-        override fun onAnimationEnd(animation: Animator?) {
-          super.onAnimationEnd(animation)
-          runOnUiThread {
-            buttonCancel.visibility = View.INVISIBLE
-          }
+      override fun onAnimationEnd(animation: Animator?) {
+        super.onAnimationEnd(animation)
+        runOnUiThread {
+          buttonCancel.visibility = View.INVISIBLE
         }
+      }
 
-        override fun onAnimationCancel(animation: Animator?) {
-          super.onAnimationCancel(animation)
-          runOnUiThread {
-            buttonCancel.visibility = View.INVISIBLE
-          }
+      override fun onAnimationCancel(animation: Animator?) {
+        super.onAnimationCancel(animation)
+        runOnUiThread {
+          buttonCancel.visibility = View.INVISIBLE
         }
-      })
-    }
+      }
+    })
   }
 
   private fun playAnimation(itemId: Int) {
     stopAnimation()
-    when (itemId) {
-      R.id.menu_action_jump_to -> mapboxMap.setCamera(START_CAMERA_POSITION)
+    runningCancelableAnimator = when (itemId) {
+      R.id.menu_action_jump_to -> {
+        mapboxMap.setCamera(START_CAMERA_POSITION)
+        null
+      }
       R.id.menu_action_ease_to ->
         mapboxMap.easeTo(
           EASE_TO_TARGET_CAMERA_POSITION,
           prepareAnimationOptions(2000)
-        )?.let {
-          runningCancelableAnimator = it
-        }
+        )
       R.id.menu_action_fly_to ->
         mapboxMap.flyTo(
           EASE_TO_TARGET_CAMERA_POSITION,
           prepareAnimationOptions(2000)
-        )?.let {
-          runningCancelableAnimator = it
-        }
+        )
       R.id.menu_action_pitch_by ->
         mapboxMap.pitchBy(
           70.0,
           prepareAnimationOptions(2000)
-        )?.let {
-          runningCancelableAnimator = it
-        }
+        )
       R.id.menu_action_scale_by ->
         mapboxMap.scaleBy(
           15.0,
           ScreenCoordinate(10.0, 10.0),
           prepareAnimationOptions(2000)
-        )?.let {
-          runningCancelableAnimator = it
-        }
+        )
       R.id.menu_action_move_by ->
         mapboxMap.moveBy(
           ScreenCoordinate(500.0, 500.0),
           prepareAnimationOptions(3000)
-        )?.let {
-          runningCancelableAnimator = it
-        }
+        )
       R.id.menu_action_rotate_by ->
         mapboxMap.rotateBy(
           ScreenCoordinate(0.0, 0.0),
           ScreenCoordinate(500.0, 500.0),
           prepareAnimationOptions(7000)
-        )?.let {
-          runningCancelableAnimator = it
-        }
+        )
+      else -> null
     }
   }
 

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/CameraPredefinedAnimatorsActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/CameraPredefinedAnimatorsActivity.kt
@@ -1,5 +1,7 @@
 package com.mapbox.maps.testapp.examples
 
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -25,7 +27,7 @@ import com.mapbox.maps.plugin.animation.CameraAnimatorsFactory.Companion.DEFAULT
 import com.mapbox.maps.plugin.animation.MapAnimationOptions.Companion.mapAnimationOptions
 import com.mapbox.maps.plugin.animation.animator.CameraAnimator
 import com.mapbox.maps.testapp.R
-import kotlinx.android.synthetic.main.activity_dds_style_circles_categorically.*
+import kotlinx.android.synthetic.main.activity_camera_predefined_animators.*
 
 /**
  * Example of using predefined animators with camera animation system.
@@ -34,7 +36,9 @@ class CameraPredefinedAnimatorsActivity : AppCompatActivity() {
 
   private lateinit var mapboxMap: MapboxMap
   private lateinit var cameraAnimationsPlugin: CameraAnimationsPlugin
+
   private var currentAnimators: Array<CameraAnimator<Any>> = arrayOf()
+  private var runningCancelableAnimator: Cancelable? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -46,6 +50,9 @@ class CameraPredefinedAnimatorsActivity : AppCompatActivity() {
         mapboxMap.setCamera(START_CAMERA_POSITION)
       }
     )
+    buttonCancel.setOnClickListener {
+      runningCancelableAnimator?.cancel()
+    }
     initSpinner()
   }
 
@@ -132,48 +139,83 @@ class CameraPredefinedAnimatorsActivity : AppCompatActivity() {
     cameraAnimationsPlugin.unregisterAnimators(*currentAnimators)
   }
 
+  private fun prepareAnimationOptions(duration: Long): MapAnimationOptions {
+    return mapAnimationOptions {
+      duration(duration)
+      animatorListener(object : AnimatorListenerAdapter() {
+
+        override fun onAnimationStart(animation: Animator?) {
+          super.onAnimationStart(animation)
+          runOnUiThread {
+            buttonCancel.visibility = View.VISIBLE
+          }
+        }
+
+        override fun onAnimationEnd(animation: Animator?) {
+          super.onAnimationEnd(animation)
+          runOnUiThread {
+            buttonCancel.visibility = View.INVISIBLE
+          }
+        }
+
+        override fun onAnimationCancel(animation: Animator?) {
+          super.onAnimationCancel(animation)
+          runOnUiThread {
+            buttonCancel.visibility = View.INVISIBLE
+          }
+        }
+      })
+    }
+  }
+
   private fun playAnimation(itemId: Int) {
     stopAnimation()
     when (itemId) {
       R.id.menu_action_jump_to -> mapboxMap.setCamera(START_CAMERA_POSITION)
-      R.id.menu_action_ease_to -> mapboxMap.easeTo(
-        EASE_TO_TARGET_CAMERA_POSITION,
-        mapAnimationOptions {
-          duration(2000)
+      R.id.menu_action_ease_to ->
+        mapboxMap.easeTo(
+          EASE_TO_TARGET_CAMERA_POSITION,
+          prepareAnimationOptions(2000)
+        )?.let {
+          runningCancelableAnimator = it
         }
-      )
-      R.id.menu_action_fly_to -> mapboxMap.flyTo(
-        EASE_TO_TARGET_CAMERA_POSITION,
-        mapAnimationOptions {
-          duration(2000)
+      R.id.menu_action_fly_to ->
+        mapboxMap.flyTo(
+          EASE_TO_TARGET_CAMERA_POSITION,
+          prepareAnimationOptions(2000)
+        )?.let {
+          runningCancelableAnimator = it
         }
-      )
-      R.id.menu_action_pitch_by -> mapboxMap.pitchBy(
-        70.0,
-        mapAnimationOptions {
-          duration(2000)
+      R.id.menu_action_pitch_by ->
+        mapboxMap.pitchBy(
+          70.0,
+          prepareAnimationOptions(2000)
+        )?.let {
+          runningCancelableAnimator = it
         }
-      )
-      R.id.menu_action_scale_by -> mapboxMap.scaleBy(
-        15.0,
-        ScreenCoordinate(10.0, 10.0),
-        mapAnimationOptions {
-          duration(2000)
+      R.id.menu_action_scale_by ->
+        mapboxMap.scaleBy(
+          15.0,
+          ScreenCoordinate(10.0, 10.0),
+          prepareAnimationOptions(2000)
+        )?.let {
+          runningCancelableAnimator = it
         }
-      )
-      R.id.menu_action_move_by -> mapboxMap.moveBy(
-        ScreenCoordinate(500.0, 500.0),
-        mapAnimationOptions {
-          duration(3000)
+      R.id.menu_action_move_by ->
+        mapboxMap.moveBy(
+          ScreenCoordinate(500.0, 500.0),
+          prepareAnimationOptions(3000)
+        )?.let {
+          runningCancelableAnimator = it
         }
-      )
-      R.id.menu_action_rotate_by -> mapboxMap.rotateBy(
-        ScreenCoordinate(0.0, 0.0),
-        ScreenCoordinate(500.0, 500.0),
-        mapAnimationOptions {
-          duration(7000)
+      R.id.menu_action_rotate_by ->
+        mapboxMap.rotateBy(
+          ScreenCoordinate(0.0, 0.0),
+          ScreenCoordinate(500.0, 500.0),
+          prepareAnimationOptions(7000)
+        )?.let {
+          runningCancelableAnimator = it
         }
-      )
     }
   }
 

--- a/app/src/main/res/layout/activity_camera_predefined_animators.xml
+++ b/app/src/main/res/layout/activity_camera_predefined_animators.xml
@@ -32,7 +32,7 @@
         android:layout_marginEnd="50dp"
         android:layout_marginBottom="20dp"
         android:padding="10dp"
-        android:text="Cancel animation"
+        android:text="@string/cancel_animation"
         android:textSize="18sp"
         app:layout_constraintBottom_toTopOf="@id/spinnerView"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_camera_predefined_animators.xml
+++ b/app/src/main/res/layout/activity_camera_predefined_animators.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/constraint_layout"
     android:layout_width="match_parent"
@@ -11,18 +10,31 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@id/spinnerView"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatSpinner
         android:id="@+id/spinnerView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:theme="@style/CameraPredefinedAnimationsActivityTheme"
         android:entries="@array/interpolators_array"
+        android:theme="@style/CameraPredefinedAnimationsActivityTheme"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/buttonCancel"
+        android:visibility="invisible"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="50dp"
+        android:layout_marginBottom="20dp"
+        android:padding="10dp"
+        android:text="Cancel animation"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toTopOf="@id/spinnerView"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="menu_animator_pitch_by">Pitch By</string>
     <string name="menu_animator_scale_by">Scale By</string>
     <string name="menu_animator_rotate_by">Rotate By</string>
+    <string name="cancel_animation">Cancel animation</string>
 
     <!--Marker strings for DirectionsActivity activity-->
     <string name="snaking_directions_activity_error">Direction route retrieval failed</string>

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -557,12 +557,14 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
    *
    * @param cameraOptions The camera options to ease to
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   override fun easeTo(
     cameraOptions: CameraOptions,
     animationOptions: MapAnimationOptions?
-  ) {
-    startHighLevelAnimation(
+  ): Cancelable {
+    return startHighLevelAnimation(
       cameraAnimationsFactory.getEaseTo(cameraOptions),
       animationOptions
     )
@@ -573,12 +575,14 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
    *
    * @param screenCoordinate The screen coordinate distance to move by
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   override fun moveBy(
     screenCoordinate: ScreenCoordinate,
     animationOptions: MapAnimationOptions?
-  ) {
-    startHighLevelAnimation(
+  ): Cancelable {
+    return startHighLevelAnimation(
       cameraAnimationsFactory.getMoveBy(screenCoordinate),
       animationOptions
     )
@@ -590,13 +594,15 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
    * @param amount The amount to scale by
    * @param screenCoordinate The optional focal point to scale on
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   override fun scaleBy(
     amount: Double,
     screenCoordinate: ScreenCoordinate?,
     animationOptions: MapAnimationOptions?
-  ) {
-    startHighLevelAnimation(
+  ): Cancelable {
+    return startHighLevelAnimation(
       cameraAnimationsFactory.getScaleBy(amount, screenCoordinate),
       animationOptions
     )
@@ -607,6 +613,8 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
    *
    * @param amount The amount to scale by
    * @param currentZoom The current zoom value
+   *
+   * @return [Cancelable] animator set object.
    */
   override fun calculateScaleBy(amount: Double, currentZoom: Double): Double =
     CameraTransform.calculateScaleBy(amount, currentZoom)
@@ -617,13 +625,15 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
    * @param first The first pointer to rotate on
    * @param second The second pointer to rotate on
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   override fun rotateBy(
     first: ScreenCoordinate,
     second: ScreenCoordinate,
     animationOptions: MapAnimationOptions?
-  ) {
-    startHighLevelAnimation(
+  ): Cancelable {
+    return startHighLevelAnimation(
       cameraAnimationsFactory.getRotateBy(first, second),
       animationOptions
     )
@@ -634,12 +644,14 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
    *
    * @param pitch The amount to pitch by
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   override fun pitchBy(
     pitch: Double,
     animationOptions: MapAnimationOptions?
-  ) {
-    startHighLevelAnimation(
+  ): Cancelable {
+    return startHighLevelAnimation(
       cameraAnimationsFactory.getPitchBy(pitch),
       animationOptions
     )
@@ -657,12 +669,14 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
    *
    * @param cameraOptions The camera options to fly to
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   override fun flyTo(
     cameraOptions: CameraOptions,
     animationOptions: MapAnimationOptions?
-  ) {
-    startHighLevelAnimation(
+  ): Cancelable {
+    return startHighLevelAnimation(
       cameraAnimationsFactory.getFlyTo(cameraOptions),
       animationOptions
     )
@@ -747,7 +761,7 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
   private fun startHighLevelAnimation(
     animators: Array<CameraAnimator<*>>,
     animationOptions: MapAnimationOptions?
-  ) {
+  ): Cancelable {
     animators.forEach {
       it.isInternal = true
       it.owner = animationOptions?.owner
@@ -775,7 +789,8 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
       }
       playTogether(*animators)
     }
-    highLevelAnimatorSet = HighLevelAnimatorSet(animationOptions?.owner, animatorSet).also {
+    return HighLevelAnimatorSet(animationOptions?.owner, animatorSet).also {
+      highLevelAnimatorSet = it
       it.animatorSet.start()
     }
   }
@@ -803,11 +818,13 @@ fun MapPluginProviderDelegate.getCameraAnimationsPlugin(): CameraAnimationsPlugi
  *
  * @param cameraOptions The camera options to ease to
  * @param animationOptions Transition options (animation duration, listeners etc)
+ *
+ * @return [Cancelable] animator set object or null if associated map object was garbage collected.
  */
 fun MapPluginExtensionsDelegate.easeTo(
   cameraOptions: CameraOptions,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { easeTo(cameraOptions, animationOptions) }
+) = cameraAnimationsPlugin { easeTo(cameraOptions, animationOptions) } as Cancelable?
 
 /**
  * Extension flyTo() function for [MapPluginExtensionsDelegate]
@@ -815,11 +832,13 @@ fun MapPluginExtensionsDelegate.easeTo(
  *
  * @param cameraOptions The camera options to fly to
  * @param animationOptions Transition options (animation duration, listeners etc)
+ *
+ * @return [Cancelable] animator set object or null if associated map object was garbage collected.
  */
 fun MapPluginExtensionsDelegate.flyTo(
   cameraOptions: CameraOptions,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { flyTo(cameraOptions, animationOptions) }
+) = cameraAnimationsPlugin { flyTo(cameraOptions, animationOptions) } as Cancelable?
 
 /**
  * Extension pitchBy() function for [MapPluginExtensionsDelegate]
@@ -827,11 +846,13 @@ fun MapPluginExtensionsDelegate.flyTo(
  *
  * @param pitch The amount to pitch by
  * @param animationOptions Transition options (animation duration, listeners etc)
+ *
+ * @return [Cancelable] animator set object or null if associated map object was garbage collected.
  */
 fun MapPluginExtensionsDelegate.pitchBy(
   pitch: Double,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { pitchBy(pitch, animationOptions) }
+) = cameraAnimationsPlugin { pitchBy(pitch, animationOptions) } as Cancelable?
 
 /**
  * Extension scaleBy() function for [MapPluginExtensionsDelegate]
@@ -840,12 +861,14 @@ fun MapPluginExtensionsDelegate.pitchBy(
  * @param amount The amount to scale by
  * @param screenCoordinate The optional focal point to scale on
  * @param animationOptions Transition options (animation duration, listeners etc)
+ *
+ * @return [Cancelable] animator set object or null if associated map object was garbage collected.
  */
 fun MapPluginExtensionsDelegate.scaleBy(
   amount: Double,
   screenCoordinate: ScreenCoordinate?,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { scaleBy(amount, screenCoordinate, animationOptions) }
+) = cameraAnimationsPlugin { scaleBy(amount, screenCoordinate, animationOptions) } as Cancelable?
 
 /**
  * Extension moveBy() function for [MapPluginExtensionsDelegate]
@@ -853,11 +876,13 @@ fun MapPluginExtensionsDelegate.scaleBy(
  *
  * @param screenCoordinate The screen coordinate distance to move by
  * @param animationOptions Transition options (animation duration, listeners etc)
+ *
+ * @return [Cancelable] animator set object or null if associated map object was garbage collected.
  */
 fun MapPluginExtensionsDelegate.moveBy(
   screenCoordinate: ScreenCoordinate,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { moveBy(screenCoordinate, animationOptions) }
+) = cameraAnimationsPlugin { moveBy(screenCoordinate, animationOptions) } as Cancelable?
 
 /**
  * Extension rotateBy() function for [MapPluginExtensionsDelegate]
@@ -866,9 +891,11 @@ fun MapPluginExtensionsDelegate.moveBy(
  * @param first The first pointer to rotate on
  * @param second The second pointer to rotate on
  * @param animationOptions Transition options (animation duration, listeners etc)
+ *
+ * @return [Cancelable] animator set object or null if associated map object was garbage collected.
  */
 fun MapPluginExtensionsDelegate.rotateBy(
   first: ScreenCoordinate,
   second: ScreenCoordinate,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { rotateBy(first, second, animationOptions) }
+) = cameraAnimationsPlugin { rotateBy(first, second, animationOptions) } as Cancelable?

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -563,12 +563,10 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
   override fun easeTo(
     cameraOptions: CameraOptions,
     animationOptions: MapAnimationOptions?
-  ): Cancelable {
-    return startHighLevelAnimation(
-      cameraAnimationsFactory.getEaseTo(cameraOptions),
-      animationOptions
-    )
-  }
+  ) = startHighLevelAnimation(
+    cameraAnimationsFactory.getEaseTo(cameraOptions),
+    animationOptions
+  )
 
   /**
    * Move the map by a given screen coordinate with optional animation.
@@ -581,12 +579,10 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
   override fun moveBy(
     screenCoordinate: ScreenCoordinate,
     animationOptions: MapAnimationOptions?
-  ): Cancelable {
-    return startHighLevelAnimation(
-      cameraAnimationsFactory.getMoveBy(screenCoordinate),
-      animationOptions
-    )
-  }
+  ) = startHighLevelAnimation(
+    cameraAnimationsFactory.getMoveBy(screenCoordinate),
+    animationOptions
+  )
 
   /**
    * Scale the map by with optional animation.
@@ -601,12 +597,10 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     amount: Double,
     screenCoordinate: ScreenCoordinate?,
     animationOptions: MapAnimationOptions?
-  ): Cancelable {
-    return startHighLevelAnimation(
-      cameraAnimationsFactory.getScaleBy(amount, screenCoordinate),
-      animationOptions
-    )
-  }
+  ) = startHighLevelAnimation(
+    cameraAnimationsFactory.getScaleBy(amount, screenCoordinate),
+    animationOptions
+  )
 
   /**
    * Calculate target zoom by applying scale
@@ -632,12 +626,10 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     first: ScreenCoordinate,
     second: ScreenCoordinate,
     animationOptions: MapAnimationOptions?
-  ): Cancelable {
-    return startHighLevelAnimation(
-      cameraAnimationsFactory.getRotateBy(first, second),
-      animationOptions
-    )
-  }
+  ) = startHighLevelAnimation(
+    cameraAnimationsFactory.getRotateBy(first, second),
+    animationOptions
+  )
 
   /**
    * Pitch the map by with optional animation.
@@ -650,12 +642,10 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
   override fun pitchBy(
     pitch: Double,
     animationOptions: MapAnimationOptions?
-  ): Cancelable {
-    return startHighLevelAnimation(
-      cameraAnimationsFactory.getPitchBy(pitch),
-      animationOptions
-    )
-  }
+  ) = startHighLevelAnimation(
+    cameraAnimationsFactory.getPitchBy(pitch),
+    animationOptions
+  )
 
   /**
    * Fly the map camera to a given camera options.
@@ -675,12 +665,10 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
   override fun flyTo(
     cameraOptions: CameraOptions,
     animationOptions: MapAnimationOptions?
-  ): Cancelable {
-    return startHighLevelAnimation(
-      cameraAnimationsFactory.getFlyTo(cameraOptions),
-      animationOptions
-    )
-  }
+  ) = startHighLevelAnimation(
+    cameraAnimationsFactory.getFlyTo(cameraOptions),
+    animationOptions
+  )
 
   override fun createZoomAnimator(
     options: CameraAnimatorOptions<Double>,
@@ -824,7 +812,7 @@ fun MapPluginProviderDelegate.getCameraAnimationsPlugin(): CameraAnimationsPlugi
 fun MapPluginExtensionsDelegate.easeTo(
   cameraOptions: CameraOptions,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { easeTo(cameraOptions, animationOptions) } as Cancelable?
+) = cameraAnimationsPlugin { easeTo(cameraOptions, animationOptions) } as Cancelable
 
 /**
  * Extension flyTo() function for [MapPluginExtensionsDelegate]
@@ -838,7 +826,7 @@ fun MapPluginExtensionsDelegate.easeTo(
 fun MapPluginExtensionsDelegate.flyTo(
   cameraOptions: CameraOptions,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { flyTo(cameraOptions, animationOptions) } as Cancelable?
+) = cameraAnimationsPlugin { flyTo(cameraOptions, animationOptions) } as Cancelable
 
 /**
  * Extension pitchBy() function for [MapPluginExtensionsDelegate]
@@ -852,7 +840,7 @@ fun MapPluginExtensionsDelegate.flyTo(
 fun MapPluginExtensionsDelegate.pitchBy(
   pitch: Double,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { pitchBy(pitch, animationOptions) } as Cancelable?
+) = cameraAnimationsPlugin { pitchBy(pitch, animationOptions) } as Cancelable
 
 /**
  * Extension scaleBy() function for [MapPluginExtensionsDelegate]
@@ -868,7 +856,7 @@ fun MapPluginExtensionsDelegate.scaleBy(
   amount: Double,
   screenCoordinate: ScreenCoordinate?,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { scaleBy(amount, screenCoordinate, animationOptions) } as Cancelable?
+) = cameraAnimationsPlugin { scaleBy(amount, screenCoordinate, animationOptions) } as Cancelable
 
 /**
  * Extension moveBy() function for [MapPluginExtensionsDelegate]
@@ -882,7 +870,7 @@ fun MapPluginExtensionsDelegate.scaleBy(
 fun MapPluginExtensionsDelegate.moveBy(
   screenCoordinate: ScreenCoordinate,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { moveBy(screenCoordinate, animationOptions) } as Cancelable?
+) = cameraAnimationsPlugin { moveBy(screenCoordinate, animationOptions) } as Cancelable
 
 /**
  * Extension rotateBy() function for [MapPluginExtensionsDelegate]
@@ -898,4 +886,4 @@ fun MapPluginExtensionsDelegate.rotateBy(
   first: ScreenCoordinate,
   second: ScreenCoordinate,
   animationOptions: MapAnimationOptions? = null
-) = cameraAnimationsPlugin { rotateBy(first, second, animationOptions) } as Cancelable?
+) = cameraAnimationsPlugin { rotateBy(first, second, animationOptions) } as Cancelable

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/HighLevelAnimatorSet.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/HighLevelAnimatorSet.kt
@@ -5,4 +5,9 @@ import android.animation.AnimatorSet
 internal data class HighLevelAnimatorSet(
   val owner: String?,
   val animatorSet: AnimatorSet
-)
+) : Cancelable {
+
+  override fun cancel() {
+    animatorSet.cancel()
+  }
+}

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -840,6 +840,27 @@ class CameraAnimationsPluginImplTest {
   }
 
   @Test
+  fun cancelStartedHighLevelAnimation() {
+    val listener = CameraAnimatorListener()
+    shadowOf(getMainLooper()).pause()
+    val cancelable = cameraAnimationsPluginImpl.flyTo(
+      CameraOptions.Builder()
+        .center(Point.fromLngLat(VALUE, VALUE))
+        .bearing(VALUE)
+        .build(),
+      mapAnimationOptions {
+        duration(50L)
+        animatorListener(listener)
+      }
+    )
+    cancelable.cancel()
+    shadowOf(getMainLooper()).idle()
+    // expecting 1 (and not 2) because we register 1 high-level animator listener
+    assertEquals(1, listener.startedCount)
+    assertEquals(1, listener.canceledCount)
+  }
+
+  @Test
   fun anchorTest() {
     shadowOf(getMainLooper()).pause()
     val anchor = ScreenCoordinate(7.0, 7.0)

--- a/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
+++ b/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
@@ -26,7 +26,7 @@ class CompassViewPluginTest {
   private val fadeAnimator = mockk<ValueAnimator>(relaxUnitFun = true)
   private val delegateProvider = mockk<MapDelegateProvider>()
   private val mapCameraDelegate = mockk<MapCameraDelegate>(relaxUnitFun = true)
-  private val animatePlugin = mockk<CameraAnimationsPlugin>(relaxUnitFun = true)
+  private val animatePlugin = mockk<CameraAnimationsPlugin>(relaxed = true)
   private lateinit var fadeAnimatorEndListener: Animator.AnimatorListener
   private lateinit var fadeAnimatorUpdateListener: ValueAnimator.AnimatorUpdateListener
 

--- a/plugin-location/src/test/java/com/mapbox/maps/plugin/location/LocationCameraControllerTest.kt
+++ b/plugin-location/src/test/java/com/mapbox/maps/plugin/location/LocationCameraControllerTest.kt
@@ -11,6 +11,7 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.plugin.PLUGIN_CAMERA_ANIMATIONS_CLASS_NAME
 import com.mapbox.maps.plugin.PLUGIN_GESTURE_CLASS_NAME
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.Cancelable
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
@@ -492,8 +493,10 @@ internal class LocationCameraControllerTest {
 
     val listener: OnLocationCameraTransitionListener = mockk(relaxed = true)
     val location: Location = mockk(relaxed = true)
+    val cancelable = mockk<Cancelable>()
     every { animationPlugin.flyTo(any(), any()) } answers {
       listener.onLocationCameraTransitionFinished(CameraMode.TRACKING)
+      cancelable
     }
     locationCameraController.setCameraMode(
       CameraMode.TRACKING,
@@ -532,10 +535,12 @@ internal class LocationCameraControllerTest {
       null,
       listener
     )
+    val cancelable = mockk<Cancelable>()
     every {
       animationPlugin.flyTo(any(), any())
     } answers {
       listener.onLocationCameraTransitionFinished(CameraMode.TRACKING_GPS_NORTH)
+      cancelable
     }
     locationCameraController.setCameraMode(
       CameraMode.TRACKING_GPS_NORTH,
@@ -574,10 +579,12 @@ internal class LocationCameraControllerTest {
       null,
       listener
     )
+    val cancelable = mockk<Cancelable>()
     every {
       animationPlugin.flyTo(any(), any())
     } answers {
       listener.onLocationCameraTransitionFinished(CameraMode.TRACKING)
+      cancelable
     }
     assertEquals(CameraMode.TRACKING, locationCameraController.cameraMode)
     locationCameraController.setCameraMode(
@@ -610,8 +617,10 @@ internal class LocationCameraControllerTest {
     val listener: OnLocationCameraTransitionListener = mockk(relaxed = true)
     val location: Location = mockk(relaxed = true)
 
+    val cancelable = mockk<Cancelable>()
     every { animationPlugin.flyTo(any(), any()) } answers {
       listener.onLocationCameraTransitionCanceled(CameraMode.TRACKING)
+      cancelable
     }
 
     locationCameraController.setCameraMode(
@@ -635,8 +644,9 @@ internal class LocationCameraControllerTest {
         0.0
       )
     ).bearing(0.0).build()
+    val cancelable = mockk<Cancelable>()
     every { projectionDelegate.getMetersPerPixelAtLatitude(any()) } returns 1000.0
-    every { animationPlugin.flyTo(any(), any()) } returns Unit
+    every { animationPlugin.flyTo(any(), any()) } returns cancelable
     locationCameraController.initializeOptions(options)
     locationCameraController.setEnabled(true)
 
@@ -727,7 +737,8 @@ internal class LocationCameraControllerTest {
       )
     ).bearing(0.0).build()
     every { projectionDelegate.getMetersPerPixelAtLatitude(any()) } returns 1000.0
-    every { animationPlugin.flyTo(any(), any()) } returns Unit
+    val cancelable = mockk<Cancelable>()
+    every { animationPlugin.flyTo(any(), any()) } returns cancelable
     locationCameraController.initializeOptions(options)
     locationCameraController.setEnabled(true)
 
@@ -856,9 +867,10 @@ internal class LocationCameraControllerTest {
       )
     ).bearing(0.0).build()
     every { projectionDelegate.getMetersPerPixelAtLatitude(any()) } returns 1000.0
+    val cancelable = mockk<Cancelable>()
     every {
       animationPlugin.flyTo(any(), any())
-    } returns Unit
+    } returns cancelable
     locationCameraController.initializeOptions(options)
     locationCameraController.setEnabled(true)
 

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
@@ -31,11 +31,13 @@ interface CameraAnimationsPlugin : MapPlugin {
    *
    * @param cameraOptions The camera options to ease to
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   fun easeTo(
     cameraOptions: CameraOptions,
     animationOptions: MapAnimationOptions? = null
-  )
+  ): Cancelable
 
   /**
    * Scale the map by with optional animation.
@@ -43,23 +45,27 @@ interface CameraAnimationsPlugin : MapPlugin {
    * @param amount The amount to scale by
    * @param screenCoordinate The optional focal point to scale on
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   fun scaleBy(
     amount: Double,
     screenCoordinate: ScreenCoordinate?,
     animationOptions: MapAnimationOptions? = null
-  )
+  ): Cancelable
 
   /**
    * Move the map by a given screen coordinate with optional animation.
    *
    * @param screenCoordinate The screen coordinate distance to move by
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   fun moveBy(
     screenCoordinate: ScreenCoordinate,
     animationOptions: MapAnimationOptions? = null
-  )
+  ): Cancelable
 
   /**
    * Rotate the map by with optional animation.
@@ -67,23 +73,27 @@ interface CameraAnimationsPlugin : MapPlugin {
    * @param first The first pointer to rotate on
    * @param second The second pointer to rotate on
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   fun rotateBy(
     first: ScreenCoordinate,
     second: ScreenCoordinate,
     animationOptions: MapAnimationOptions? = null
-  )
+  ): Cancelable
 
   /**
    * Pitch the map by with optional animation.
    *
    * @param pitch The amount to pitch by
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   fun pitchBy(
     pitch: Double,
     animationOptions: MapAnimationOptions? = null
-  )
+  ): Cancelable
 
   /**
    * Fly the map camera to a given camera options.
@@ -99,11 +109,13 @@ interface CameraAnimationsPlugin : MapPlugin {
    *
    * @param cameraOptions The camera options to fly to
    * @param animationOptions Transition options (animation duration, listeners etc)
+   *
+   * @return [Cancelable] animator set object.
    */
   fun flyTo(
     cameraOptions: CameraOptions,
     animationOptions: MapAnimationOptions? = null
-  )
+  ): Cancelable
 
   /**
    * Create CameraZoomAnimator

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/Cancelable.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/Cancelable.kt
@@ -1,0 +1,13 @@
+package com.mapbox.maps.plugin.animation
+
+/**
+ * Interface describing cancelable animation set for high-level functions
+ * like flyTo, easeTo etc.
+ */
+fun interface Cancelable {
+
+  /**
+   * Cancel running animation set.
+   */
+  fun cancel()
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[animation] High-level animations return cancelable interface</changelog>`.

### Summary of changes

High-level animation functions like `flyTo`, `easeTo` etc now return `Cancelable` interface allowing to cancel that high-level animation if needed.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->