### PR TITLE
[build] increase memory to avoid out-of-memory when generating dokka

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ VERSION_NAME=10.0.0-SNAPSHOT
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2024m -XX:MaxPermSize=512m
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=512m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
Increases allocate-able memory for the gradle build, this is needed for building dokka with all internal dependencies. 
See https://github.com/Kotlin/dokka/issues/1680 for similar issue. 