### PR TITLE
Avoid clearing styleLoadedListeners inside mapLoadingErrorListener, and vice versa.

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/integration/events/StyleLoadedEventTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/integration/events/StyleLoadedEventTest.kt
@@ -1,0 +1,105 @@
+package com.mapbox.maps.testapp.integration.events
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.mapbox.maps.MapView
+import com.mapbox.maps.R
+import com.mapbox.maps.testapp.EmptyActivity
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Test that the style loaded event is fired even when the sprites loading is failed.
+ */
+@RunWith(AndroidJUnit4::class)
+class StyleLoadedEventTest {
+  @get:Rule
+  var rule: ActivityScenarioRule<EmptyActivity> = ActivityScenarioRule(EmptyActivity::class.java)
+
+  lateinit var mapView: MapView
+  lateinit var countDownLatch: CountDownLatch
+
+  @Before
+  fun setUp() {
+    rule.scenario.onActivity {
+      mapView = MapView(it)
+      mapView.id = R.id.mapView
+      it.setContentView(mapView)
+    }
+  }
+
+  @After
+  fun cleanUp() {
+    rule.scenario.onActivity {
+      mapView.onStop()
+      mapView.onDestroy()
+    }
+  }
+
+  @Test
+  fun testStyleLoadedEventWhenSpritesLoadFails() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      mapView.getMapboxMap().loadStyleJSON(
+        """
+      {
+        "version": 8,
+        "name": "Land",
+        "metadata": {
+          "mapbox:autocomposite": true
+        },
+        "sources": {
+          "composite": {
+            "url": "mapbox://mapbox.mapbox-terrain-v2",
+            "type": "vector"
+          }
+        },
+        "sprite": "mapbox://sprites/mapbox/mapbox-terrain-v2",
+        "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+        "layers": [
+          {
+            "layout": {
+              "visibility": "visible"
+            },
+            "type": "fill",
+            "source": "composite",
+            "id": "admin",
+            "paint": {
+              "fill-color": "hsl(359, 100%, 50%)",
+              "fill-opacity": 1
+            },
+            "source-layer": "landcover"
+          },
+          {
+            "layout": {
+              "visibility": "visible"
+            },
+            "type": "fill",
+            "source": "composite",
+            "id": "layer-0",
+            "paint": {
+              "fill-opacity": 1,
+              "fill-color": "hsl(359, 100%, 50%)"
+            },
+            "source-layer": "Layer_0"
+          }
+        ]
+      }
+        """.trimIndent()
+      ) {
+        countDownLatch.countDown()
+      }
+      mapView.onStart()
+    }
+
+    if (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+}

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -56,13 +56,11 @@ internal class StyleObserver(
       }
       awaitingStyleLoadListeners.clear()
     }
-    awaitingStyleErrorListener = null
   }
 
   override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
     Logger.e(TAG, "OnMapLoadError: $mapLoadErrorType: $message")
     awaitingStyleErrorListener?.onMapLoadError(mapLoadErrorType, message)
-    awaitingStyleLoadListeners.clear()
   }
 
   fun onDestroy() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/348

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fixed an issue that causes OnStyleLoaded callback not fired when there's a sprite loading error.</changelog>`.

### Summary of changes
Avoid clearing styleLoadedListeners inside mapLoadingErrorListener, and vice versa.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->