### PR TITLE
[gestures] Remove animator cancel listeners logic

### DIFF
--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -106,11 +106,6 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase {
               actionAfter?.invoke()
               immediateEaseInProcess = false
             }
-
-            override fun onAnimationCancel(animation: Animator?) {
-              actionAfter?.invoke()
-              immediateEaseInProcess = false
-            }
           })
         }
       )
@@ -792,11 +787,6 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase {
 
     anchorAnimator.addListener(
       object : AnimatorListenerAdapter() {
-        override fun onAnimationStart(animation: Animator) {}
-        override fun onAnimationCancel(animation: Animator) {
-          cameraAnimationsPlugin.anchor = rotateCachedAnchor
-          dispatchCameraIdle()
-        }
         override fun onAnimationEnd(animation: Animator) {
           cameraAnimationsPlugin.anchor = rotateCachedAnchor
           dispatchCameraIdle()
@@ -1060,13 +1050,6 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase {
 
     anchorAnimator.addListener(object : AnimatorListenerAdapter() {
 
-      override fun onAnimationStart(animation: Animator) {}
-
-      override fun onAnimationCancel(animation: Animator) {
-        cameraAnimationsPlugin.anchor = scaleCachedAnchor
-        dispatchCameraIdle()
-      }
-
       override fun onAnimationEnd(animation: Animator) {
         cameraAnimationsPlugin.anchor = scaleCachedAnchor
         dispatchCameraIdle()
@@ -1277,12 +1260,6 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase {
 
             override fun onAnimationEnd(animation: Animator?) {
               super.onAnimationEnd(animation)
-              flingInProcess = false
-              mapTransformDelegate.dragEnd()
-            }
-
-            override fun onAnimationCancel(animation: Animator?) {
-              super.onAnimationCancel(animation)
               flingInProcess = false
               mapTransformDelegate.dragEnd()
             }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[gestures] Remove animator cancel listeners logic duplicating end listeners logic.</changelog>`.

### Summary of changes

Remove animator cancel listeners logic because same logic is duplicated in `onAnimationEnd` callbacks. That means that if animator is cancelled end code will be executed twice.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->