### PR TITLE
Restore the default resource options when exiting the MapViewCustomizationActivity.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
@@ -70,7 +70,8 @@ class MapViewCustomizationActivity : AppCompatActivity() {
       .bearing(120.0)
       .build()
 
-    val mapInitOptions = MapInitOptions(this, resourceOptions, mapOptions, plugins, initialCameraOptions, true)
+    val mapInitOptions =
+      MapInitOptions(this, resourceOptions, mapOptions, plugins, initialCameraOptions, true)
 
     // create view programmatically and add to root layout
     customMapView = MapView(this, mapInitOptions)
@@ -106,5 +107,8 @@ class MapViewCustomizationActivity : AppCompatActivity() {
     super.onDestroy()
     mapView.onDestroy()
     customMapView.onDestroy()
+    // Restore the default resource settings, otherwise it will affect other activities
+    ResourceOptionsManager.getDefault(this).resourceOptions =
+      ResourceOptions.Builder().applyDefaultParams(this).build()
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes
Restore the default resource options when exiting the MapViewCustomizationActivity, since it will affect other activities as well.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->