### PR TITLE
[sdk] rework style loading to avoid invoking previously set listeners

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -102,7 +102,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     }
     renderer.onStart()
     pluginRegistry.onStart()
-    if (!mapboxMap.isStyleLoadInited) {
+    if (!mapboxMap.isStyleLoadInitiated) {
       // Load the style in mapInitOptions if no style has loaded yet.
       mapInitOptions.styleUri?.let {
         mapboxMap.loadStyleUri(it)
@@ -125,6 +125,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   }
 
   override fun onDestroy() {
+    mapboxMap.onDestroy()
     nativeObserver.clearListeners()
     renderer.onDestroy()
     pluginRegistry.cleanup()

--- a/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
@@ -29,8 +29,6 @@ internal class NativeObserver(
   val onStyleImageMissingListeners = CopyOnWriteArrayList<OnStyleImageMissingListener>()
   val onStyleImageUnusedListeners = CopyOnWriteArrayList<OnStyleImageUnusedListener>()
 
-  val awaitingStyleGetters = mutableListOf<Style.OnStyleLoaded>()
-
   var observedEvents = CopyOnWriteArrayList<String>()
   //
   // Internal callbacks
@@ -337,8 +335,6 @@ internal class NativeObserver(
     onStyleDataLoadedListeners.clear()
     onStyleImageMissingListeners.clear()
     onStyleImageUnusedListeners.clear()
-
-    awaitingStyleGetters.clear()
   }
 
   companion object {

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -1,0 +1,78 @@
+package com.mapbox.maps
+
+import com.mapbox.common.Logger
+import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
+import com.mapbox.maps.plugin.delegates.listeners.OnStyleLoadedListener
+import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
+import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Class that listens to style error and load events
+ * and maintains and invokes user added listeners.
+ */
+internal class StyleObserver(
+  private val mapboxMap: MapboxMap,
+  private val nativeMap: WeakReference<MapInterface>,
+  private val nativeObserver: NativeObserver,
+  private val pixelRatio: Float
+) : OnStyleLoadedListener, OnMapLoadErrorListener {
+
+  private val awaitingStyleLoadListeners = CopyOnWriteArrayList<Style.OnStyleLoaded>()
+  private var awaitingStyleErrorListener: OnMapLoadErrorListener? = null
+
+  init {
+    nativeObserver.addOnStyleLoadedListener(this)
+    nativeObserver.addOnMapLoadErrorListener(this)
+  }
+
+  /**
+   * Clears previous added listeners and setup to receive callback for new style loaded or error events.
+   */
+  fun onNewStyleLoad(loadedListener: Style.OnStyleLoaded?, onMapLoadErrorListener: OnMapLoadErrorListener?) {
+    awaitingStyleLoadListeners.clear()
+    loadedListener?.let {
+      awaitingStyleLoadListeners.add(loadedListener)
+    }
+    awaitingStyleErrorListener = onMapLoadErrorListener
+  }
+
+  /**
+   * Add a style listener invoked when a new style loaded events occurs.
+   */
+  fun addOnStyleLoadListener(loadedListener: Style.OnStyleLoaded) {
+    awaitingStyleLoadListeners.add(loadedListener)
+  }
+
+  /**
+   * Invoked when a style has loaded
+   */
+  override fun onStyleLoaded() {
+    nativeMap.get()?.let {
+      mapboxMap.style = Style(it as StyleManagerInterface, pixelRatio)
+      val iterator = awaitingStyleLoadListeners.iterator()
+      while (iterator.hasNext()) {
+        iterator.next().onStyleLoaded(mapboxMap.style)
+      }
+      awaitingStyleLoadListeners.clear()
+    }
+    awaitingStyleErrorListener = null
+  }
+
+  override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
+    Logger.e(TAG, "OnMapLoadError: $mapLoadErrorType: $message")
+    awaitingStyleErrorListener?.onMapLoadError(mapLoadErrorType, message)
+    awaitingStyleLoadListeners.clear()
+  }
+
+  fun onDestroy() {
+    awaitingStyleLoadListeners.clear()
+    awaitingStyleErrorListener = null
+    nativeObserver.removeOnMapLoadErrorListener(this)
+    nativeObserver.removeOnStyleLoadedListener(this)
+  }
+
+  companion object {
+    const val TAG = "Mbgl-StyleObserver"
+  }
+}

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -65,8 +65,7 @@ class MapControllerTest {
 
     every { MapProvider.getMapboxMap(nativeMap, nativeObserver, 1.0f) } answers { mapboxMap }
     every { MapProvider.getMapPluginRegistry(any(), any(), any()) } returns pluginRegistry
-
-    every { mapboxMap.isStyleLoadInited } returns false
+    every { mapboxMap.isStyleLoadInitiated } returns false
     mapController =
       MapController(
         renderer,
@@ -89,7 +88,7 @@ class MapControllerTest {
 
   @Test
   fun onStartWithStyleLoaded() {
-    every { mapboxMap.isStyleLoadInited } returns true
+    every { mapboxMap.isStyleLoadInitiated } returns true
     mapController.onStart()
     verify(exactly = 0) { mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) }
   }

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -38,45 +38,40 @@ class MapboxMapTest {
   @Test
   fun loadStyleUri() {
     Shadows.shadowOf(Looper.getMainLooper()).pause()
-    assertFalse(mapboxMap.isStyleLoadInited)
+    assertFalse(mapboxMap.isStyleLoadInitiated)
     mapboxMap.loadStyleUri("foo")
     Shadows.shadowOf(Looper.getMainLooper()).idle()
-    verify { nativeObserver.addOnStyleDataLoadedListener(any()) }
     verify { nativeMap.styleURI = "foo" }
-    assertTrue(mapboxMap.isStyleLoadInited)
+    assertTrue(mapboxMap.isStyleLoadInitiated)
   }
 
   @Test
   fun loadStyleUriLambda() {
     Shadows.shadowOf(Looper.getMainLooper()).pause()
-    assertFalse(mapboxMap.isStyleLoadInited)
+    assertFalse(mapboxMap.isStyleLoadInitiated)
     mapboxMap.loadStyleUri("foo") {}
     Shadows.shadowOf(Looper.getMainLooper()).idle()
-    verify { nativeObserver.addOnStyleDataLoadedListener(any()) }
-    verify { nativeMap.styleURI = "foo" }
-    assertTrue(mapboxMap.isStyleLoadInited)
+    assertTrue(mapboxMap.isStyleLoadInitiated)
   }
 
   @Test
   fun loadStyleJSON() {
     Shadows.shadowOf(Looper.getMainLooper()).pause()
-    assertFalse(mapboxMap.isStyleLoadInited)
+    assertFalse(mapboxMap.isStyleLoadInitiated)
     mapboxMap.loadStyleJSON("foo")
     Shadows.shadowOf(Looper.getMainLooper()).idle()
-    verify { nativeObserver.addOnStyleDataLoadedListener(any()) }
     verify { nativeMap.styleJSON = "foo" }
-    assertTrue(mapboxMap.isStyleLoadInited)
+    assertTrue(mapboxMap.isStyleLoadInitiated)
   }
 
   @Test
   fun loadStyleJSONLambda() {
     Shadows.shadowOf(Looper.getMainLooper()).pause()
-    assertFalse(mapboxMap.isStyleLoadInited)
+    assertFalse(mapboxMap.isStyleLoadInitiated)
     mapboxMap.loadStyleJSON("foo") {}
     Shadows.shadowOf(Looper.getMainLooper()).idle()
-    verify { nativeObserver.addOnStyleDataLoadedListener(any()) }
     verify { nativeMap.styleJSON = "foo" }
-    assertTrue(mapboxMap.isStyleLoadInited)
+    assertTrue(mapboxMap.isStyleLoadInitiated)
   }
 
   @Test
@@ -86,11 +81,11 @@ class MapboxMapTest {
     val onMapLoadError = mockk<OnMapLoadErrorListener>()
     val onStyleLoadError = mockk<Style.OnStyleLoaded>()
     Shadows.shadowOf(Looper.getMainLooper()).pause()
-    assertFalse(mapboxMap.isStyleLoadInited)
+    assertFalse(mapboxMap.isStyleLoadInitiated)
     mapboxMap.loadStyle(styleExtension, onStyleLoadError, onMapLoadError)
     Shadows.shadowOf(Looper.getMainLooper()).idle()
     verify { nativeMap.styleURI = "foobar" }
-    assertTrue(mapboxMap.isStyleLoadInited)
+    assertTrue(mapboxMap.isStyleLoadInitiated)
   }
 
   @Test
@@ -98,21 +93,11 @@ class MapboxMapTest {
     val styleExtension = mockk<StyleContract.StyleExtension>()
     every { styleExtension.styleUri } returns "foobar"
     Shadows.shadowOf(Looper.getMainLooper()).pause()
-    assertFalse(mapboxMap.isStyleLoadInited)
+    assertFalse(mapboxMap.isStyleLoadInitiated)
     mapboxMap.loadStyle(styleExtension) {}
     Shadows.shadowOf(Looper.getMainLooper()).idle()
     verify { nativeMap.styleURI = "foobar" }
-    assertTrue(mapboxMap.isStyleLoadInited)
-  }
-
-  @Test
-  fun finishLoadingStyle() {
-    val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
-    val mapLoadError = mockk<OnMapLoadErrorListener>()
-    mapboxMap.onFinishLoadingStyle(styleLoadCallback, mapLoadError)
-    verify { styleLoadCallback.onStyleLoaded(any()) }
-    verify { nativeObserver.awaitingStyleGetters.clear() }
-    verify { mapboxMap.removeOnMapLoadErrorListener(mapLoadError) }
+    assertTrue(mapboxMap.isStyleLoadInitiated)
   }
 
   @Test
@@ -151,13 +136,6 @@ class MapboxMapTest {
   }
 
   @Test
-  fun getStyleWaitCallback() {
-    val styleLoadCallback = mockk<Style.OnStyleLoaded>()
-    mapboxMap.getStyle(styleLoadCallback)
-    verify { nativeObserver.awaitingStyleGetters.add(styleLoadCallback) }
-  }
-
-  @Test
   fun getStyleLoadedCallback() {
     val style = mockk<Style>()
     mapboxMap.style = style
@@ -165,16 +143,6 @@ class MapboxMapTest {
     val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     mapboxMap.getStyle(styleLoadCallback)
     verify { styleLoadCallback.onStyleLoaded(style) }
-  }
-
-  @Test
-  fun getStyleLoadedWaitCallback() {
-    val style = mockk<Style>()
-    mapboxMap.style = style
-    every { style.fullyLoaded } returns false
-    val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
-    mapboxMap.getStyle(styleLoadCallback)
-    verify { nativeObserver.awaitingStyleGetters.add(styleLoadCallback) }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
@@ -529,8 +529,6 @@ class NativeObserverTest {
     nativeObserver.onStyleImageUnusedListeners.add(mockk(relaxed = true))
     nativeObserver.onStyleDataLoadedListeners.add(mockk(relaxed = true))
 
-    nativeObserver.awaitingStyleGetters.add(mockk(relaxed = true))
-
     nativeObserver.clearListeners()
 
     assertTrue(nativeObserver.onCameraChangeListeners.isEmpty())
@@ -550,7 +548,5 @@ class NativeObserverTest {
     assertTrue(nativeObserver.onStyleImageMissingListeners.isEmpty())
     assertTrue(nativeObserver.onStyleImageUnusedListeners.isEmpty())
     assertTrue(nativeObserver.onStyleDataLoadedListeners.isEmpty())
-
-    assertTrue(nativeObserver.awaitingStyleGetters.isEmpty())
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -1,0 +1,117 @@
+package com.mapbox.maps
+
+import com.mapbox.common.ShadowLogger
+import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
+import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.lang.ref.WeakReference
+
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowLogger::class])
+class StyleObserverTest {
+
+  lateinit var map: WeakReference<MapInterface>
+
+  @Before
+  fun setUp() {
+    val mapInterface = mockk<MapInterface>()
+    map = WeakReference(mapInterface)
+  }
+
+  /**
+   * Verifies if the correct listeners are attached to NativeMapObserver when StyleObserver is created
+   */
+  @Test
+  fun onStyleObserverCreate() {
+    val nativeObserver = mockk<NativeObserver>(relaxed = true)
+    StyleObserver(mockk(), mockk(), nativeObserver, 1.0f)
+    verify { nativeObserver.addOnStyleLoadedListener(any()) }
+    verify { nativeObserver.addOnMapLoadErrorListener(any()) }
+  }
+
+  /**
+   * Verifies if the correct listeners are detached to NativeMapObserver when StyleObserver is destroyed
+   */
+  @Test
+  fun onStyleObserverDestroy() {
+    val nativeObserver = mockk<NativeObserver>(relaxed = true)
+    StyleObserver(mockk(), mockk(), nativeObserver, 1.0f).onDestroy()
+    verify { nativeObserver.removeOnStyleLoadedListener(any()) }
+    verify { nativeObserver.removeOnMapLoadErrorListener(any()) }
+  }
+
+  /**
+   * Verifies if the user provided OnStyleLoaded is called when style loading finishes
+   */
+  @Test
+  fun onStyleLoadSuccess() {
+    val styleObserver = StyleObserver(mockk(relaxed = true), map, mockk(relaxed = true), 1.0f)
+    val styleLoaded = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.onNewStyleLoad(styleLoaded, null)
+    styleObserver.onStyleLoaded()
+    verify { styleLoaded.onStyleLoaded(any()) }
+  }
+
+  /**
+   * Verifies if the multiple user provided OnStyleLoaded are called when style loading finishes
+   */
+  @Test
+  fun onStyleLoadSuccessMulti() {
+    val styleObserver = StyleObserver(mockk(relaxed = true), map, mockk(relaxed = true), 1.0f)
+    val styleLoaded = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.onNewStyleLoad(styleLoaded, null)
+    val styleLoaded2 = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.addOnStyleLoadListener(styleLoaded2)
+    styleObserver.onStyleLoaded()
+    verify { styleLoaded.onStyleLoaded(any()) }
+    verify { styleLoaded2.onStyleLoaded(any()) }
+  }
+
+  /**
+   * Verifies if the user provided OnStyleLoaded is not called called when a new style has been loaded
+   */
+  @Test
+  fun onStyleLoadSuccessNotCalled() {
+    val styleObserver = StyleObserver(mockk(relaxed = true), map, mockk(relaxed = true), 1.0f)
+    val styleLoadedFail = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.onNewStyleLoad(styleLoadedFail, null)
+    val styleLoadedSucces = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.onNewStyleLoad(styleLoadedSucces, null)
+    styleObserver.onStyleLoaded()
+    verify(exactly = 0) { styleLoadedFail.onStyleLoaded(any()) }
+    verify { styleLoadedSucces.onStyleLoaded(any()) }
+  }
+
+  /**
+   * Verifies if the user provided OnMapLoadErrorListener is called when the style has produced an error
+   */
+  @Test
+  fun onStyleLoadError() {
+    val styleObserver = StyleObserver(mockk(relaxed = true), map, mockk(relaxed = true), 1.0f)
+    val errorListener = mockk<OnMapLoadErrorListener>(relaxed = true)
+    styleObserver.onNewStyleLoad(mockk(relaxed = true), errorListener)
+    styleObserver.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar")
+    verify { errorListener.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar") }
+  }
+
+  /**
+   * Verifies if the user provided OnMapLoadListener is not called when a secondary style load occurs
+   */
+  @Test
+  fun onStyleLoadErrorNotCalled() {
+    val styleObserver = StyleObserver(mockk(relaxed = true), map, mockk(relaxed = true), 1.0f)
+    val errorListenerFail = mockk<OnMapLoadErrorListener>(relaxed = true)
+    styleObserver.onNewStyleLoad(mockk(relaxed = true), errorListenerFail)
+    val errorListenerSuccess = mockk<OnMapLoadErrorListener>(relaxed = true)
+    styleObserver.onNewStyleLoad(mockk(relaxed = true), errorListenerSuccess)
+    styleObserver.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar")
+    verify(exactly = 0) { errorListenerFail.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar") }
+    verify { errorListenerSuccess.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar") }
+  }
+}


### PR DESCRIPTION
Replaces https://github.com/mapbox/mapbox-maps-android/pull/178

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Style and map error loading listeners are only called for the style that was associated to the listeners when style loading started. This avoid calling the wrong listeners with multiple style loads. Renamed Style#isStyleLoadInited to Style#isStyleLoadInitiated.</changelog>`.

### Summary of changes

This PR reworks how we do style loading internally to expose these to developers. We make sure to clear any set listeners when a new style will be loaded. This avoids calling OnStyleLoaded on an old obsolete instance of a previous set style. 

### User impact (optional)

When a user load a style and it errors out and load a new style. Only the secondary interface provided to the second style loading will be invoked. The first one will be ignored. 