### PR TITLE
Make sure to execute first camera update

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -303,6 +303,11 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
 
   private fun registerInternalUpdateListener(animator: CameraAnimator<*>) {
     animator.addInternalUpdateListener {
+      // set current animator value
+      updateCameraValue(animator)
+      // add current animator to queue-set if was not present
+      runningAnimatorsQueue.add(it)
+
       // main idea here is not to update map on each option change
       // we perform jump based on update tick of first (oldest) animation
       val firstAnimator = if (runningAnimatorsQueue.iterator().hasNext()) {
@@ -333,10 +338,6 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
         // reset values
         cameraOptionsBuilder = CameraOptions.Builder()
       }
-      // set current animator value
-      updateCameraValue(animator)
-      // add current animator to queue-set if was not present
-      runningAnimatorsQueue.add(it)
     }
   }
 

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -21,8 +21,12 @@ import kotlin.properties.Delegates
  * It is responsible for:
  *   - Storing all the [ValueAnimator]'s that could be run. Only specific camera animators could be used in this plugin.
  *   - Controlling animation execution - only one [ValueAnimator] of certain type could be run at a time.
- *   If some another animation with same [CameraAnimator.type] is about to start previous one will be cancelled.
+ *     If some another animation with same [CameraAnimator.type] is about to start previous one will be cancelled.
  *   - Giving possibility to listen to [CameraOptions] values changes during animations via listeners.
+ *   - If several animations of different [CameraAnimator.type] are running simultaneously map camera
+ *     will be updated only on oldest animation update (the oldest is the one that was started first).
+ *     That actually means that animation start order matters. High-level animations [flyTo] and [easeTo]
+ *     will always trigger camera center animator first.
  *
  * [CameraAnimationsPluginImpl] is NOT thread-safe meaning all animations must be started from one thread.
  * However, it doesn't have to be the UI thread.

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -287,10 +287,6 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
             unregisterAnimators(this, cancelAnimators = false)
           }
           if (runningAnimatorsQueue.isEmpty()) {
-            if (animator.type == CameraAnimatorType.ANCHOR) {
-              anchor = animatedValue as ScreenCoordinate
-            }
-            performMapJump(cameraOptionsBuilder.anchor(anchor).build())
             mapTransformDelegate.setUserAnimationInProgress(false)
           }
           lifecycleListeners.forEach {

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
@@ -40,6 +40,17 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
     val animationList = mutableListOf<ValueAnimator>()
     val currentCameraState = mapCameraManagerDelegate.cameraState
 
+    cameraOptions.center?.let { target ->
+      animationList.add(
+        CameraCenterAnimator(
+          options = cameraAnimatorOptions(target) {
+            startValue(currentCameraState.center)
+          },
+          block = defaultAnimationParameters[CameraAnimatorType.CENTER]
+        )
+      )
+    }
+
     cameraOptions.anchor?.let {
       animationList.add(
         CameraAnchorAnimator(
@@ -91,17 +102,6 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
             startValue(currentCameraState.pitch)
           },
           block = defaultAnimationParameters[CameraAnimatorType.PITCH]
-        )
-      )
-    }
-
-    cameraOptions.center?.let { target ->
-      animationList.add(
-        CameraCenterAnimator(
-          options = cameraAnimatorOptions(target) {
-            startValue(currentCameraState.center)
-          },
-          block = defaultAnimationParameters[CameraAnimatorType.CENTER]
         )
       )
     }
@@ -362,12 +362,6 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
       (r1 - r0) / rho
 
     val animators = mutableListOf(
-      CameraBearingAnimator(
-        options = cameraAnimatorOptions(endBearing) {
-          startValue(startBearing)
-        },
-        block = defaultAnimationParameters[CameraAnimatorType.BEARING]
-      ),
       CameraCenterAnimator(
         evaluator = { fraction, _, _ ->
           // s: The distance traveled along the flight path, measured in
@@ -384,6 +378,12 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
           startValue(startPointRaw)
         },
         block = defaultAnimationParameters[CameraAnimatorType.CENTER]
+      ),
+      CameraBearingAnimator(
+        options = cameraAnimatorOptions(endBearing) {
+          startValue(startBearing)
+        },
+        block = defaultAnimationParameters[CameraAnimatorType.BEARING]
       ),
       CameraZoomAnimator(
         evaluator = { fraction, _, _ ->

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsListenersTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsListenersTest.kt
@@ -184,7 +184,7 @@ class CameraAnimationsListenersTest {
     bearingAnimator.start()
     Shadows.shadowOf(Looper.getMainLooper()).idle()
 
-    Assert.assertEquals(6, valuesList.size)
+    Assert.assertEquals(5, valuesList.size)
     Assert.assertArrayEquals(intArrayOf(0, 1, 2), valuesList.slice(0..2).toIntArray())
   }
 
@@ -209,7 +209,7 @@ class CameraAnimationsListenersTest {
     bearingAnimator.start()
     Shadows.shadowOf(Looper.getMainLooper()).idle()
 
-    Assert.assertEquals(6, valuesList.size)
+    Assert.assertEquals(5, valuesList.size)
     Assert.assertArrayEquals(intArrayOf(0, 1, 2), valuesList.slice(0..2).toIntArray())
   }
 
@@ -231,7 +231,7 @@ class CameraAnimationsListenersTest {
     bearingAnimator.start()
     Shadows.shadowOf(Looper.getMainLooper()).idle()
 
-    Assert.assertArrayEquals(intArrayOf(0, 0), valuesList.toIntArray())
+    Assert.assertArrayEquals(intArrayOf(0), valuesList.toIntArray())
   }
 
   @Test
@@ -253,7 +253,7 @@ class CameraAnimationsListenersTest {
     bearingAnimator.start()
     Shadows.shadowOf(Looper.getMainLooper()).idle()
 
-    Assert.assertEquals(6, valuesList.size)
+    Assert.assertEquals(5, valuesList.size)
     Assert.assertArrayEquals(intArrayOf(0, 1, 1), valuesList.slice(0..2).toIntArray())
   }
 
@@ -287,7 +287,7 @@ class CameraAnimationsListenersTest {
     bearingAnimator.start()
     Shadows.shadowOf(Looper.getMainLooper()).idle()
 
-    Assert.assertEquals(6, valuesList.size)
+    Assert.assertEquals(5, valuesList.size)
     Assert.assertArrayEquals(intArrayOf(0, 1, 2), valuesList.slice(0..2).toIntArray())
     valuesList.clear()
 

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -492,8 +492,8 @@ class CameraAnimationsPluginImplTest {
     bearingAnimator.start()
     shadowOf(getMainLooper()).idle()
 
-    // Adding value 2 because of first call after Animator.start() and last in the onEnd() or onCancel()
-    val countUpdates = (bearingDuration + 2).toInt()
+    // Adding value 2 because of first call after Animator.start()
+    val countUpdates = (bearingDuration + 1).toInt()
     verify(exactly = countUpdates) { mapCameraManagerDelegate.setCamera(any<CameraOptions>()) }
   }
 

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -297,7 +297,7 @@ class CameraAnimationsPluginImplTest {
 
     val targetPitch = 5.0
     val cameraOptions = CameraOptions.Builder().pitch(targetPitch).build()
-    val expectedValues = mutableSetOf(0.0, targetPitch)
+    val expectedValues = mutableSetOf(targetPitch)
     val updatedValues = mutableListOf<Double>()
 
     cameraAnimationsPluginImpl.addCameraPitchChangeListener { updatedValue ->
@@ -366,7 +366,7 @@ class CameraAnimationsPluginImplTest {
     val cameraOptions1 = CameraOptions.Builder().pitch(targetPitchFirst).build()
     val cameraOptions2 = CameraOptions.Builder().pitch(targetPitchSecond).build()
     val cameraOptions3 = CameraOptions.Builder().pitch(targetPitchThird).build()
-    val expectedValues = mutableSetOf(0.0, targetPitchFirst, targetPitchSecond, targetPitchThird)
+    val expectedValues = mutableSetOf(targetPitchFirst, targetPitchSecond, targetPitchThird)
     val updatedValues = mutableListOf<Double>()
 
     cameraAnimationsPluginImpl.addCameraPitchChangeListener { updatedValue ->
@@ -924,6 +924,42 @@ class CameraAnimationsPluginImplTest {
     shadowOf(getMainLooper()).idle()
     assertEquals(1, listener.startedCount)
     assertEquals(1, listener.endedCount)
+  }
+
+  @Test
+  fun firstUpdateTickTest() {
+    val updateList = mutableListOf<CameraOptions>()
+    every { mapCameraManagerDelegate.setCamera(any<CameraOptions>()) } answers {
+      updateList.add(firstArg())
+    }
+    shadowOf(getMainLooper()).pause()
+    val bearingAnimator = cameraAnimationsPluginImpl.createBearingAnimator(
+      cameraAnimatorOptions(60.0) {
+        startValue(20.0)
+      }
+    ) {
+      duration = 50
+    }
+    val pitchAnimator = cameraAnimationsPluginImpl.createPitchAnimator(
+      cameraAnimatorOptions(40.0) {
+        startValue(10.0)
+      }
+    ) {
+      duration = 50
+    }
+    cameraAnimationsPluginImpl.registerAnimators(
+      bearingAnimator, pitchAnimator
+    )
+    bearingAnimator.start()
+    pitchAnimator.start()
+    shadowOf(getMainLooper()).idle()
+    // first bearing tick as first animation -
+    // bearing updated to start value and pitch is not updated
+    assertEquals(20.0, updateList[0].bearing!!, EPS)
+    assertEquals(0.0, updateList[0].pitch!!, EPS)
+    // second bearing tick as first animation -
+    // pitch is updated to start value
+    assertEquals(10.0, updateList[1].pitch!!, EPS)
   }
 
   class LifecycleListener : CameraAnimationsLifecycleListener {

--- a/sdk-base/src/main/java/com/mapbox/maps/ExtensionUtils.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/ExtensionUtils.kt
@@ -41,14 +41,25 @@ fun MapSnapshotInterface.bitmap(): Bitmap {
 
 /**
  * Extension function to convert [CameraState] to [CameraOptions].
+ *
+ * If [anchor] is specified - [CameraOptions.center] will be explicitly set to NULL
+ * in order for the anchor to apply to the map camera.
  */
-fun CameraState.toCameraOptions(anchor: ScreenCoordinate? = null): CameraOptions {
-  return CameraOptions.Builder()
-    .anchor(anchor)
-    .center(center)
-    .padding(padding)
-    .zoom(zoom)
-    .pitch(pitch)
-    .bearing(bearing)
-    .build()
-}
+fun CameraState.toCameraOptions(anchor: ScreenCoordinate? = null): CameraOptions =
+  if (anchor != null) {
+    CameraOptions.Builder()
+      .anchor(anchor)
+      .padding(padding)
+      .zoom(zoom)
+      .pitch(pitch)
+      .bearing(bearing)
+      .build()
+  } else {
+    CameraOptions.Builder()
+      .center(center)
+      .padding(padding)
+      .zoom(zoom)
+      .pitch(pitch)
+      .bearing(bearing)
+      .build()
+  }

--- a/sdk/src/androidTest/java/com/mapbox/maps/CameraAnimationsPluginTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/CameraAnimationsPluginTest.kt
@@ -227,10 +227,10 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
   fun testEaseToSingleDurationZero() {
     val targetBearing = 5.0
     val cameraOptions = CameraOptions.Builder().bearing(targetBearing).build()
-    val expectedValues = mutableSetOf(-0.0, targetBearing)
+    val expectedValues = mutableSetOf(targetBearing)
     val updatedValues = mutableListOf<Double>()
 
-    val latch = CountDownLatch(2)
+    val latch = CountDownLatch(1)
     val cameraAnimationPlugin = mapView.camera
     cameraAnimationPlugin.addCameraBearingChangeListener {
       Logger.i(TAG, "onChanged $it")
@@ -280,10 +280,10 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
     val cameraOptions1 = CameraOptions.Builder().bearing(targetBearing1).build()
     val cameraOptions2 = CameraOptions.Builder().bearing(targetBearing2).build()
     val cameraOptions3 = CameraOptions.Builder().bearing(targetBearing3).build()
-    val expectedValues = mutableSetOf(-0.0, targetBearing1, targetBearing2, targetBearing3)
+    val expectedValues = mutableSetOf(targetBearing1, targetBearing2, targetBearing3)
     val updatedValues = mutableListOf<Double>()
 
-    val latch = CountDownLatch(4)
+    val latch = CountDownLatch(3)
     val cameraAnimationPlugin = mapView.camera
     cameraAnimationPlugin.addCameraBearingChangeListener {
       Logger.i(TAG, "onChanged $it")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #363 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Update map camera on first animator update.</changelog>`.

### Summary of changes

The camera plugin impl executes camera jumps on a tick of first animator. The animator is registered _also_ when it first ticks, but it was registered last. Because the logic to execute the updates checks for the registered animators, and the animators was registered last in that logical block, the first tick of the animation was effectively ignored.

This skipped update was causing a little bit of desynchronization when paired with other animations (like location puck animation)

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

Example before (notice puck moving forward and back when animations starts):

https://user-images.githubusercontent.com/16925074/118990206-f7403780-b982-11eb-9b7d-ad035e5be161.mp4

Example after:

https://user-images.githubusercontent.com/16925074/118990221-fad3be80-b982-11eb-94ca-8c3139275e36.mp4
<!--
If this PR introduces user-facing changes, please note them here.
-->