### PR TITLE
Add removeAnnotationManager API;  Fix crash if the belowLayerId doesn't exist on the current style

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/CircleAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/CircleAnnotationActivity.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
+import com.mapbox.maps.plugin.annotation.AnnotationPlugin
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.testapp.R
@@ -25,12 +26,13 @@ class CircleAnnotationActivity : AppCompatActivity() {
     get() {
       return AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]
     }
+  private lateinit var annotationPlugin: AnnotationPlugin
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_annotation)
     mapView.getMapboxMap().loadStyleUri(nextStyle) {
-      val annotationPlugin = mapView.annotations
+      annotationPlugin = mapView.annotations
       circleManager = annotationPlugin.createCircleAnnotationManager(mapView).apply {
         addClickListener(
           OnCircleAnnotationClickListener {
@@ -88,7 +90,11 @@ class CircleAnnotationActivity : AppCompatActivity() {
       }
     }
 
-    deleteAll.setOnClickListener { circleManager?.deleteAll() }
+    deleteAll.setOnClickListener {
+      circleManager?.let {
+        annotationPlugin.removeAnnotationManager(it)
+      }
+    }
     changeStyle.setOnClickListener {
       mapView.getMapboxMap().loadStyleUri(nextStyle)
     }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PointAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PointAnnotationActivity.kt
@@ -18,6 +18,7 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression.Companio
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.toNumber
 import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.mapbox.maps.extension.style.layers.properties.generated.TextAnchor
+import com.mapbox.maps.plugin.annotation.AnnotationPlugin
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.testapp.R
@@ -39,16 +40,18 @@ class PointAnnotationActivity : AppCompatActivity() {
     get() {
       return AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]
     }
+  private lateinit var annotationPlugin: AnnotationPlugin
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_annotation)
     mapView.getMapboxMap().loadStyleUri(nextStyle) {
-      val annotationPlugin = mapView.annotations
+      annotationPlugin = mapView.annotations
       symbolManager = annotationPlugin.createPointAnnotationManager(mapView).apply {
         addClickListener(
           OnPointAnnotationClickListener {
-            Toast.makeText(this@PointAnnotationActivity, "Click: ${it.id}", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this@PointAnnotationActivity, "Click: ${it.id}", Toast.LENGTH_SHORT)
+              .show()
             false
           }
         )
@@ -138,7 +141,11 @@ class PointAnnotationActivity : AppCompatActivity() {
       }
     }
 
-    deleteAll.setOnClickListener { symbolManager?.deleteAll() }
+    deleteAll.setOnClickListener {
+      symbolManager?.let {
+        annotationPlugin.removeAnnotationManager(it)
+      }
+    }
     changeStyle.setOnClickListener {
       mapView.getMapboxMap().loadStyleUri(nextStyle)
     }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PolyfillAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PolyfillAnnotationActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.gson.JsonPrimitive
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
+import com.mapbox.maps.plugin.annotation.AnnotationPlugin
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.testapp.R
@@ -26,12 +27,13 @@ class PolyfillAnnotationActivity : AppCompatActivity() {
     get() {
       return AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]
     }
+  private lateinit var annotationPlugin: AnnotationPlugin
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_annotation)
     mapView.getMapboxMap().loadStyleUri(nextStyle) {
-      val annotationPlugin = mapView.annotations
+      annotationPlugin = mapView.annotations
       fillManager = annotationPlugin.createPolygonAnnotationManager(mapView).apply {
         addClickListener(
           OnPolygonAnnotationClickListener {
@@ -95,7 +97,11 @@ class PolyfillAnnotationActivity : AppCompatActivity() {
       }
     }
 
-    deleteAll.setOnClickListener { fillManager?.deleteAll() }
+    deleteAll.setOnClickListener {
+      fillManager?.let {
+        annotationPlugin.removeAnnotationManager(it)
+      }
+    }
     changeStyle.setOnClickListener { mapView.getMapboxMap().loadStyleUri(nextStyle) }
   }
 

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PolylineAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PolylineAnnotationActivity.kt
@@ -8,6 +8,7 @@ import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.plugin.annotation.AnnotationConfig
+import com.mapbox.maps.plugin.annotation.AnnotationPlugin
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.testapp.R
@@ -27,15 +28,16 @@ class PolylineAnnotationActivity : AppCompatActivity() {
     get() {
       return AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]
     }
+  private lateinit var annotationPlugin: AnnotationPlugin
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_annotation)
     mapView.getMapboxMap().loadStyleUri(nextStyle) {
-      val annotationPlugin = mapView.annotations
+      annotationPlugin = mapView.annotations
       lineManager = annotationPlugin.createPolylineAnnotationManager(
         mapView,
-        AnnotationConfig(COUNTRY_LABEL, LAYER_ID, SOURCE_ID)
+        AnnotationConfig(PITCH_OUTLINE, LAYER_ID, SOURCE_ID)
       ).apply {
         it.getLayer(LAYER_ID)?.let { layer ->
           Toast.makeText(this@PolylineAnnotationActivity, layer.layerId, Toast.LENGTH_LONG).show()
@@ -101,7 +103,11 @@ class PolylineAnnotationActivity : AppCompatActivity() {
       }
     }
 
-    deleteAll.setOnClickListener { lineManager?.deleteAll() }
+    deleteAll.setOnClickListener {
+      lineManager?.let {
+        annotationPlugin.removeAnnotationManager(it)
+      }
+    }
     changeStyle.setOnClickListener {
       mapView.getMapboxMap().loadStyleUri(nextStyle)
     }
@@ -130,6 +136,6 @@ class PolylineAnnotationActivity : AppCompatActivity() {
   companion object {
     private const val LAYER_ID = "line_layer"
     private const val SOURCE_ID = "line_source"
-    private const val COUNTRY_LABEL = "country-label"
+    private const val PITCH_OUTLINE = "pitch-outline"
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImplTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImplTest.kt
@@ -1,0 +1,97 @@
+package com.mapbox.maps.plugin.annotation
+
+import android.view.View
+import com.mapbox.maps.extension.style.StyleInterface
+import com.mapbox.maps.extension.style.layers.addLayer
+import com.mapbox.maps.extension.style.sources.addSource
+import com.mapbox.maps.plugin.annotation.generated.CircleAnnotationManager
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
+import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
+import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager
+import com.mapbox.maps.plugin.delegates.MapDelegateProvider
+import com.mapbox.maps.plugin.delegates.MapStyleStateDelegate
+import com.mapbox.maps.plugin.gestures.GesturesPlugin
+import io.mockk.*
+import junit.framework.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowValueConverter::class, ShadowLogger::class])
+class AnnotationPluginImplTest {
+  private val delegateProvider: MapDelegateProvider = mockk(relaxed = true)
+  private val style: StyleInterface = mockk(relaxed = true)
+  private val gesturesPlugin: GesturesPlugin = mockk(relaxed = true)
+  private val mapView: View = mockk(relaxed = true)
+  private lateinit var annotationPluginImpl: AnnotationPluginImpl
+
+  @Before
+  fun setUp() {
+    mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+    mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
+
+    val styleStateDelegate = mockk<MapStyleStateDelegate>()
+    every { delegateProvider.styleStateDelegate } returns styleStateDelegate
+    every { styleStateDelegate.isFullyLoaded() } returns true
+    every { style.addSource(any()) } just Runs
+    every { style.addLayer(any()) } just Runs
+    every { style.styleSourceExists(any()) } returns false
+    every { style.styleLayerExists(any()) } returns false
+    every { delegateProvider.mapPluginProviderDelegate.getPlugin(any<Class<GesturesPlugin>>()) } returns gesturesPlugin
+
+    annotationPluginImpl = AnnotationPluginImpl()
+    annotationPluginImpl.onDelegateProvider(delegateProvider)
+  }
+
+  @Test
+  fun createAndRemove() {
+    val circleAnnotationManager =
+      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.CircleAnnotation, null)
+    assert(circleAnnotationManager is CircleAnnotationManager)
+    val pointAnnotationManager =
+      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.PointAnnotation, null)
+    assert(pointAnnotationManager is PointAnnotationManager)
+    val polygonAnnotationManager =
+      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.PolygonAnnotation, null)
+    assert(polygonAnnotationManager is PolygonAnnotationManager)
+    val polylineAnnotationManager =
+      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.PolylineAnnotation, null)
+    assert(polylineAnnotationManager is PolylineAnnotationManager)
+    assertEquals(4, annotationPluginImpl.managerList.size)
+
+    annotationPluginImpl.removeAnnotationManager(circleAnnotationManager)
+    annotationPluginImpl.removeAnnotationManager(pointAnnotationManager)
+    annotationPluginImpl.removeAnnotationManager(polygonAnnotationManager)
+    annotationPluginImpl.removeAnnotationManager(polylineAnnotationManager)
+    assertEquals(0, annotationPluginImpl.managerList.size)
+    verify { circleAnnotationManager.onDestroy() }
+    verify { pointAnnotationManager.onDestroy() }
+    verify { polygonAnnotationManager.onDestroy() }
+    verify { polylineAnnotationManager.onDestroy() }
+  }
+
+  @Test
+  fun onStyleChanged() {
+    val circleAnnotationManager =
+      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.CircleAnnotation, null)
+    assert(circleAnnotationManager is CircleAnnotationManager)
+    val pointAnnotationManager =
+      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.PointAnnotation, null)
+    assert(pointAnnotationManager is PointAnnotationManager)
+    val polygonAnnotationManager =
+      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.PolygonAnnotation, null)
+    assert(polygonAnnotationManager is PolygonAnnotationManager)
+    val polylineAnnotationManager =
+      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.PolylineAnnotation, null)
+    assert(polylineAnnotationManager is PolylineAnnotationManager)
+    assertEquals(4, annotationPluginImpl.managerList.size)
+    annotationPluginImpl.onStyleChanged(style)
+    verify { circleAnnotationManager.onStyleLoaded(style) }
+    verify { pointAnnotationManager.onStyleLoaded(style) }
+    verify { polygonAnnotationManager.onStyleLoaded(style) }
+    verify { polylineAnnotationManager.onStyleLoaded(style) }
+  }
+}

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -79,6 +79,8 @@ class CircleAnnotationManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.removeStyleLayer(any()) } returns mockk()
+    every { style.removeStyleSource(any()) } returns mockk()
     every { style.pixelRatio } returns 1.0f
     every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
@@ -131,6 +133,8 @@ class CircleAnnotationManagerTest {
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(CircleAnnotation.ID_KEY, manager.getAnnotationIdKey())
     verify { style.addLayer(any()) }
+    every { style.styleLayerExists("test_layer") } returns true
+
     manager = CircleAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
     verify { style.addLayerBelow(any(), "test_layer") }
 
@@ -140,7 +144,11 @@ class CircleAnnotationManagerTest {
     assertEquals(1, manager.dragListeners.size)
     assertEquals(1, manager.clickListeners.size)
     assertEquals(1, manager.longClickListeners.size)
+    every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     manager.onDestroy()
+    verify { style.removeStyleLayer(any()) }
+    verify { style.removeStyleSource(any()) }
     verify { gesturesPlugin.removeOnMapClickListener(any()) }
     verify { gesturesPlugin.removeOnMapLongClickListener(any()) }
     verify { gesturesPlugin.removeOnMoveListener(any()) }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -82,6 +82,8 @@ class PointAnnotationManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.removeStyleLayer(any()) } returns mockk()
+    every { style.removeStyleSource(any()) } returns mockk()
     every { style.pixelRatio } returns 1.0f
     every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
@@ -156,6 +158,8 @@ class PointAnnotationManagerTest {
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(PointAnnotation.ID_KEY, manager.getAnnotationIdKey())
     verify { style.addLayer(any()) }
+    every { style.styleLayerExists("test_layer") } returns true
+
     manager = PointAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
     verify { style.addLayerBelow(any(), "test_layer") }
 
@@ -165,7 +169,11 @@ class PointAnnotationManagerTest {
     assertEquals(1, manager.dragListeners.size)
     assertEquals(1, manager.clickListeners.size)
     assertEquals(1, manager.longClickListeners.size)
+    every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     manager.onDestroy()
+    verify { style.removeStyleLayer(any()) }
+    verify { style.removeStyleSource(any()) }
     verify { gesturesPlugin.removeOnMapClickListener(any()) }
     verify { gesturesPlugin.removeOnMapLongClickListener(any()) }
     verify { gesturesPlugin.removeOnMoveListener(any()) }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -80,6 +80,8 @@ class PolygonAnnotationManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.removeStyleLayer(any()) } returns mockk()
+    every { style.removeStyleSource(any()) } returns mockk()
     every { style.pixelRatio } returns 1.0f
     every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
@@ -129,6 +131,8 @@ class PolygonAnnotationManagerTest {
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(PolygonAnnotation.ID_KEY, manager.getAnnotationIdKey())
     verify { style.addLayer(any()) }
+    every { style.styleLayerExists("test_layer") } returns true
+
     manager = PolygonAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
     verify { style.addLayerBelow(any(), "test_layer") }
 
@@ -138,7 +142,11 @@ class PolygonAnnotationManagerTest {
     assertEquals(1, manager.dragListeners.size)
     assertEquals(1, manager.clickListeners.size)
     assertEquals(1, manager.longClickListeners.size)
+    every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     manager.onDestroy()
+    verify { style.removeStyleLayer(any()) }
+    verify { style.removeStyleSource(any()) }
     verify { gesturesPlugin.removeOnMapClickListener(any()) }
     verify { gesturesPlugin.removeOnMapLongClickListener(any()) }
     verify { gesturesPlugin.removeOnMoveListener(any()) }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -81,6 +81,8 @@ class PolylineAnnotationManagerTest {
     every { style.getSource(any()) } returns null
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
+    every { style.removeStyleLayer(any()) } returns mockk()
+    every { style.removeStyleSource(any()) } returns mockk()
     every { style.pixelRatio } returns 1.0f
     every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
@@ -134,6 +136,8 @@ class PolylineAnnotationManagerTest {
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(PolylineAnnotation.ID_KEY, manager.getAnnotationIdKey())
     verify { style.addLayer(any()) }
+    every { style.styleLayerExists("test_layer") } returns true
+
     manager = PolylineAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
     verify { style.addLayerBelow(any(), "test_layer") }
 
@@ -143,7 +147,11 @@ class PolylineAnnotationManagerTest {
     assertEquals(1, manager.dragListeners.size)
     assertEquals(1, manager.clickListeners.size)
     assertEquals(1, manager.longClickListeners.size)
+    every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     manager.onDestroy()
+    verify { style.removeStyleLayer(any()) }
+    verify { style.removeStyleSource(any()) }
     verify { gesturesPlugin.removeOnMapClickListener(any()) }
     verify { gesturesPlugin.removeOnMapLongClickListener(any()) }
     verify { gesturesPlugin.removeOnMoveListener(any()) }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
@@ -22,4 +22,11 @@ interface AnnotationPlugin : MapPlugin, MapSizePlugin, MapStyleObserverPlugin {
     type: AnnotationType,
     annotationConfig: AnnotationConfig?
   ): AnnotationManager<*, *, *, *, *, *, *>
+
+  /**
+   * Removes an annotation manager, this will remove the underlying layer and source from the style.
+   * A removed annotation manager will not be able to reuse anymore, users need to create new annotation manger
+   * to add annotations.
+   */
+  fun removeAnnotationManager(annotationManager: AnnotationManager<*, *, *, *, *, *, *>)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #291 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Add removeAnnotationManager API; Fix crash if the belowLayerId doesn't exist on the current style</changelog>`.

### Summary of changes

- Add removeAnnotationManager API to enable users remove the useless annotation manager and the inside layer and source

- If user set the belowLayerId in config and the current style doesn't have this layer, it will crash while adding the annotation layer. This pr adds the check for this below layer and will add the annotation layer directly if the below layer doesn't esist.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->