### PR TITLE
[Annotation] Add selected state handling to annotation plugin

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/CircleAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/CircleAnnotationActivity.kt
@@ -34,11 +34,31 @@ class CircleAnnotationActivity : AppCompatActivity() {
       circleManager = annotationPlugin.createCircleAnnotationManager(mapView).apply {
         addClickListener(
           OnCircleAnnotationClickListener {
-            Toast.makeText(this@CircleAnnotationActivity, "click", Toast.LENGTH_LONG).show()
+            Toast.makeText(this@CircleAnnotationActivity, "click: ${it.id}", Toast.LENGTH_SHORT)
+              .show()
             false
           }
         )
 
+        addInteractionListener(
+          object : OnCircleAnnotationInteractionListener {
+            override fun onSelectAnnotation(annotation: CircleAnnotation) {
+              Toast.makeText(
+                this@CircleAnnotationActivity,
+                "onSelectAnnotation: ${annotation.id}",
+                Toast.LENGTH_SHORT
+              ).show()
+            }
+
+            override fun onDeselectAnnotation(annotation: CircleAnnotation) {
+              Toast.makeText(
+                this@CircleAnnotationActivity,
+                "onDeselectAnnotation: ${annotation.id}",
+                Toast.LENGTH_SHORT
+              ).show()
+            }
+          }
+        )
         val circleAnnotationOptions: CircleAnnotationOptions = CircleAnnotationOptions()
           .withPoint(Point.fromLngLat(CIRCLE_LONGITUDE, CIRCLE_LATITUDE))
           .withCircleColor(Color.YELLOW)

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PointAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PointAnnotationActivity.kt
@@ -48,17 +48,36 @@ class PointAnnotationActivity : AppCompatActivity() {
       symbolManager = annotationPlugin.createPointAnnotationManager(mapView).apply {
         addClickListener(
           OnPointAnnotationClickListener {
-            Toast.makeText(this@PointAnnotationActivity, "Click: $it", Toast.LENGTH_LONG).show()
+            Toast.makeText(this@PointAnnotationActivity, "Click: ${it.id}", Toast.LENGTH_SHORT).show()
             false
           }
         )
 
         addLongClickListener(
           OnPointAnnotationLongClickListener {
-            Toast.makeText(this@PointAnnotationActivity, "LongClick: $it", Toast.LENGTH_LONG).show()
+            Toast.makeText(this@PointAnnotationActivity, "LongClick: ${it.id}", Toast.LENGTH_SHORT)
+              .show()
             false
           }
         )
+
+        addInteractionListener(object : OnPointAnnotationInteractionListener {
+          override fun onSelectAnnotation(annotation: PointAnnotation) {
+            Toast.makeText(
+              this@PointAnnotationActivity,
+              "onSelectAnnotation: ${annotation.id}",
+              Toast.LENGTH_SHORT
+            ).show()
+          }
+
+          override fun onDeselectAnnotation(annotation: PointAnnotation) {
+            Toast.makeText(
+              this@PointAnnotationActivity,
+              "onDeselectAnnotation: ${annotation.id}",
+              Toast.LENGTH_SHORT
+            ).show()
+          }
+        })
 
         bitmapFromDrawableRes(
           this@PointAnnotationActivity,
@@ -140,7 +159,8 @@ class PointAnnotationActivity : AppCompatActivity() {
       R.id.menu_action_filter -> {
         if (symbolManager != null && pointAnnotation != null) {
           val idKey = symbolManager!!.getAnnotationIdKey()
-          val expression: Expression = eq(toNumber(get(idKey)), literal(pointAnnotation!!.id.toDouble()))
+          val expression: Expression =
+            eq(toNumber(get(idKey)), literal(pointAnnotation!!.id.toDouble()))
           val filter = symbolManager!!.layerFilter
           if (filter != null && filter == expression) {
             symbolManager!!.layerFilter = not(eq(toNumber(get(idKey)), literal(-1)))
@@ -167,7 +187,12 @@ class PointAnnotationActivity : AppCompatActivity() {
 
       R.id.menu_action_animate -> {
         resetSymbol()
-        pointAnnotation?.let { easeSymbol(it, Point.fromLngLat(AIRPORT_LATITUDE, AIRPORT_LONGITUDE)) }
+        pointAnnotation?.let {
+          easeSymbol(
+            it,
+            Point.fromLngLat(AIRPORT_LATITUDE, AIRPORT_LONGITUDE)
+          )
+        }
         return true
       }
       else -> return super.onOptionsItemSelected(item)
@@ -182,7 +207,11 @@ class PointAnnotationActivity : AppCompatActivity() {
     pointAnnotation?.let { symbolManager?.update(it) }
   }
 
-  private fun easeSymbol(pointAnnotation: PointAnnotation, location: Point, rotation: Double = 180.0) {
+  private fun easeSymbol(
+    pointAnnotation: PointAnnotation,
+    location: Point,
+    rotation: Double = 180.0
+  ) {
     val originalPosition: Point = pointAnnotation.point
     val originalRotation = pointAnnotation.iconRotate
     if (originalPosition == location || originalRotation == rotation) {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PolyfillAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PolyfillAnnotationActivity.kt
@@ -35,10 +35,30 @@ class PolyfillAnnotationActivity : AppCompatActivity() {
       fillManager = annotationPlugin.createPolygonAnnotationManager(mapView).apply {
         addClickListener(
           OnPolygonAnnotationClickListener {
-            Toast.makeText(this@PolyfillAnnotationActivity, "click", Toast.LENGTH_LONG).show()
+            Toast.makeText(this@PolyfillAnnotationActivity, "click ${it.id}", Toast.LENGTH_SHORT)
+              .show()
             false
           }
         )
+
+        addInteractionListener(object : OnPolygonAnnotationInteractionListener {
+          override fun onSelectAnnotation(annotation: PolygonAnnotation) {
+            Toast.makeText(
+              this@PolyfillAnnotationActivity,
+              "onSelectAnnotation ${annotation.id}",
+              Toast.LENGTH_SHORT
+            ).show()
+          }
+
+          override fun onDeselectAnnotation(annotation: PolygonAnnotation) {
+            Toast.makeText(
+              this@PolyfillAnnotationActivity,
+              "onDeselectAnnotation ${annotation.id}",
+              Toast.LENGTH_SHORT
+            ).show()
+          }
+        })
+
         val points = listOf(
           listOf(
             Point.fromLngLat(-3.363937, -10.733102),

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PolylineAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PolylineAnnotationActivity.kt
@@ -42,14 +42,29 @@ class PolylineAnnotationActivity : AppCompatActivity() {
         }
         addClickListener(
           OnPolylineAnnotationClickListener {
-            Toast.makeText(
-              this@PolylineAnnotationActivity,
-              "click",
-              Toast.LENGTH_LONG
-            ).show()
+            Toast.makeText(this@PolylineAnnotationActivity, "click ${it.id}", Toast.LENGTH_SHORT)
+              .show()
             false
           }
         )
+
+        addInteractionListener(object : OnPolylineAnnotationInteractionListener {
+          override fun onSelectAnnotation(annotation: PolylineAnnotation) {
+            Toast.makeText(
+              this@PolylineAnnotationActivity,
+              "onSelectAnnotation ${annotation.id}",
+              Toast.LENGTH_SHORT
+            ).show()
+          }
+
+          override fun onDeselectAnnotation(annotation: PolylineAnnotation) {
+            Toast.makeText(
+              this@PolylineAnnotationActivity,
+              "onDeselectAnnotation ${annotation.id}",
+              Toast.LENGTH_SHORT
+            ).show()
+          }
+        })
 
         val points = listOf(
           Point.fromLngLat(-4.375974, -2.178992),

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
@@ -12,7 +12,7 @@ import java.lang.ref.WeakReference
  */
 class AnnotationPluginImpl : AnnotationPlugin {
   private lateinit var delegateProvider: MapDelegateProvider
-  private val managerList = mutableListOf<WeakReference<AnnotationManager<*, *, *, *, *, *>>>()
+  private val managerList = mutableListOf<WeakReference<AnnotationManager<*, *, *, *, *, *, *>>>()
   private var width = 0
   private var height = 0
 
@@ -28,7 +28,7 @@ class AnnotationPluginImpl : AnnotationPlugin {
     mapView: View,
     type: AnnotationType,
     annotationConfig: AnnotationConfig?
-  ): AnnotationManager<*, *, *, *, *, *> {
+  ): AnnotationManager<*, *, *, *, *, *, *> {
     val manager = when (type) {
       AnnotationType.PolygonAnnotation -> PolygonAnnotationManager(mapView, delegateProvider, annotationConfig)
       AnnotationType.CircleAnnotation -> CircleAnnotationManager(mapView, delegateProvider, annotationConfig)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotation.kt
@@ -20,7 +20,7 @@ import com.mapbox.maps.plugin.delegates.MapCameraManagerDelegate
 class CircleAnnotation(
   id: Long,
   /** The annotation manger that manipulate this annotation */
-  private val annotationManager: AnnotationManager<Point, CircleAnnotation, *, *, *, *>,
+  private val annotationManager: AnnotationManager<Point, CircleAnnotation, *, *, *, *, *>,
   jsonObject: JsonObject,
   geometry: Point
 ) : Annotation<Point>(id, jsonObject, geometry) {

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
@@ -24,7 +24,7 @@ class CircleAnnotationManager(
   delegateProvider: MapDelegateProvider,
   annotationConfig: AnnotationConfig? = null
 ) :
-  AnnotationManagerImpl<Point, CircleAnnotation, CircleAnnotationOptions, OnCircleAnnotationDragListener, OnCircleAnnotationClickListener, OnCircleAnnotationLongClickListener, CircleLayer>(
+  AnnotationManagerImpl<Point, CircleAnnotation, CircleAnnotationOptions, OnCircleAnnotationDragListener, OnCircleAnnotationClickListener, OnCircleAnnotationLongClickListener, OnCircleAnnotationInteractionListener, CircleLayer>(
     mapView, delegateProvider, annotationConfig
   ) {
   private val id = ID_GENERATOR.incrementAndGet()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationOptions.kt
@@ -278,7 +278,7 @@ class CircleAnnotationOptions : AnnotationOptions<Point, CircleAnnotation> {
    */
   override fun build(
     id: Long,
-    annotationManager: AnnotationManager<Point, CircleAnnotation, *, *, *, *>
+    annotationManager: AnnotationManager<Point, CircleAnnotation, *, *, *, *, *>
   ): CircleAnnotation {
     if (geometry == null) {
       throw RuntimeException("geometry field is required")

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/OnCircleAnnotationInteractionListener.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/OnCircleAnnotationInteractionListener.kt
@@ -1,0 +1,10 @@
+// This file is generated.
+
+package com.mapbox.maps.plugin.annotation.generated
+
+import com.mapbox.maps.plugin.annotation.OnAnnotationInteractionListener
+
+/**
+ * Interface definition for a callback to be invoked when a circleAnnotation has been selected or deselected.
+ */
+interface OnCircleAnnotationInteractionListener : OnAnnotationInteractionListener<CircleAnnotation>

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/OnPointAnnotationInteractionListener.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/OnPointAnnotationInteractionListener.kt
@@ -1,0 +1,10 @@
+// This file is generated.
+
+package com.mapbox.maps.plugin.annotation.generated
+
+import com.mapbox.maps.plugin.annotation.OnAnnotationInteractionListener
+
+/**
+ * Interface definition for a callback to be invoked when a pointAnnotation has been selected or deselected.
+ */
+interface OnPointAnnotationInteractionListener : OnAnnotationInteractionListener<PointAnnotation>

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/OnPolygonAnnotationInteractionListener.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/OnPolygonAnnotationInteractionListener.kt
@@ -1,0 +1,10 @@
+// This file is generated.
+
+package com.mapbox.maps.plugin.annotation.generated
+
+import com.mapbox.maps.plugin.annotation.OnAnnotationInteractionListener
+
+/**
+ * Interface definition for a callback to be invoked when a polygonAnnotation has been selected or deselected.
+ */
+interface OnPolygonAnnotationInteractionListener : OnAnnotationInteractionListener<PolygonAnnotation>

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/OnPolylineAnnotationInteractionListener.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/OnPolylineAnnotationInteractionListener.kt
@@ -1,0 +1,10 @@
+// This file is generated.
+
+package com.mapbox.maps.plugin.annotation.generated
+
+import com.mapbox.maps.plugin.annotation.OnAnnotationInteractionListener
+
+/**
+ * Interface definition for a callback to be invoked when a polylineAnnotation has been selected or deselected.
+ */
+interface OnPolylineAnnotationInteractionListener : OnAnnotationInteractionListener<PolylineAnnotation>

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
@@ -23,7 +23,7 @@ import com.mapbox.maps.plugin.delegates.MapCameraManagerDelegate
 class PointAnnotation(
   id: Long,
   /** The annotation manger that manipulate this annotation */
-  private val annotationManager: AnnotationManager<Point, PointAnnotation, *, *, *, *>,
+  private val annotationManager: AnnotationManager<Point, PointAnnotation, *, *, *, *, *>,
   jsonObject: JsonObject,
   geometry: Point
 ) : Annotation<Point>(id, jsonObject, geometry) {

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
@@ -24,7 +24,7 @@ class PointAnnotationManager(
   delegateProvider: MapDelegateProvider,
   annotationConfig: AnnotationConfig? = null
 ) :
-  AnnotationManagerImpl<Point, PointAnnotation, PointAnnotationOptions, OnPointAnnotationDragListener, OnPointAnnotationClickListener, OnPointAnnotationLongClickListener, SymbolLayer>(
+  AnnotationManagerImpl<Point, PointAnnotation, PointAnnotationOptions, OnPointAnnotationDragListener, OnPointAnnotationClickListener, OnPointAnnotationLongClickListener, OnPointAnnotationInteractionListener, SymbolLayer>(
     mapView, delegateProvider, annotationConfig
   ) {
   private val id = ID_GENERATOR.incrementAndGet()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationOptions.kt
@@ -669,7 +669,7 @@ class PointAnnotationOptions : AnnotationOptions<Point, PointAnnotation> {
    */
   override fun build(
     id: Long,
-    annotationManager: AnnotationManager<Point, PointAnnotation, *, *, *, *>
+    annotationManager: AnnotationManager<Point, PointAnnotation, *, *, *, *, *>
   ): PointAnnotation {
     if (geometry == null) {
       throw RuntimeException("geometry field is required")

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotation.kt
@@ -20,7 +20,7 @@ import com.mapbox.maps.plugin.delegates.MapCameraManagerDelegate
 class PolygonAnnotation(
   id: Long,
   /** The annotation manger that manipulate this annotation */
-  private val annotationManager: AnnotationManager<Polygon, PolygonAnnotation, *, *, *, *>,
+  private val annotationManager: AnnotationManager<Polygon, PolygonAnnotation, *, *, *, *, *>,
   jsonObject: JsonObject,
   geometry: Polygon
 ) : Annotation<Polygon>(id, jsonObject, geometry) {

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
@@ -24,7 +24,7 @@ class PolygonAnnotationManager(
   delegateProvider: MapDelegateProvider,
   annotationConfig: AnnotationConfig? = null
 ) :
-  AnnotationManagerImpl<Polygon, PolygonAnnotation, PolygonAnnotationOptions, OnPolygonAnnotationDragListener, OnPolygonAnnotationClickListener, OnPolygonAnnotationLongClickListener, FillLayer>(
+  AnnotationManagerImpl<Polygon, PolygonAnnotation, PolygonAnnotationOptions, OnPolygonAnnotationDragListener, OnPolygonAnnotationClickListener, OnPolygonAnnotationLongClickListener, OnPolygonAnnotationInteractionListener, FillLayer>(
     mapView, delegateProvider, annotationConfig
   ) {
   private val id = ID_GENERATOR.incrementAndGet()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationOptions.kt
@@ -225,7 +225,7 @@ class PolygonAnnotationOptions : AnnotationOptions<Polygon, PolygonAnnotation> {
    */
   override fun build(
     id: Long,
-    annotationManager: AnnotationManager<Polygon, PolygonAnnotation, *, *, *, *>
+    annotationManager: AnnotationManager<Polygon, PolygonAnnotation, *, *, *, *, *>
   ): PolygonAnnotation {
     if (geometry == null) {
       throw RuntimeException("geometry field is required")

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotation.kt
@@ -20,7 +20,7 @@ import com.mapbox.maps.plugin.delegates.MapCameraManagerDelegate
 class PolylineAnnotation(
   id: Long,
   /** The annotation manger that manipulate this annotation */
-  private val annotationManager: AnnotationManager<LineString, PolylineAnnotation, *, *, *, *>,
+  private val annotationManager: AnnotationManager<LineString, PolylineAnnotation, *, *, *, *, *>,
   jsonObject: JsonObject,
   geometry: LineString
 ) : Annotation<LineString>(id, jsonObject, geometry) {

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
@@ -24,7 +24,7 @@ class PolylineAnnotationManager(
   delegateProvider: MapDelegateProvider,
   annotationConfig: AnnotationConfig? = null
 ) :
-  AnnotationManagerImpl<LineString, PolylineAnnotation, PolylineAnnotationOptions, OnPolylineAnnotationDragListener, OnPolylineAnnotationClickListener, OnPolylineAnnotationLongClickListener, LineLayer>(
+  AnnotationManagerImpl<LineString, PolylineAnnotation, PolylineAnnotationOptions, OnPolylineAnnotationDragListener, OnPolylineAnnotationClickListener, OnPolylineAnnotationLongClickListener, OnPolylineAnnotationInteractionListener, LineLayer>(
     mapView, delegateProvider, annotationConfig
   ) {
   private val id = ID_GENERATOR.incrementAndGet()

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationOptions.kt
@@ -285,7 +285,7 @@ class PolylineAnnotationOptions : AnnotationOptions<LineString, PolylineAnnotati
    */
   override fun build(
     id: Long,
-    annotationManager: AnnotationManager<LineString, PolylineAnnotation, *, *, *, *>
+    annotationManager: AnnotationManager<LineString, PolylineAnnotation, *, *, *, *, *>
   ): PolylineAnnotation {
     if (geometry == null) {
       throw RuntimeException("geometry field is required")

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -275,11 +275,22 @@ class CircleAnnotationManagerTest {
     val listener = mockk<OnCircleAnnotationClickListener>()
     every { listener.onAnnotationClick(any()) } returns false
     manager.addClickListener(listener)
+
+    val interactionListener = mockk<OnCircleAnnotationInteractionListener>()
+    every { interactionListener.onSelectAnnotation(any()) } just Runs
+    every { interactionListener.onDeselectAnnotation(any()) } just Runs
+    manager.addInteractionListener(interactionListener)
+
     captureSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
     verify { listener.onAnnotationClick(annotation) }
+    verify { interactionListener.onSelectAnnotation(annotation) }
+    captureSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
+    verify { interactionListener.onDeselectAnnotation(annotation) }
 
     manager.removeClickListener(listener)
     assertTrue(manager.clickListeners.isEmpty())
+    manager.removeInteractionListener(interactionListener)
+    assertTrue(manager.interactionListener.isEmpty())
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -388,11 +388,22 @@ class PointAnnotationManagerTest {
     val listener = mockk<OnPointAnnotationClickListener>()
     every { listener.onAnnotationClick(any()) } returns false
     manager.addClickListener(listener)
+
+    val interactionListener = mockk<OnPointAnnotationInteractionListener>()
+    every { interactionListener.onSelectAnnotation(any()) } just Runs
+    every { interactionListener.onDeselectAnnotation(any()) } just Runs
+    manager.addInteractionListener(interactionListener)
+
     captureSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
     verify { listener.onAnnotationClick(annotation) }
+    verify { interactionListener.onSelectAnnotation(annotation) }
+    captureSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
+    verify { interactionListener.onDeselectAnnotation(annotation) }
 
     manager.removeClickListener(listener)
     assertTrue(manager.clickListeners.isEmpty())
+    manager.removeInteractionListener(interactionListener)
+    assertTrue(manager.interactionListener.isEmpty())
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -273,11 +273,22 @@ class PolygonAnnotationManagerTest {
     val listener = mockk<OnPolygonAnnotationClickListener>()
     every { listener.onAnnotationClick(any()) } returns false
     manager.addClickListener(listener)
+
+    val interactionListener = mockk<OnPolygonAnnotationInteractionListener>()
+    every { interactionListener.onSelectAnnotation(any()) } just Runs
+    every { interactionListener.onDeselectAnnotation(any()) } just Runs
+    manager.addInteractionListener(interactionListener)
+
     captureSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
     verify { listener.onAnnotationClick(annotation) }
+    verify { interactionListener.onSelectAnnotation(annotation) }
+    captureSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
+    verify { interactionListener.onDeselectAnnotation(annotation) }
 
     manager.removeClickListener(listener)
     assertTrue(manager.clickListeners.isEmpty())
+    manager.removeInteractionListener(interactionListener)
+    assertTrue(manager.interactionListener.isEmpty())
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -278,11 +278,22 @@ class PolylineAnnotationManagerTest {
     val listener = mockk<OnPolylineAnnotationClickListener>()
     every { listener.onAnnotationClick(any()) } returns false
     manager.addClickListener(listener)
+
+    val interactionListener = mockk<OnPolylineAnnotationInteractionListener>()
+    every { interactionListener.onSelectAnnotation(any()) } just Runs
+    every { interactionListener.onDeselectAnnotation(any()) } just Runs
+    manager.addInteractionListener(interactionListener)
+
     captureSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
     verify { listener.onAnnotationClick(annotation) }
+    verify { interactionListener.onSelectAnnotation(annotation) }
+    captureSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
+    verify { interactionListener.onDeselectAnnotation(annotation) }
 
     manager.removeClickListener(listener)
     assertTrue(manager.clickListeners.isEmpty())
+    manager.removeInteractionListener(interactionListener)
+    assertTrue(manager.interactionListener.isEmpty())
   }
 
   @Test

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/Annotation.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/Annotation.kt
@@ -32,7 +32,7 @@ abstract class Annotation<T : Geometry>(
    * Get the offset geometry for the touch point
    */
   abstract fun getOffsetGeometry(
-    cameraManagerDelegate: MapCameraManagerDelegate,
+    mapCameraManagerDelegate: MapCameraManagerDelegate,
     moveDistancesObject: MoveDistancesObject,
     touchAreaShiftX: Int,
     touchAreaShiftY: Int
@@ -60,6 +60,11 @@ abstract class Annotation<T : Geometry>(
    * Whether this annotation is draggable
    */
   var isDraggable: Boolean = false
+
+  /**
+   * Whether or not this annotation has been selected, either via a tap gesture or programmatically.
+   */
+  var isSelected: Boolean = false
 
   /**
    * Static variables and methods.

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManager.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManager.kt
@@ -13,7 +13,8 @@ interface AnnotationManager<
   S : AnnotationOptions<G, T>,
   D : OnAnnotationDragListener<T>,
   U : OnAnnotationClickListener<T>,
-  V : OnAnnotationLongClickListener<T>> {
+  V : OnAnnotationLongClickListener<T>,
+  I : OnAnnotationInteractionListener<T>> {
 
   /**
    * Create an annotation with the option
@@ -56,6 +57,14 @@ interface AnnotationManager<
   fun onDestroy()
 
   /**
+   * Toggles the annotation's selection state.
+   * If the annotation is deselected, it becomes selected.
+   * If the annotation is selected, it becomes deselected.
+   * @param annotation: The annotation to select.
+   */
+  fun selectAnnotation(annotation: T)
+
+  /**
    * Invoked when MapView's width and height have changed.
    * @param width the width of mapView
    * @param height the height of mapView
@@ -93,6 +102,11 @@ interface AnnotationManager<
   val longClickListeners: MutableList<V>
 
   /**
+   * The added interactionListener
+   */
+  val interactionListener: MutableList<I>
+
+  /**
    * Add a callback to be invoked when an annotation is dragged.
    *
    * @param d the callback to be invoked when an annotation is dragged
@@ -107,32 +121,46 @@ interface AnnotationManager<
   fun removeDragListener(d: D) = dragListeners.remove(d)
 
   /**
-   * Add a callback to be invoked when a symbol has been clicked.
+   * Add a callback to be invoked when a annotation has been clicked.
    *
-   * @param u the callback to be invoked when a symbol is clicked
+   * @param u the callback to be invoked when a annotation is clicked
    */
   fun addClickListener(u: U) = clickListeners.add(u)
 
   /**
-   * Remove a previously added callback that was to be invoked when symbol has been clicked.
+   * Remove a previously added callback that was to be invoked when annotation has been clicked.
    *
    * @param u the callback to be removed
    */
   fun removeClickListener(u: U) = clickListeners.remove(u)
 
   /**
-   * Add a callback to be invoked when a symbol has been long clicked.
+   * Add a callback to be invoked when a annotation has been long clicked.
    *
-   * @param v the callback to be invoked when a symbol is clicked
+   * @param v the callback to be invoked when a annotation is clicked
    */
   fun addLongClickListener(v: V) = longClickListeners.add(v)
 
   /**
-   * Remove a previously added callback that was to be invoked when symbol has been long clicked.
+   * Remove a previously added callback that was to be invoked when annotation has been long clicked.
    *
    * @param v the callback to be removed
    */
   fun removeLongClickListener(v: V) = longClickListeners.remove(v)
+
+  /**
+   * Add a callback to be invoked when a annotation has been selected or deselected.
+   *
+   * @param i the callback to be invoked when a annotation is selected or deselected
+   */
+  fun addInteractionListener(i: I) = interactionListener.add(i)
+
+  /**
+   * Remove a previously added callback that was to be invoked when annotation has been selected or deselected.
+   *
+   * @param i the callback to be removed
+   */
+  fun removeInteractionListener(i: I) = interactionListener.remove(i)
 
   /**
    * Enable a data-driven property. Please visit [The online documentation](https://docs.mapbox.com/android/maps/guides/data-driven-styling/) for more details about data-driven-styling

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationOptions.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationOptions.kt
@@ -14,5 +14,5 @@ fun interface AnnotationOptions<G : Geometry, T : Annotation<G>> {
    *
    * @return the annotation that is built
    */
-  fun build(id: Long, annotationManager: AnnotationManager<G, T, *, *, *, *>): T
+  fun build(id: Long, annotationManager: AnnotationManager<G, T, *, *, *, *, *>): T
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
@@ -21,5 +21,5 @@ interface AnnotationPlugin : MapPlugin, MapSizePlugin, MapStyleObserverPlugin {
     mapView: View,
     type: AnnotationType,
     annotationConfig: AnnotationConfig?
-  ): AnnotationManager<*, *, *, *, *, *>
+  ): AnnotationManager<*, *, *, *, *, *, *>
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/OnAnnotationInteractionListener.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/OnAnnotationInteractionListener.kt
@@ -1,0 +1,22 @@
+package com.mapbox.maps.plugin.annotation
+
+/**
+ * Generic interface definition of a callback to be invoked when an annotation has been selected or deselected.
+ *
+ * @param <T> generic parameter extending from Annotation
+ */
+interface OnAnnotationInteractionListener<T : Annotation<*>> {
+  /**
+   * Called when an annotation has been selected
+   *
+   * @param annotation the annotation selected.
+   */
+  fun onSelectAnnotation(annotation: T)
+
+  /**
+   * Called when an annotation has been deselected
+   *
+   * @param annotation the annotation deselected.
+   */
+  fun onDeselectAnnotation(annotation: T)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[Annotation] Add selected state handling to annotation plugin</changelog>`.

### Summary of changes
This pr add a `isSelected` property for Annotations and a new API `AnnotationManager#selectAnnotation` to change the select state for an Annotation. Users can register a `OnAnnotationInteractionListener` to listen to the select state change.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->