### PR TITLE
Introduce ResourceOptionsManager to configure default resource options, remove xml config for paths.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
@@ -3,6 +3,7 @@ package com.mapbox.maps.testapp.examples
 import android.os.Bundle
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.common.TileStore
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
 import com.mapbox.maps.plugin.*
@@ -22,6 +23,13 @@ class MapViewCustomizationActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     // Create  a custom CredentialsManager with a token and set it to CredentialsManager.shared, so that all MapViews created with default config will apply this token.
     CredentialsManager.default.setAccessToken(getString(R.string.mapbox_access_token))
+
+    // Create a custom ResourceOptionsManager with customised tile store and tile size, so that all MapViews created with default config will apply these settings.
+    ResourceOptionsManager.getDefault(this).update {
+      tileStore(TileStore.getInstance())
+      cacheSize(75_000L)
+    }
+
     setContentView(R.layout.activity_map_view_customization)
     // all options provided in xml file - so we just load style
     mapView.getMapboxMap().loadStyleUri(Style.DARK)
@@ -47,10 +55,10 @@ class MapViewCustomizationActivity : AppCompatActivity() {
       PLUGIN_ATTRIBUTION_CLASS_NAME
     )
 
-    // set token and cache size for this particular map view
-    val resourceOptions = ResourceOptions.Builder()
+    // set token and cache size for this particular map view, these settings will overwrite the default value.
+    val resourceOptions = ResourceOptions.Builder().applyDefaultParams(this)
       .accessToken(getString(R.string.mapbox_access_token))
-      .cacheSize(75_000L)
+      .cacheSize(10_000L)
       .build()
 
     // set initial camera position

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
@@ -27,6 +27,7 @@ class MapViewCustomizationActivity : AppCompatActivity() {
     // Create a custom ResourceOptionsManager with customised tile store and tile size, so that all MapViews created with default config will apply these settings.
     ResourceOptionsManager.getDefault(this).update {
       tileStore(TileStore.getInstance())
+      tileStoreUsageMode(TileStoreUsageMode.READ_AND_UPDATE)
       cacheSize(75_000L)
     }
 
@@ -38,7 +39,7 @@ class MapViewCustomizationActivity : AppCompatActivity() {
 
   private fun configureMapViewFromCode() {
     // set map options
-    val mapOptions = MapOptions.Builder()
+    val mapOptions = MapOptions.Builder().applyDefaultParams(this)
       .constrainMode(ConstrainMode.HEIGHT_ONLY)
       .glyphsRasterizationOptions(
         GlyphsRasterizationOptions.Builder()
@@ -59,6 +60,7 @@ class MapViewCustomizationActivity : AppCompatActivity() {
     val resourceOptions = ResourceOptions.Builder().applyDefaultParams(this)
       .accessToken(getString(R.string.mapbox_access_token))
       .cacheSize(10_000L)
+      .tileStoreUsageMode(TileStoreUsageMode.DISABLED)
       .build()
 
     // set initial camera position

--- a/sdk/src/main/java/com/mapbox/maps/CredentialsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/CredentialsManager.kt
@@ -5,7 +5,7 @@ import android.content.Context
 /**
  * Convenience class that holds [MapboxMap] related token.
  * `CredentialsManager` could be created per `MapView` instance if given view should use some specific token.
- * Most common use-case when all `MapView`s should use same token could be handled by using `CredentialsManager.shared` static object.
+ * Most common use-case when all `MapView`s should use same token could be handled by using `CredentialsManager.default` static object.
  *
  * @property accessToken the token will be applied.
  */

--- a/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
@@ -40,26 +40,15 @@ data class MapInitOptions constructor(
      * Get a default [ResourceOptions] with token from default [CredentialsManager]
      * @property context the context of the application.
      */
-    fun getDefaultResourceOptions(context: Context): ResourceOptions = ResourceOptionsManager.getDefault(context).resourceOptions
+    fun getDefaultResourceOptions(context: Context): ResourceOptions =
+      ResourceOptionsManager.getDefault(context).resourceOptions
 
     /**
      * Get a default [MapOptions] with reasterization mode [GlyphsRasterizationMode#ALL_GLYPHS_RASTERIZED_LOCALLY]
      * @property context the context of the application.
      */
-    fun getDefaultMapOptions(context: Context): MapOptions = MapOptions.Builder()
-      .glyphsRasterizationOptions(
-        GlyphsRasterizationOptions.Builder()
-          .rasterizationMode(GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY)
-          .fontFamily(FontUtils.extractValidFont(null))
-          .build()
-      )
-      .pixelRatio(context.resources.displayMetrics.density)
-      .constrainMode(ConstrainMode.HEIGHT_ONLY)
-      .contextMode(ContextMode.UNIQUE)
-      .orientation(NorthOrientation.UPWARDS)
-      .viewportMode(ViewportMode.DEFAULT)
-      .crossSourceCollisions(true)
-      .build()
+    fun getDefaultMapOptions(context: Context): MapOptions =
+      MapOptions.Builder().applyDefaultParams(context).build()
 
     /**
      * Get a default selection of Mapbox created plugins.
@@ -78,4 +67,34 @@ data class MapInitOptions constructor(
       )
     }
   }
+}
+
+/**
+ * Get a default [MapOptions.Builder] with reasterization mode [GlyphsRasterizationMode#ALL_GLYPHS_RASTERIZED_LOCALLY]
+ * @property context the context of the application.
+ * @return [MapOptions.Builder]
+ */
+fun MapOptions.Builder.applyDefaultParams(context: Context): MapOptions.Builder = also {
+  glyphsRasterizationOptions(
+    GlyphsRasterizationOptions.Builder()
+      .rasterizationMode(GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY)
+      .fontFamily(FontUtils.extractValidFont(null))
+      .build()
+  )
+  pixelRatio(context.resources.displayMetrics.density)
+  constrainMode(ConstrainMode.HEIGHT_ONLY)
+  contextMode(ContextMode.UNIQUE)
+  orientation(NorthOrientation.UPWARDS)
+  viewportMode(ViewportMode.DEFAULT)
+  crossSourceCollisions(true)
+}
+
+/**
+ * Get a default [ResourceOptions.Builder] with token from default [CredentialsManager]
+ * @property context the context of the application.
+ */
+fun ResourceOptions.Builder.applyDefaultParams(context: Context): ResourceOptions.Builder = also {
+  accessToken(CredentialsManager.default.getAccessToken(context))
+  cachePath("${context.filesDir.absolutePath}/$DATABASE_NAME")
+  cacheSize(DEFAULT_CACHE_SIZE) // 50 mb
 }

--- a/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
@@ -37,19 +37,10 @@ data class MapInitOptions constructor(
    */
   companion object {
     /**
-     * The default cache size, which is 50MB
-     */
-    const val DEFAULT_CACHE_SIZE = 1024 * 1024 * 50L
-
-    /**
      * Get a default [ResourceOptions] with token from default [CredentialsManager]
      * @property context the context of the application.
      */
-    fun getDefaultResourceOptions(context: Context): ResourceOptions = ResourceOptions.Builder()
-      .accessToken(CredentialsManager.default.getAccessToken(context))
-      .cachePath("${context.filesDir.absolutePath}/$DATABASE_NAME")
-      .cacheSize(DEFAULT_CACHE_SIZE) // 50 mb
-      .build()
+    fun getDefaultResourceOptions(context: Context): ResourceOptions = ResourceOptionsManager.getDefault(context).resourceOptions
 
     /**
      * Get a default [MapOptions] with reasterization mode [GlyphsRasterizationMode#ALL_GLYPHS_RASTERIZED_LOCALLY]

--- a/sdk/src/main/java/com/mapbox/maps/MapboxConstants.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxConstants.kt
@@ -10,6 +10,11 @@ import java.util.*
 const val DATABASE_NAME = "mbx.db"
 
 /**
+ * The default cache size, which is 50MB
+ */
+const val DEFAULT_CACHE_SIZE = 1024 * 1024 * 50L
+
+/**
  * Default Locale for data processing (ex: String.toLowerCase(com.mapbox.maps.getMAPBOX_LOCALE, "foo"))
  */
 val MAPBOX_LOCALE: Locale = Locale.US

--- a/sdk/src/main/java/com/mapbox/maps/ResourceOptionsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ResourceOptionsManager.kt
@@ -7,12 +7,11 @@ import android.content.Context
  * `ResourceOptionsManager` could be created per `MapView` instance if given view should use some specific resource options.
  * Most common use-case when all `MapView`s should use same resource options could be handled by using `ResourceOptionsManager.getDefault(context: Context)` static object.
  *
- * @property context the context .
+ * @property resourceOptions the initial resource options.
  */
-class ResourceOptionsManager(private var context: Context) {
-  var resourceOptions = ResourceOptions.Builder().applyDefaultParams(context)
-    .build()
-    private set
+class ResourceOptionsManager(
+  var resourceOptions: ResourceOptions
+) {
 
   /**
    * Update specific resource options in a closure.
@@ -32,7 +31,10 @@ class ResourceOptionsManager(private var context: Context) {
      */
     fun getDefault(context: Context): ResourceOptionsManager {
       if (!this::default.isInitialized) {
-        default = ResourceOptionsManager(context)
+        default = ResourceOptionsManager(
+          ResourceOptions.Builder().applyDefaultParams(context)
+            .build()
+        )
       }
       return default
     }

--- a/sdk/src/main/java/com/mapbox/maps/ResourceOptionsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ResourceOptionsManager.kt
@@ -1,0 +1,48 @@
+package com.mapbox.maps
+
+import android.content.Context
+
+/**
+ * Convenience class that holds the default ResourceOptions.
+ * `ResourceOptionsManager` could be created per `MapView` instance if given view should use some specific resource options.
+ * Most common use-case when all `MapView`s should use same resource options could be handled by using `ResourceOptionsManager.getDefault(context: Context)` static object.
+ *
+ * @property context the context .
+ */
+data class ResourceOptionsManager(private var context: Context) {
+  var resourceOptions = ResourceOptions.Builder()
+    .accessToken(CredentialsManager.default.getAccessToken(context))
+    .cachePath("${context.filesDir.absolutePath}/$DATABASE_NAME")
+    .cacheSize(DEFAULT_CACHE_SIZE) // 50 mb
+    .build()
+    private set
+
+  /**
+   * Update specific resource options in a closure.
+   */
+  fun update(block: ResourceOptions.Builder.() -> Unit) {
+    resourceOptions = resourceOptions.toBuilder().apply(block).build()
+  }
+
+  /**
+   * Static variables and methods.
+   */
+  companion object {
+    private lateinit var default: ResourceOptionsManager
+
+    /**
+     * The default cache size, which is 50MB
+     */
+    const val DEFAULT_CACHE_SIZE = 1024 * 1024 * 50L
+
+    /**
+     * The default shared instance with default resource options.
+     */
+    fun getDefault(context: Context): ResourceOptionsManager {
+      if (!this::default.isInitialized) {
+        default = ResourceOptionsManager(context)
+      }
+      return default
+    }
+  }
+}

--- a/sdk/src/main/java/com/mapbox/maps/ResourceOptionsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ResourceOptionsManager.kt
@@ -29,6 +29,7 @@ class ResourceOptionsManager(
     /**
      * The default shared instance with default resource options.
      */
+    @Synchronized
     fun getDefault(context: Context): ResourceOptionsManager {
       if (!this::default.isInitialized) {
         default = ResourceOptionsManager(

--- a/sdk/src/main/java/com/mapbox/maps/ResourceOptionsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ResourceOptionsManager.kt
@@ -9,11 +9,8 @@ import android.content.Context
  *
  * @property context the context .
  */
-data class ResourceOptionsManager(private var context: Context) {
-  var resourceOptions = ResourceOptions.Builder()
-    .accessToken(CredentialsManager.default.getAccessToken(context))
-    .cachePath("${context.filesDir.absolutePath}/$DATABASE_NAME")
-    .cacheSize(DEFAULT_CACHE_SIZE) // 50 mb
+class ResourceOptionsManager(private var context: Context) {
+  var resourceOptions = ResourceOptions.Builder().applyDefaultParams(context)
     .build()
     private set
 
@@ -29,11 +26,6 @@ data class ResourceOptionsManager(private var context: Context) {
    */
   companion object {
     private lateinit var default: ResourceOptionsManager
-
-    /**
-     * The default cache size, which is 50MB
-     */
-    const val DEFAULT_CACHE_SIZE = 1024 * 1024 * 50L
 
     /**
      * The default shared instance with default resource options.

--- a/sdk/src/main/java/com/mapbox/maps/ResourcesAttributeParser.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ResourcesAttributeParser.kt
@@ -3,7 +3,6 @@ package com.mapbox.maps
 import android.content.Context
 import android.content.res.TypedArray
 import android.util.AttributeSet
-import com.mapbox.common.TileStore
 
 /**
  * Utility class for parsing [AttributeSet] to [ResourcesSettings].
@@ -20,29 +19,26 @@ internal object ResourcesAttributeParser {
     typedArray: TypedArray,
     credentialsManager: CredentialsManager
   ): ResourceOptions {
-    val accessTokenString: String =
-      typedArray.getString(R.styleable.mapbox_MapView_mapbox_resourcesAccessToken)
-        ?: credentialsManager.getAccessToken(context)
+    val builder = ResourceOptionsManager.getDefault(context).resourceOptions.toBuilder()
 
-    val cachePathString =
-      typedArray.getString(R.styleable.mapbox_MapView_mapbox_resourcesCachePath)
-        ?: "${context.filesDir.absolutePath}/$DATABASE_NAME"
+    if (typedArray.hasValue(R.styleable.mapbox_MapView_mapbox_resourcesAccessToken)) {
+      builder.accessToken(
+        typedArray.getString(R.styleable.mapbox_MapView_mapbox_resourcesAccessToken)
+          ?: credentialsManager.getAccessToken(context)
+      )
+    }
 
-    val tileStorePathString =
-      typedArray.getString(R.styleable.mapbox_MapView_mapbox_resourcesTileStorePath)
+    if (typedArray.hasValue(R.styleable.mapbox_MapView_mapbox_resourcesBaseUrl)) {
+      builder.baseURL(typedArray.getString(R.styleable.mapbox_MapView_mapbox_resourcesBaseUrl))
+    }
 
-    val builder = ResourceOptions.Builder()
-      .accessToken(accessTokenString)
-      .baseURL(typedArray.getString(R.styleable.mapbox_MapView_mapbox_resourcesBaseUrl))
-      .cachePath(cachePathString)
-      .cacheSize(
+    if (typedArray.hasValue(R.styleable.mapbox_MapView_mapbox_resourcesCacheSize)) {
+      builder.cacheSize(
         typedArray.getFloat(
           R.styleable.mapbox_MapView_mapbox_resourcesCacheSize,
-          MapInitOptions.DEFAULT_CACHE_SIZE.toFloat() // 50 mb
+          ResourceOptionsManager.DEFAULT_CACHE_SIZE.toFloat() // 50 mb
         ).toLong()
       )
-    tileStorePathString?.let {
-      builder.tileStore(TileStore.getInstance(it))
     }
     return builder.build()
   }

--- a/sdk/src/main/java/com/mapbox/maps/ResourcesAttributeParser.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ResourcesAttributeParser.kt
@@ -36,7 +36,7 @@ internal object ResourcesAttributeParser {
       builder.cacheSize(
         typedArray.getFloat(
           R.styleable.mapbox_MapView_mapbox_resourcesCacheSize,
-          ResourceOptionsManager.DEFAULT_CACHE_SIZE.toFloat() // 50 mb
+          DEFAULT_CACHE_SIZE.toFloat() // 50 mb
         ).toLong()
       )
     }

--- a/sdk/src/main/res-public/values/public.xml
+++ b/sdk/src/main/res-public/values/public.xml
@@ -6,12 +6,6 @@
     <!-- An URL that defines the base for API requests. -->
     <public name="mapbox_resourcesBaseUrl" type="attr" />
 
-    <!-- The path to the assets. -->
-    <public name="mapbox_resourcesCachePath" type="attr" />
-
-    <!-- The path to the tile store. -->
-    <public name="mapbox_resourcesTileStorePath" type="attr" />
-
     <!-- The size of the cache. -->
     <public name="mapbox_resourcesCacheSize" type="attr" />
 

--- a/sdk/src/main/res/values/attrs.xml
+++ b/sdk/src/main/res/values/attrs.xml
@@ -52,10 +52,6 @@
         <attr name="mapbox_resourcesAccessToken" format="string" />
         <!-- An URL that defines the base for API requests. -->
         <attr name="mapbox_resourcesBaseUrl" format="string" />
-        <!-- The path to the assets. -->
-        <attr name="mapbox_resourcesCachePath" format="string" />
-        <!-- The path to the tile store. -->
-        <attr name="mapbox_resourcesTileStorePath" format="string" />
         <!-- The size of the cache. -->
         <attr name="mapbox_resourcesCacheSize" format="float" />
 

--- a/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
@@ -78,7 +78,7 @@ class MapInitOptionsTest {
     val mapboxMapOptions = MapInitOptions(context)
     assertEquals("token", mapboxMapOptions.resourceOptions.accessToken)
     assertTrue(mapboxMapOptions.resourceOptions.cachePath!!.endsWith("foobar/mbx.db"))
-    assertEquals(MapInitOptions.DEFAULT_CACHE_SIZE, mapboxMapOptions.resourceOptions.cacheSize)
+    assertEquals(ResourceOptionsManager.DEFAULT_CACHE_SIZE, mapboxMapOptions.resourceOptions.cacheSize)
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
@@ -78,7 +78,7 @@ class MapInitOptionsTest {
     val mapboxMapOptions = MapInitOptions(context)
     assertEquals("token", mapboxMapOptions.resourceOptions.accessToken)
     assertTrue(mapboxMapOptions.resourceOptions.cachePath!!.endsWith("foobar/mbx.db"))
-    assertEquals(ResourceOptionsManager.DEFAULT_CACHE_SIZE, mapboxMapOptions.resourceOptions.cacheSize)
+    assertEquals(DEFAULT_CACHE_SIZE, mapboxMapOptions.resourceOptions.cacheSize)
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
@@ -6,6 +6,7 @@ import com.mapbox.common.ShadowLogger
 import com.mapbox.maps.plugin.*
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -29,6 +30,13 @@ class MapInitOptionsTest {
     every { context.filesDir } returns File("foobar")
     every { context.resources.displayMetrics } returns displayMetrics
     displayMetrics.density = 1f
+  }
+
+  @After
+  fun cleanUp() {
+    ResourceOptionsManager.getDefault(context).resourceOptions =
+      ResourceOptions.Builder().applyDefaultParams(context)
+        .build()
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/ResourceAttributeParserTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ResourceAttributeParserTest.kt
@@ -22,10 +22,10 @@ class ResourceAttributeParserTest {
     every { context.packageName } returns "foobar"
     every { resources.getIdentifier("mapbox_access_token", "string", "foobar") } returns -1
     every { context.getString(-1) } returns "pk.foobar"
-    every { context.filesDir } returns File("/sdcard/data")
     every { typedArray.getString(any()) } returns null
     every { typedArray.getBoolean(any(), any()) } returns true
     every { typedArray.getFloat(any(), any()) } returns 99.0f
+    every { typedArray.hasValue(any()) } returns true
   }
 
   @Test
@@ -34,7 +34,6 @@ class ResourceAttributeParserTest {
       ResourcesAttributeParser.parseResourcesOptions(context, typedArray, CredentialsManager.default)
     assertEquals("pk.foobar", resourceOptions.accessToken)
     assertEquals(null, resourceOptions.baseURL)
-    assertEquals("/sdcard/data/mbx.db", resourceOptions.cachePath)
     assertEquals(99L, resourceOptions.cacheSize)
   }
 

--- a/sdk/src/test/java/com/mapbox/maps/ResourceOptionsManagerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ResourceOptionsManagerTest.kt
@@ -1,0 +1,64 @@
+package com.mapbox.maps
+
+import android.content.Context
+import com.mapbox.common.TileStore
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class ResourceOptionsManagerTest {
+
+  private val context: Context = mockk(relaxUnitFun = true)
+  private val tileStore: TileStore = mockk(relaxUnitFun = true)
+
+  @Before
+  fun setUp() {
+    CredentialsManager.default.setAccessToken("token")
+    every { context.filesDir } returns File("foobar")
+  }
+
+  @After
+  fun cleanUp() {
+    ResourceOptionsManager.getDefault(context).resourceOptions =
+      ResourceOptions.Builder().applyDefaultParams(context)
+        .build()
+  }
+
+  @Test
+  fun getDefaultResourceOptionsManagerTest() {
+    val defaultResourceOptionsManager = ResourceOptionsManager.getDefault(context)
+    assertEquals("token", defaultResourceOptionsManager.resourceOptions.accessToken)
+    Assert.assertTrue(defaultResourceOptionsManager.resourceOptions.cachePath!!.endsWith("foobar/mbx.db"))
+    assertEquals(DEFAULT_CACHE_SIZE, defaultResourceOptionsManager.resourceOptions.cacheSize)
+  }
+
+  @Test
+  fun updateDefaultResourceOptionsManagerTest() {
+    val defaultResourceOptionsManager = ResourceOptionsManager.getDefault(context)
+    defaultResourceOptionsManager.update {
+      cacheSize(1000L)
+      accessToken("abc")
+      cachePath("cachePath")
+      tileStore(tileStore)
+      tileStoreUsageMode(TileStoreUsageMode.READ_AND_UPDATE)
+      baseURL("baseUrl")
+    }
+    assertEquals("abc", ResourceOptionsManager.getDefault(context).resourceOptions.accessToken)
+    assertEquals("cachePath", ResourceOptionsManager.getDefault(context).resourceOptions.cachePath)
+    assertEquals(1000L, ResourceOptionsManager.getDefault(context).resourceOptions.cacheSize)
+    assertEquals(tileStore, ResourceOptionsManager.getDefault(context).resourceOptions.tileStore)
+    assertEquals(
+      TileStoreUsageMode.READ_AND_UPDATE,
+      ResourceOptionsManager.getDefault(context).resourceOptions.tileStoreUsageMode
+    )
+    assertEquals("baseUrl", ResourceOptionsManager.getDefault(context).resourceOptions.baseURL)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes:  #329 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Introduce ResourceOptionsManager to configure the default resource options, and removed the xml configuration options for cache path and tile store path.</changelog>`.

### Summary of changes

This PR introduces ResourceOptionsManager to configure the default resource options, and removed the xml configuration options for cache path and tile store path.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->