### PR TITLE
Add an option to mutate camera state using the CameraOptionsKtx.kt DSL

### DIFF
--- a/sdk-base/build.gradle.kts
+++ b/sdk-base/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
   api(Dependencies.mapboxGestures)
   api(Dependencies.mapboxGlNative)
   api(Dependencies.mapboxCoreCommon)
+  testImplementation(Dependencies.junit)
+  testImplementation(Dependencies.mockk)
+  testImplementation(Dependencies.androidxTestCore)
 }
 
 tasks.withType<DokkaTask>().configureEach {

--- a/sdk-base/src/main/java/com/mapbox/maps/dsl/CameraOptionsKtx.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/dsl/CameraOptionsKtx.kt
@@ -1,9 +1,27 @@
 package com.mapbox.maps.dsl
 
 import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.CameraState
 
 /**
  * DSL builder function to create [CameraOptions] object.
  */
-inline fun cameraOptions(block: CameraOptions.Builder.() -> Unit) =
+inline fun cameraOptions(block: CameraOptions.Builder.() -> Unit): CameraOptions =
   CameraOptions.Builder().apply(block).build()
+
+/**
+ * DSL builder function to create [CameraOptions] object.
+ *
+ * @param cameraState existing camera state that is used for a mutation base
+ */
+inline fun cameraOptions(
+  cameraState: CameraState,
+  block: CameraOptions.Builder.() -> Unit
+): CameraOptions = CameraOptions.Builder()
+  .padding(cameraState.padding)
+  .center(cameraState.center)
+  .bearing(cameraState.bearing)
+  .zoom(cameraState.zoom)
+  .pitch(cameraState.pitch)
+  .apply(block)
+  .build()

--- a/sdk-base/src/test/java/com/mapbox/maps/dsl/CameraOptionsKtxTest.kt
+++ b/sdk-base/src/test/java/com/mapbox/maps/dsl/CameraOptionsKtxTest.kt
@@ -1,0 +1,85 @@
+package com.mapbox.maps.dsl
+
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.CameraState
+import com.mapbox.maps.EdgeInsets
+import org.junit.Assert
+import org.junit.Test
+
+class CameraOptionsKtxTest {
+
+  @Test
+  fun `cameraOptions with mutation`() {
+    val expected = CameraState(
+      Point.fromLngLat(10.0, 20.0),
+      EdgeInsets(1.0, 2.0, 3.0, 4.0),
+      5.0,
+      6.0,
+      7.0,
+    )
+
+    val result = cameraOptions {
+      center(expected.center)
+      padding(expected.padding)
+      zoom(expected.zoom)
+      bearing(expected.bearing)
+      pitch(expected.pitch)
+    }
+
+    Assert.assertEquals(expected.center, result.center)
+    Assert.assertEquals(expected.padding, result.padding)
+    Assert.assertEquals(expected.zoom, result.zoom)
+    Assert.assertEquals(expected.bearing, result.bearing)
+    Assert.assertEquals(expected.pitch, result.pitch)
+  }
+
+  @Test
+  fun `cameraOptions without mutation is equal to the base cameraState`() {
+    val expected = CameraState(
+      Point.fromLngLat(10.0, 20.0),
+      EdgeInsets(1.0, 2.0, 3.0, 4.0),
+      5.0,
+      6.0,
+      7.0,
+    )
+
+    val result = cameraOptions(expected) {
+      // no impl
+    }
+
+    Assert.assertEquals(expected.center, result.center)
+    Assert.assertEquals(expected.padding, result.padding)
+    Assert.assertEquals(expected.zoom, result.zoom)
+    Assert.assertEquals(expected.bearing, result.bearing)
+    Assert.assertEquals(expected.pitch, result.pitch)
+  }
+
+  @Test
+  fun `cameraOptions with mutation on a base cameraState`() {
+    val base = CameraState(
+      Point.fromLngLat(10.0, 20.0),
+      EdgeInsets(1.0, 2.0, 3.0, 4.0),
+      5.0,
+      6.0,
+      7.0
+    )
+    val expected = CameraOptions.Builder()
+      .center(Point.fromLngLat(20.0, 30.0))
+      .padding(EdgeInsets(8.0, 9.0, 10.0, 11.0))
+      .zoom(12.0)
+      .bearing(13.0)
+      .pitch(14.0)
+      .build()
+
+    val result = cameraOptions(base) {
+      center(expected.center)
+      padding(expected.padding)
+      zoom(expected.zoom)
+      bearing(expected.bearing)
+      pitch(expected.pitch)
+    }
+
+    Assert.assertEquals(expected, result)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog:
```
<changelog>Added a `cameraOptions(cameraState, builderBlock)` inline method that helps mutate an existing `CameraState` object.</changelog>
```

### Summary of changes

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

Adds an option to use a `CameraState` as a mutation base for the `cameraOptions` inline DSL.
