### PR TITLE
Remove the prefix for tag name in update-android-docs.sh

### DIFF
--- a/scripts/update-android-docs.sh
+++ b/scripts/update-android-docs.sh
@@ -57,6 +57,10 @@ if [ -z "$MAPS_SDK_VERSION" ]; then
   exit 1
 fi
 
+#Split version name to remove the "android-v" prefix
+array=(`echo $MAPS_SDK_VERSION | tr 'v' ' '` )
+MAPS_SDK_VERSION=${array[1]}
+
 function generate_docs() {
   make dokka-html || dokka_result=1
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)
The previous script for auto-generating docs would use the tag name directly, which created a wrong dir for docs and need to be updated for[ beta.17](https://github.com/mapbox/mapbox-maps-android/pull/264).
This pr removes the "android-v" prefix from tag name to fix this issue.
<!--
If this PR introduces user-facing changes, please note them here.
-->