### PR TITLE
[compass] make compassview visible when enabled

### DIFF
--- a/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
+++ b/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.animation.addListener
 import com.mapbox.maps.CameraOptions
-import com.mapbox.maps.CameraState
 import com.mapbox.maps.plugin.InvalidPluginConfigurationException
 import com.mapbox.maps.plugin.PLUGIN_CAMERA_ANIMATIONS_CLASS_NAME
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
@@ -37,7 +36,7 @@ open class CompassViewPlugin(
 
   private lateinit var compassView: CompassView
   private lateinit var mapCameraManager: MapCameraManagerDelegate
-  private lateinit var cameraState: CameraState
+  internal var bearing: Double = 0.0
   private var animationPlugin: CameraAnimationsPlugin? = null
 
   private var isHidden = false
@@ -78,7 +77,7 @@ open class CompassViewPlugin(
       internalSettings.marginRight.toInt(),
       internalSettings.marginBottom.toInt()
     )
-    update(cameraState.bearing)
+    update(bearing)
     compassView.requestLayout()
   }
 
@@ -90,9 +89,9 @@ open class CompassViewPlugin(
     set(value) {
       internalSettings.enabled = value
       compassView.isCompassEnabled = value
-      update(cameraState.bearing)
+      update(bearing)
       if (value && !shouldHideCompass()) {
-        compassView.setCompassAlpha(1.0f)
+        compassView.setCompassAlpha(internalSettings.opacity)
         compassView.isCompassVisible = true
       } else {
         compassView.setCompassAlpha(0.0f)
@@ -149,7 +148,7 @@ open class CompassViewPlugin(
    */
   override fun onDelegateProvider(delegateProvider: MapDelegateProvider) {
     mapCameraManager = delegateProvider.mapCameraManagerDelegate
-    cameraState = delegateProvider.mapCameraManagerDelegate.cameraState
+    bearing = delegateProvider.mapCameraManagerDelegate.cameraState.bearing
     animationPlugin = delegateProvider.mapPluginProviderDelegate.getPlugin(
       Class.forName(
         PLUGIN_CAMERA_ANIMATIONS_CLASS_NAME
@@ -165,7 +164,7 @@ open class CompassViewPlugin(
    * Called whenever activity's/fragment's lifecycle is entering a "started" state.
    */
   override fun onStart() {
-    update(cameraState.bearing)
+    update(bearing)
   }
 
   /**
@@ -227,6 +226,7 @@ open class CompassViewPlugin(
   }
 
   private fun update(bearing: Double) {
+    this.bearing = bearing
     compassView.compassRotation = -bearing.toFloat()
     updateVisibility()
   }

--- a/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
+++ b/plugin-compass/src/test/java/com/mapbox/maps/plugin/compass/CompassViewPluginTest.kt
@@ -180,6 +180,7 @@ class CompassViewPluginTest {
   @Test
   fun setEnabled_true() {
     every { mapCameraDelegate.cameraState.bearing } returns 10.0
+    compassPlugin.onDelegateProvider(delegateProvider)
     every { compassView.compassRotation } returns -10f
     every { compassView.isCompassEnabled } returns true
     compassPlugin.enabled = true
@@ -403,5 +404,14 @@ class CompassViewPluginTest {
         }
       )
     }
+  }
+
+  @Test
+  fun onCompassDisabledRotateMapEnabled() {
+    compassPlugin.enabled = false
+    compassPlugin.onCameraMove(0.0, 0.0, 0.0, 0.0, 40.0, arrayOf())
+    every { compassView.compassRotation } returns -40.0f
+    compassPlugin.enabled = true
+    verify { compassView.isCompassVisible = true }
   }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Make compass visible when camera was mutated while compass was disabled.</changelog>`.

### Summary of changes

Previous implementation used a camera state but we weren't caching it. When you had the compass disabled, rotated the camera and renabled the compass after. It wasn't showing, you had to mutate the camera again to make the compass visible. 