### PR TITLE
[sdk] remove temporary CustomMapInterface

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/CustomMapInterface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/CustomMapInterface.kt
@@ -1,6 +1,0 @@
-package com.mapbox.maps
-
-/**
- * Temporary interface wrapper around MapInterface, StyleManagerInterface and ObservableInterface
- */
-interface CustomMapInterface : MapInterface, StyleManagerInterface, ObservableInterface

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -24,7 +24,7 @@ class MapControllerTest {
 
   private val nativeObserver: NativeObserver = mockk(relaxUnitFun = true)
 
-  private val nativeMap: CustomMapInterface = mockk(relaxUnitFun = true)
+  private val nativeMap: MapInterface = mockk(relaxUnitFun = true)
 
   private lateinit var mapView: MapView
 

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -25,7 +25,7 @@ import java.lang.ref.WeakReference
 @LooperMode(LooperMode.Mode.PAUSED)
 class MapboxMapTest {
 
-  private val nativeMap: CustomMapInterface = mockk(relaxed = true)
+  private val nativeMap: MapInterface = mockk(relaxed = true)
   private val nativeObserver: NativeObserver = mockk(relaxed = true)
 
   private lateinit var mapboxMap: MapboxMap

--- a/sdk/src/test/java/com/mapbox/maps/StyleTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleTest.kt
@@ -14,7 +14,7 @@ import org.junit.Test
 class StyleTest {
 
   private lateinit var style: Style
-  private val nativeMap: CustomMapInterface = mockk(relaxed = true)
+  private val nativeMap: MapInterface = mockk(relaxed = true)
 
   @Before
   fun setUp() {


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Remove temporary CustomMapInterface used for testing, obsolete with having interface inheritance from upstream.</changelog>`.

### Summary of changes
Remove temporary CustomMapInterface used for testing, obsolete with having interface inheritance from upstream.

### User impact (optional)
CustomMapInterface has been removed from public API