### PR TITLE
Fix crash if doing setCamera during map loading

### DIFF
--- a/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
+++ b/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
@@ -183,7 +183,9 @@ open class CompassViewPlugin(
     bearing: Double,
     padding: Array<Double>
   ) {
+//    Handler(Looper.getMainLooper()).post {
     update(bearing)
+//    }
   }
 
   /**

--- a/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
+++ b/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
@@ -2,6 +2,8 @@ package com.mapbox.maps.plugin.compass
 
 import android.animation.ValueAnimator
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
@@ -28,7 +30,8 @@ import kotlin.math.abs
  */
 open class CompassViewPlugin(
   private val viewImplProvider: (Context) -> CompassViewImpl = { CompassViewImpl(it) },
-  private val fadeAnimator: ValueAnimator = ValueAnimator.ofFloat(1f, 0f)
+  private val fadeAnimator: ValueAnimator = ValueAnimator.ofFloat(1f, 0f),
+  private val mainHandler: Handler = Handler(Looper.getMainLooper())
 ) :
   CompassPlugin, CompassSettingsBase() {
 
@@ -174,6 +177,7 @@ open class CompassViewPlugin(
 
   /**
    * Called whenever camera position changes.
+   * Could be invoked from any thread when map starts rendering.
    */
   override fun onCameraMove(
     lat: Double,
@@ -183,9 +187,9 @@ open class CompassViewPlugin(
     bearing: Double,
     padding: Array<Double>
   ) {
-//    Handler(Looper.getMainLooper()).post {
-    update(bearing)
-//    }
+    mainHandler.post {
+      update(bearing)
+    }
   }
 
   /**

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/MapCameraPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/MapCameraPlugin.kt
@@ -1,13 +1,18 @@
 package com.mapbox.maps.plugin
 
+import androidx.annotation.AnyThread
+
 /**
  * Definition for map camera plugins. The map will constantly push current camera position values.
+ *
  */
 fun interface MapCameraPlugin : MapPlugin {
 
   /**
    * Called whenever camera position changes.
+   * Could be invoked from any thread when map starts rendering.
    */
+  @AnyThread
   fun onCameraMove(
     lat: Double,
     lon: Double,

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/MapCameraPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/MapCameraPlugin.kt
@@ -4,7 +4,6 @@ import androidx.annotation.AnyThread
 
 /**
  * Definition for map camera plugins. The map will constantly push current camera position values.
- *
  */
 fun interface MapCameraPlugin : MapPlugin {
 

--- a/sdk/src/androidTest/java/com/mapbox/maps/MapIntegrationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/MapIntegrationTest.kt
@@ -1,0 +1,65 @@
+package com.mapbox.maps
+
+import androidx.test.annotation.UiThreadTest
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.mapbox.geojson.Point
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class MapIntegrationTest {
+
+  @get:Rule
+  val rule = ActivityScenarioRule(EmptyActivity::class.java)
+
+  private lateinit var mapView: MapView
+  private lateinit var mapboxMap: MapboxMap
+  private lateinit var countDownLatch: CountDownLatch
+
+  @Before
+  @UiThreadTest
+  fun setUp() {
+  }
+
+  @Test
+  fun testSetCameraOnStart() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      it.runOnUiThread {
+        mapView = MapView(it)
+        mapboxMap = mapView.getMapboxMap()
+        it.frameLayout.addView(mapView)
+        mapView.onStart()
+        mapboxMap.setCamera(
+          CameraOptions.Builder()
+            .center(Point.fromLngLat(17.045988781311138, 51.12341909978734))
+            .bearing(27.254667247679752)
+            .pitch(0.0)
+            .padding(EdgeInsets(140.0, 140.0, 140.0, 140.0))
+            .zoom(13.282170222962456)
+            .build()
+        )
+        countDownLatch.countDown()
+      }
+    }
+    if (!countDownLatch.await(5, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @After
+  @UiThreadTest
+  fun teardown() {
+    mapView.onStop()
+    mapView.onDestroy()
+  }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #308 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix crash if doing setCamera during map loading</changelog>`.

### Summary of changes

Every consumer (in our case it's compass plugin) should make sure that `MapCameraPlugin.onCameraMove` is called from correct thread.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->