### PR TITLE
Request layout when updating ornaments margins

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -967,5 +967,17 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ExampleOverviewActivity" />
         </activity>
+        <activity
+            android:name=".examples.OrnamentMarginActivity"
+            android:description="@string/description_ornaments_margin"
+            android:exported="true"
+            android:label="@string/activity_ornaments">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_config" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".ExampleOverviewActivity" />
+        </activity>
     </application>
 </manifest>

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/OrnamentMarginActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/OrnamentMarginActivity.kt
@@ -1,0 +1,91 @@
+package com.mapbox.maps.testapp.examples
+
+import android.os.Bundle
+import android.view.Gravity
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.android.gestures.RotateGestureDetector
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.plugin.attribution.attribution
+import com.mapbox.maps.plugin.compass.compass
+import com.mapbox.maps.plugin.gestures.OnRotateListener
+import com.mapbox.maps.plugin.gestures.addOnRotateListener
+import com.mapbox.maps.plugin.logo.logo
+import com.mapbox.maps.plugin.scalebar.scalebar
+import com.mapbox.maps.testapp.R
+import kotlinx.android.synthetic.main.activity_simple_map.*
+
+/**
+ * Test activity to validate correct margin displacement of ornaments when the map rotates.
+ */
+class OrnamentMarginActivity : AppCompatActivity(), OnRotateListener {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_simple_map)
+    with(mapView.getMapboxMap()) {
+      mapView.attribution.position = Gravity.END or Gravity.BOTTOM
+      setCamera(
+        CameraOptions.Builder()
+          .center(Point.fromLngLat(23.760833, 61.498056))
+          .zoom(14.0)
+          .build()
+      )
+      addOnRotateListener(this@OrnamentMarginActivity)
+    }
+  }
+
+  override fun onRotate(detector: RotateGestureDetector) {
+    val bearing = mapView.getMapboxMap().getCameraOptions().bearing?.toFloat()!!
+    val margin = 2f * if (bearing <= 180f) bearing else 180f - (bearing % 180f)
+    with(mapView.logo) {
+      marginLeft = margin
+      marginBottom = margin
+      marginRight = margin
+      marginTop = margin
+    }
+    with(mapView.attribution) {
+      marginLeft = margin
+      marginBottom = margin
+      marginRight = margin
+      marginTop = margin
+    }
+    with(mapView.scalebar) {
+      marginLeft = margin
+      marginBottom = margin
+      marginRight = margin
+      marginTop = margin
+    }
+    with(mapView.compass) {
+      marginLeft = margin
+      marginBottom = margin
+      marginRight = margin
+      marginTop = margin
+    }
+  }
+
+  override fun onRotateEnd(detector: RotateGestureDetector) {
+  }
+
+  override fun onRotateBegin(detector: RotateGestureDetector) {
+  }
+
+  override fun onStart() {
+    super.onStart()
+    mapView.onStart()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView.onStop()
+  }
+
+  override fun onLowMemory() {
+    super.onLowMemory()
+    mapView.onLowMemory()
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    mapView.onDestroy()
+  }
+}

--- a/app/src/main/res/values/example_descriptions.xml
+++ b/app/src/main/res/values/example_descriptions.xml
@@ -76,4 +76,5 @@
     <string name="description_santa_catalina">Santa Catalina Walking Route</string>
     <string name="description_multiple_display">Display the map on a secondary display</string>
     <string name="description_map_view_customization">Customize your map view</string>
+    <string name="description_ornaments_margin">Update margins of ornaments when the map rotates</string>
 </resources>

--- a/app/src/main/res/values/example_titles.xml
+++ b/app/src/main/res/values/example_titles.xml
@@ -76,4 +76,5 @@
     <string name="activity_santa_catalina">Santa Catalina Island</string>
     <string name="activity_multiple_display">Multi display</string>
     <string name="activity_map_view_customization">Creating a map view</string>
+    <string name="activity_ornaments">Ornaments</string>
 </resources>

--- a/plugin-attribution/src/main/java/com/mapbox/maps/plugin/attribution/AttributionPluginImpl.kt
+++ b/plugin-attribution/src/main/java/com/mapbox/maps/plugin/attribution/AttributionPluginImpl.kt
@@ -35,6 +35,7 @@ open class AttributionViewPlugin(
       internalSettings.marginRight.toInt(),
       internalSettings.marginBottom.toInt()
     )
+    attributionView.requestLayout()
   }
 
   /**

--- a/plugin-attribution/src/test/java/com/mapbox/maps/plugin/attribution/AttributionViewPluginImplTest.kt
+++ b/plugin-attribution/src/test/java/com/mapbox/maps/plugin/attribution/AttributionViewPluginImplTest.kt
@@ -83,9 +83,10 @@ class AttributionViewPluginImplTest {
   @Test
   fun setAttributionMargins() {
     attributionPlugin.updateSettings {
-      marginLeft = 0f; marginTop = 5f; marginRight = 0f; marginBottom = 0f
+      marginLeft = 1f; marginTop = 2f; marginRight = 3f; marginBottom = 4f
     }
-    verify { attributionView.setAttributionMargins(0, 5, 0, 0) }
+    verify { attributionView.setAttributionMargins(1, 2, 3, 4) }
+    verify { attributionView.requestLayout() }
   }
 
   @Test

--- a/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewImpl.kt
+++ b/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewImpl.kt
@@ -115,7 +115,7 @@ open class CompassViewImpl : CompassView, AppCompatImageView {
    * @param bottom Margin to the bottom in pixel
    */
   override fun setCompassMargins(left: Int, top: Int, right: Int, bottom: Int) {
-    (layoutParams as FrameLayout.LayoutParams).setMargins(left, top, right, left)
+    (layoutParams as FrameLayout.LayoutParams).setMargins(left, top, right, bottom)
   }
 
   /**

--- a/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
+++ b/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
@@ -74,6 +74,7 @@ open class CompassViewPlugin(
       internalSettings.marginBottom.toInt()
     )
     update(mapCameraDelegate.getBearing())
+    compassView.requestLayout()
   }
 
   /**

--- a/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
+++ b/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
@@ -368,9 +368,10 @@ class CompassViewPluginTest {
   @Test
   fun setCompassMargins() {
     compassPlugin.updateSettings {
-      marginLeft = 0f; marginTop = 5f; marginRight = 0f; marginBottom = 0f
+      marginLeft = 1f; marginTop = 2f; marginRight = 3f; marginBottom = 4f
     }
-    verify { compassView.setCompassMargins(0, 5, 0, 0) }
+    verify { compassView.setCompassMargins(1, 2, 3, 4) }
+    verify { compassView.requestLayout() }
   }
 
   @Test

--- a/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewImpl.kt
+++ b/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewImpl.kt
@@ -91,7 +91,7 @@ class LogoViewImpl : LogoView, AppCompatImageView {
    * @param bottom Margin to the bottom in pixel
    */
   override fun setLogoMargins(left: Int, top: Int, right: Int, bottom: Int) {
-    (layoutParams as FrameLayout.LayoutParams).setMargins(left, top, right, left)
+    (layoutParams as FrameLayout.LayoutParams).setMargins(left, top, right, bottom)
   }
 
   internal fun injectPresenter(presenter: LogoPlugin) {

--- a/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewPlugin.kt
+++ b/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewPlugin.kt
@@ -30,6 +30,7 @@ open class LogoViewPlugin(
     )
     logoView.logoGravity = internalSettings.position
     logoView.logoEnabled = internalSettings.enabled
+    logoView.requestLayout()
   }
 
   /**

--- a/plugin-logo/src/test/java/com/mapbox/maps/plugin/logo/LogoViewImplPluginTest.kt
+++ b/plugin-logo/src/test/java/com/mapbox/maps/plugin/logo/LogoViewImplPluginTest.kt
@@ -69,12 +69,13 @@ class LogoViewImplPluginTest {
   @Test
   fun setLogoMarginsViaSettings() {
     logoPlugin.updateSettings {
-      marginLeft = 0f
-      marginTop = 5f
-      marginRight = 0f
-      marginBottom = 0f
+      marginLeft = 1f
+      marginTop = 2f
+      marginRight = 3f
+      marginBottom = 4f
     }
-    verify { logoView.setLogoMargins(0, 5, 0, 0) }
+    verify { logoView.setLogoMargins(1, 2, 3, 4) }
+    verify { logoView.requestLayout() }
   }
 
   @Test

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/attribution/AttributionView.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/attribution/AttributionView.kt
@@ -43,4 +43,11 @@ interface AttributionView {
    * Set an [View.OnClickListener] to AttributionView
    */
   fun setOnClickListener(listener: View.OnClickListener)
+
+  /**
+   * Call this when something has changed which has invalidated the
+   * layout of this view. This will schedule a layout pass of the view
+   * tree.
+   */
+  fun requestLayout()
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/compass/CompassView.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/compass/CompassView.kt
@@ -51,4 +51,11 @@ interface CompassView {
    * @param bottom Margin to the bottom in pixel
    */
   fun setCompassMargins(@Px left: Int, @Px top: Int, @Px right: Int, @Px bottom: Int)
+
+  /**
+   * Call this when something has changed which has invalidated the
+   * layout of this view. This will schedule a layout pass of the view
+   * tree.
+   */
+  fun requestLayout()
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/logo/LogoView.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/logo/LogoView.kt
@@ -28,4 +28,11 @@ interface LogoView {
    * @param bottom Margin to the bottom in pixel
    */
   fun setLogoMargins(@Px left: Int, @Px top: Int, @Px right: Int, @Px bottom: Int)
+
+  /**
+   * Call this when something has changed which has invalidated the
+   * layout of this view. This will schedule a layout pass of the view
+   * tree.
+   */
+  fun requestLayout()
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Request layout when updating ornaments margins, making updates immidiate</changelog>`.

### Summary of changes
 - adds an example to reproduce the user reported bug
 - makes sure we call requestLayout after we have set margins of an ornament
 - correct calling set margins correctly with the LTRB order

### User impact (optional)

Developers now can see margins of the ornaments updating automatically when they set the values (workaround could be to call request layout yourself on the MapView). 

![image](https://user-images.githubusercontent.com/2151639/116219123-8fb01700-a74b-11eb-89da-a88be0d16a7d.png)
