### PR TITLE
Auto active LocationComponent while style loaded.

### DIFF
--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
@@ -148,6 +148,7 @@ class LocationComponentPluginImpl : LocationComponentPlugin, LocationConsumer,
    * Called when a new Style is loaded.
    */
   override fun onStyleChanged(styleDelegate: StyleInterface) {
+    applySettings()
     locationPuckManager?.let {
       if (!it.isLayerInitialised()) {
         it.initialize(styleDelegate)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationProviderImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationProviderImpl.kt
@@ -8,6 +8,7 @@ import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.common.Logger
 import com.mapbox.geojson.Point
 import java.util.concurrent.CopyOnWriteArrayList
@@ -15,7 +16,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 /**
  * Default Location Provider implementation, it can be overwritten by users.
  */
-internal class LocationProviderImpl(context: Context) : LocationProvider, LocationEngineCallback<LocationEngineResult> {
+internal class LocationProviderImpl(private val context: Context) : LocationProvider, LocationEngineCallback<LocationEngineResult> {
   private val locationEngine = LocationEngineProvider.getBestLocationEngine(context)
 
   private val locationEngineRequest =
@@ -28,9 +29,11 @@ internal class LocationProviderImpl(context: Context) : LocationProvider, Locati
 
   @SuppressLint("MissingPermission")
   private fun requestLocationUpdates() {
-    locationEngine.requestLocationUpdates(
-      locationEngineRequest, this, Looper.getMainLooper()
-    )
+    if (PermissionsManager.areLocationPermissionsGranted(context)) {
+      locationEngine.requestLocationUpdates(
+        locationEngineRequest, this, Looper.getMainLooper()
+      )
+    }
   }
 
   private fun notifyLocationUpdates(location: Location) {
@@ -76,7 +79,9 @@ internal class LocationProviderImpl(context: Context) : LocationProvider, Locati
       requestLocationUpdates()
     }
     locationConsumers.add(locationConsumer)
-    locationEngine.getLastLocation(this)
+    if (PermissionsManager.areLocationPermissionsGranted(context)) {
+      locationEngine.getLastLocation(this)
+    }
   }
 
   /**

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationProviderImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationProviderImpl.kt
@@ -31,6 +31,7 @@ internal class LocationProviderImpl(private val context: Context) :
 
   private var handler: Handler? = null
   private var runnable: Runnable? = null
+  private var updateDelay = INIT_UPDATE_DELAY
 
   @SuppressLint("MissingPermission")
   private fun requestLocationUpdates() {
@@ -43,7 +44,12 @@ internal class LocationProviderImpl(private val context: Context) :
         handler = Handler()
         runnable = Runnable { requestLocationUpdates() }
       }
-      handler?.postDelayed(runnable, UPDATE_DELAY)
+      if (updateDelay * 2 < MAX_UPDATE_DELAY) {
+        updateDelay *= 2
+      } else {
+        updateDelay = MAX_UPDATE_DELAY
+      }
+      handler?.postDelayed(runnable, updateDelay)
       Logger.w(
         TAG,
         "Missing location permission, location component will not take effect before location permission is granted."
@@ -119,6 +125,7 @@ internal class LocationProviderImpl(private val context: Context) :
 
   private companion object {
     private const val TAG = "MapboxLocationProvider"
-    private const val UPDATE_DELAY = 5000L
+    private const val INIT_UPDATE_DELAY = 100L
+    private const val MAX_UPDATE_DELAY = 5000L
   }
 }

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationProviderImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationProviderImpl.kt
@@ -16,7 +16,8 @@ import java.util.concurrent.CopyOnWriteArrayList
 /**
  * Default Location Provider implementation, it can be overwritten by users.
  */
-internal class LocationProviderImpl(private val context: Context) : LocationProvider, LocationEngineCallback<LocationEngineResult> {
+internal class LocationProviderImpl(private val context: Context) :
+  LocationProvider, LocationEngineCallback<LocationEngineResult> {
   private val locationEngine = LocationEngineProvider.getBestLocationEngine(context)
 
   private val locationEngineRequest =
@@ -32,6 +33,11 @@ internal class LocationProviderImpl(private val context: Context) : LocationProv
     if (PermissionsManager.areLocationPermissionsGranted(context)) {
       locationEngine.requestLocationUpdates(
         locationEngineRequest, this, Looper.getMainLooper()
+      )
+    } else {
+      Logger.w(
+        TAG,
+        "Missing location permission, location component will not take effect before location permission is granted."
       )
     }
   }
@@ -81,6 +87,11 @@ internal class LocationProviderImpl(private val context: Context) : LocationProv
     locationConsumers.add(locationConsumer)
     if (PermissionsManager.areLocationPermissionsGranted(context)) {
       locationEngine.getLastLocation(this)
+    } else {
+      Logger.w(
+        TAG,
+        "Missing location permission, location component will not take effect before location permission is granted."
+      )
     }
   }
 

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -71,6 +71,18 @@ class LocationPuckManagerTest {
     verify { animationManager.applyPulsingAnimationSettings(settings) }
     verify { locationLayerRenderer.addLayers(positionManager) }
     verify { locationLayerRenderer.initializeComponents(style) }
+    verify { locationLayerRenderer.hide() }
+  }
+
+  @Test
+  fun testInitialiseWithLocation() {
+    locationPuckManager.lastLocation = Point.fromLngLat(0.0, 0.0)
+    locationPuckManager.initialize(style)
+    verify { animationManager.setLocationLayerRenderer(locationLayerRenderer) }
+    verify { animationManager.setUpdateListeners(any(), any()) }
+    verify { animationManager.applyPulsingAnimationSettings(settings) }
+    verify { locationLayerRenderer.addLayers(positionManager) }
+    verify { locationLayerRenderer.initializeComponents(style) }
     verify { locationLayerRenderer.show() }
   }
 
@@ -116,7 +128,12 @@ class LocationPuckManagerTest {
     callbackSlot.captured.invoke(style)
     verify { locationLayerRenderer.addLayers(positionManager) }
     verify { locationLayerRenderer.initializeComponents(style) }
-    verify { locationLayerRenderer.show() }
+    verify { locationPuckManager.hide() }
+
+    locationPuckManager.lastLocation = Point.fromLngLat(0.0, 0.0)
+    locationPuckManager.updateSettings(settings)
+    callbackSlot.captured.invoke(style)
+    verify { locationPuckManager.show() }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #323 #324 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Enable LocationComponent automatically when style loaded; fix null island location puck</changelog>`.

### Summary of changes

- The root cause for location not shown when accepting permissions is we need to get the style to active location component 
and the style has not been set yet while init location component.
This pr listen to the style load event and trigger `applySettings ` to reactive location component and apply a loop request to get the location update after location permission is granted.

- This pr also make the location puck invisible before getting the real location from the device to fix the null island issue

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->