### PR TITLE
Fix the MapOptions and ResourceOptions default values.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
@@ -34,6 +34,8 @@ class MapViewCustomizationActivity : AppCompatActivity() {
       .glyphsRasterizationOptions(
         GlyphsRasterizationOptions.Builder()
           .rasterizationMode(GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY)
+          // Font family is required when the GlyphsRasterizationMode is set to IDEOGRAPHS_RASTERIZED_LOCALLY or ALL_GLYPHS_RASTERIZED_LOCALLY
+          .fontFamily("sans-serif")
           .build()
       )
       .build()

--- a/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
@@ -49,9 +49,11 @@ data class MapInitOptions constructor(
     fun getDefaultMapOptions(context: Context): MapOptions = MapOptions.Builder()
       .glyphsRasterizationOptions(
         GlyphsRasterizationOptions.Builder()
-          .rasterizationMode(GlyphsRasterizationMode.ALL_GLYPHS_RASTERIZED_LOCALLY)
+          .rasterizationMode(GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY)
           .build()
-      ).pixelRatio(context.resources.displayMetrics.density)
+      )
+      .pixelRatio(context.resources.displayMetrics.density)
+      .constrainMode(ConstrainMode.HEIGHT_ONLY)
       .build()
   }
 }

--- a/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
@@ -39,7 +39,7 @@ data class MapInitOptions constructor(
       .accessToken(CredentialsManager.default.getAccessToken(context))
       .cachePath("${context.filesDir.absolutePath}/$DATABASE_NAME")
       .assetPath(context.filesDir.absolutePath)
-      .cacheSize(50_000_000) // 50 mb
+      .cacheSize(50_000_000L) // 50 mb
       .build()
 
     /**
@@ -50,10 +50,15 @@ data class MapInitOptions constructor(
       .glyphsRasterizationOptions(
         GlyphsRasterizationOptions.Builder()
           .rasterizationMode(GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY)
+          .fontFamily(FontUtils.extractValidFont(null))
           .build()
       )
       .pixelRatio(context.resources.displayMetrics.density)
       .constrainMode(ConstrainMode.HEIGHT_ONLY)
+      .contextMode(ContextMode.UNIQUE)
+      .orientation(NorthOrientation.UPWARDS)
+      .viewportMode(ViewportMode.DEFAULT)
+      .crossSourceCollisions(true)
       .build()
   }
 }

--- a/sdk/src/main/java/com/mapbox/maps/ResourcesAttributeParser.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ResourcesAttributeParser.kt
@@ -3,6 +3,7 @@ package com.mapbox.maps
 import android.content.Context
 import android.content.res.TypedArray
 import android.util.AttributeSet
+import com.mapbox.common.TileStore
 
 /**
  * Utility class for parsing [AttributeSet] to [ResourcesSettings].
@@ -33,20 +34,20 @@ internal object ResourcesAttributeParser {
 
     val tileStorePathString =
       typedArray.getString(R.styleable.mapbox_MapView_mapbox_resourcesTileStorePath)
-        ?: "${context.filesDir.absolutePath}/maps_tile_store/"
 
-    return ResourceOptions.Builder()
+    val builder = ResourceOptions.Builder()
       .accessToken(accessTokenString)
       .baseURL(typedArray.getString(R.styleable.mapbox_MapView_mapbox_resourcesBaseUrl))
       .cachePath(cachePathString)
       .assetPath(assetPathString)
-      // https://github.com/mapbox/mapbox-maps-android/issues/939
-      // .tileStorePath(tileStorePathString)
       .cacheSize(
         typedArray.getFloat(
           R.styleable.mapbox_MapView_mapbox_resourcesCacheSize, 50_000_000f // 50 mb
         ).toLong()
       )
-      .build()
+    tileStorePathString?.let {
+      builder.tileStore(TileStore.getInstance(it))
+    }
+    return builder.build()
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
@@ -6,6 +6,7 @@ import com.mapbox.common.ShadowLogger
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,16 +50,33 @@ class MapInitOptionsTest {
   }
 
   @Test
-  fun defaultMapOption() {
+  fun defaultMapOptions() {
     val mapboxMapOptions = MapInitOptions(context)
     assertEquals(
       GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY,
       mapboxMapOptions.mapOptions.glyphsRasterizationOptions!!.rasterizationMode
     )
     assertEquals(
+      FontUtils.extractValidFont(null),
+      mapboxMapOptions.mapOptions.glyphsRasterizationOptions!!.fontFamily
+    )
+    assertEquals(1f, mapboxMapOptions.mapOptions.pixelRatio)
+    assertEquals(
       ConstrainMode.HEIGHT_ONLY,
       mapboxMapOptions.mapOptions.constrainMode
     )
-    assertEquals(1f, mapboxMapOptions.mapOptions.pixelRatio)
+    assertEquals(ContextMode.UNIQUE, mapboxMapOptions.mapOptions.contextMode)
+    assertEquals(NorthOrientation.UPWARDS, mapboxMapOptions.mapOptions.orientation)
+    assertEquals(ViewportMode.DEFAULT, mapboxMapOptions.mapOptions.viewportMode)
+    assertEquals(true, mapboxMapOptions.mapOptions.crossSourceCollisions)
+  }
+
+  @Test
+  fun defaultResourceOptions() {
+    val mapboxMapOptions = MapInitOptions(context)
+    assertEquals("token", mapboxMapOptions.resourceOptions.accessToken)
+    assertTrue(mapboxMapOptions.resourceOptions.cachePath!!.endsWith("foobar/mbx.db"))
+    assertTrue(mapboxMapOptions.resourceOptions.assetPath!!.endsWith("foobar"))
+    assertEquals(50_000_000L, mapboxMapOptions.resourceOptions.cacheSize)
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
@@ -52,10 +52,13 @@ class MapInitOptionsTest {
   fun defaultMapOption() {
     val mapboxMapOptions = MapInitOptions(context)
     assertEquals(
-      GlyphsRasterizationMode.ALL_GLYPHS_RASTERIZED_LOCALLY,
+      GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY,
       mapboxMapOptions.mapOptions.glyphsRasterizationOptions!!.rasterizationMode
     )
-
+    assertEquals(
+      ConstrainMode.HEIGHT_ONLY,
+      mapboxMapOptions.mapOptions.constrainMode
+    )
     assertEquals(1f, mapboxMapOptions.mapOptions.pixelRatio)
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes
This PR fixes a regression is introduced in https://github.com/mapbox/mapbox-maps-android/pull/269, the default rasterizationMode should be set to IDEOGRAPHS_RASTERIZED_LOCALLY, the default fontFamily should be set to "sans-serif" and constrainMode should be set to HEIGHT_ONLY.

The MapInitOptions default values are listed as below:

```
ResourceOptions:

cachePath: ${context.filesDir.absolutePath}/$DATABASE_NAME, where DATABASE_NAME = "mbx.db"
assetPath: context.filesDir.absolutePath
cacheSize: 50_000_000 (50 MB)

MapOptions:

glyphsRasterizationOptions: IDEOGRAPHS_RASTERIZED_LOCALLY
fontFamily: "sans-serif"
pixelRatio: context.resources.displayMetrics.density
constrainMode(ConstrainMode.HEIGHT_ONLY)
contextMode(ContextMode.UNIQUE)
orientation(NorthOrientation.UPWARDS)
viewportMode(ViewportMode.DEFAULT)
crossSourceCollisions(true)
```

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->