### PR TITLE
Remove the exclude kotlin_module rule from package options.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,11 +27,6 @@ android {
     }
   }
 
-  // temporary config until https://github.com/mapbox/mapbox-base-android/issues/53 is resolved
-  packagingOptions {
-    exclude("META-INF/*.kotlin_module")
-  }
-
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -35,11 +35,6 @@ android {
       execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
   }
-
-  // temporary config until gl-native v10.0.0-beta.5
-  packagingOptions {
-    exclude("META-INF/*.kotlin_module")
-  }
 }
 
 dependencies {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix an issue that causes the extension functions not discoverable from downstream projects.</changelog>`.

### Summary of changes

Remove the exclude kotlin_module rule from package option, which caused some extension functions(observable extension functions) not discoverable from downstream projects.

Also tried to build a snapshot 10.0.0-beta.18-SNAPSHOT to verify the fix with downstream projects.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->