### PR TITLE
[animation] Trigger nested high-level animator listener correctly

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -292,7 +292,6 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
               }
               AnimationFinishStatus.ENDED -> highLevelListener?.onAnimationEnd(animation)
             }
-            highLevelListener = null
           }
         } ?: throw RuntimeException(
           "Could not finish animation in CameraManager! " +

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -893,6 +893,39 @@ class CameraAnimationsPluginImplTest {
     assertEquals(1, counter)
   }
 
+  @Test
+  fun nestedHighLevelAnimationListeners() {
+    val listener = CameraAnimatorListener()
+    shadowOf(getMainLooper()).pause()
+    cameraAnimationsPluginImpl.flyTo(
+      CameraOptions.Builder()
+        .center(Point.fromLngLat(VALUE, VALUE))
+        .bearing(VALUE)
+        .build(),
+      mapAnimationOptions {
+        duration(50L)
+        animatorListener(object : AnimatorListenerAdapter() {
+          override fun onAnimationEnd(animation: Animator?) {
+            super.onAnimationEnd(animation)
+            cameraAnimationsPluginImpl.flyTo(
+              CameraOptions.Builder()
+                .center(Point.fromLngLat(VALUE, VALUE))
+                .bearing(VALUE)
+                .build(),
+              mapAnimationOptions {
+                duration(50L)
+                animatorListener(listener)
+              }
+            )
+          }
+        })
+      }
+    )
+    shadowOf(getMainLooper()).idle()
+    assertEquals(1, listener.startedCount)
+    assertEquals(1, listener.endedCount)
+  }
+
   class LifecycleListener : CameraAnimationsLifecycleListener {
     var starting = false
     var interrupting = false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>[animation] Trigger nested high-level animator listener correctly.</changelog>`.

### Summary of changes

In case of starting high-level animation in `onAnimationEnded` of another high-level animation the nested one would not report animation end / cancel etc callbacks. This is now fixed.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->