### PR TITLE
Integrate the `addPersistentStyleLayer` to annotation plugin and location component plugin.

### DIFF
--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/Layer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/Layer.kt
@@ -119,7 +119,7 @@ abstract class Layer : StyleContract.StyleLayerExtension {
 
   // Layer Properties
 
-  private fun getCachedLayerProperties(): Value {
+  internal fun getCachedLayerProperties(): Value {
     val properties = HashMap<String, Value>()
     layerProperties.values.forEach {
       properties[it.propertyName] = it.value

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
@@ -18,16 +18,38 @@ import com.mapbox.maps.extension.style.StyleInterface
  * In cases when a new style has the same layer, source or image resource, style's resources would be
  * used instead and `MapLoadingError` event will be emitted.
  *
- * @param delegate The style
+ * @param style The style
  * @param position the position that the current layer is added to
  */
 @MapboxExperimental
-fun Layer.bindPersistentlyTo(delegate: StyleInterface, position: LayerPosition? = null) {
-  this.delegate = delegate
-  val expected = delegate.addPersistentStyleLayer(getCachedLayerProperties(), position)
+internal fun Layer.bindPersistentlyTo(style: StyleInterface, position: LayerPosition? = null) {
+  this.delegate = style
+  val expected = style.addPersistentStyleLayer(getCachedLayerProperties(), position)
   expected.error?.let {
     throw RuntimeException("Add persistent layer failed: $it")
   }
+}
+
+/**
+ * Add layer to the style persistently.
+ *
+ * Note: This is an experimental API and is a subject to change.
+ *
+ * Whenever a new style is being parsed and currently used style has persistent layers,
+ * an engine will try to do following:
+ *   - keep the persistent layer at its relative position
+ *   - keep the source used by a persistent layer
+ *   - keep images added through `addStyleImage` method
+ *
+ * In cases when a new style has the same layer, source or image resource, style's resources would be
+ * used instead and `MapLoadingError` event will be emitted.
+ *
+ * @param layer The layer to be added to the style
+ * @param position the position that the current layer is added to
+ */
+@MapboxExperimental
+fun StyleInterface.addPersistentLayer(layer: Layer, position: LayerPosition? = null) {
+  layer.bindPersistentlyTo(this, position)
 }
 
 /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
@@ -1,0 +1,41 @@
+package com.mapbox.maps.extension.style.layers
+
+import com.mapbox.maps.LayerPosition
+import com.mapbox.maps.MapboxExperimental
+import com.mapbox.maps.extension.style.StyleInterface
+
+/**
+ * Bind the layer to the map controller persistently.
+ *
+ * Note: This is an experimental API and is a subject to change.
+ *
+ * Whenever a new style is being parsed and currently used style has persistent layers,
+ * an engine will try to do following:
+ *   - keep the persistent layer at its relative position
+ *   - keep the source used by a persistent layer
+ *   - keep images added through `addStyleImage` method
+ *
+ * In cases when a new style has the same layer, source or image resource, style's resources would be
+ * used instead and `MapLoadingError` event will be emitted.
+ *
+ * @param delegate The style
+ * @param position the position that the current layer is added to
+ */
+@MapboxExperimental
+fun Layer.bindPersistentlyTo(delegate: StyleInterface, position: LayerPosition? = null) {
+  this.delegate = delegate
+  val expected = delegate.addPersistentStyleLayer(getCachedLayerProperties(), position)
+  expected.error?.let {
+    throw RuntimeException("Add persistent layer failed: $it")
+  }
+}
+
+/**
+ * Get the persistent property as Boolean.
+ *
+ * If true, the layer will be persisted across style changes.
+ */
+@MapboxExperimental
+fun Layer.isPersistent(): Boolean? {
+  return delegate?.isStyleLayerPersistent(layerId)?.value
+}

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/LayerExtTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/LayerExtTest.kt
@@ -49,6 +49,13 @@ class LayerExtTest {
   }
 
   @Test
+  fun testAddPersistentLayer() {
+    val layer = symbolLayer("id", "source") {}
+    style.addPersistentLayer(layer)
+    verify { style.addPersistentStyleLayer(any(), any()) }
+  }
+
+  @Test
   fun testPersistentGet() {
     every { style.isStyleLayerPersistent(any()) } returns booleanExpected
     every { booleanExpected.value } returns true

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/LayerExtTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/LayerExtTest.kt
@@ -1,0 +1,60 @@
+package com.mapbox.maps.extension.style.layers
+
+import com.mapbox.bindgen.Expected
+import com.mapbox.bindgen.ExpectedFactory
+import com.mapbox.bindgen.None
+import com.mapbox.maps.StyleManager
+import com.mapbox.maps.extension.style.ShadowStyleManager
+import com.mapbox.maps.extension.style.StyleInterface
+import com.mapbox.maps.extension.style.layers.generated.symbolLayer
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowStyleManager::class])
+class LayerExtTest {
+  private val style = mockk<StyleInterface>(relaxUnitFun = true, relaxed = true)
+  private val expected = mockk<Expected<String, None>>(relaxUnitFun = true, relaxed = true)
+  private val booleanExpected =
+    mockk<Expected<String, Boolean>>(relaxUnitFun = true, relaxed = true)
+
+  @Before
+  fun prepareTest() {
+    every { style.isStyleLayerPersistent(any()) } returns booleanExpected
+    every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { style.addStyleLayer(any(), any()) } returns expected
+    every { style.setStyleLayerProperties(any(), any()) } returns expected
+    every { expected.error } returns null
+
+    // For default property getters
+    mockkStatic(StyleManager::class)
+  }
+
+  @After
+  fun cleanup() {
+    unmockkAll()
+  }
+
+  @Test
+  fun testBindPersistentlyTo() {
+    val layer = symbolLayer("id", "source") {}
+    layer.bindPersistentlyTo(style)
+    verify { style.addPersistentStyleLayer(any(), any()) }
+  }
+
+  @Test
+  fun testPersistentGet() {
+    every { style.isStyleLayerPersistent(any()) } returns booleanExpected
+    every { booleanExpected.value } returns true
+    val layer = symbolLayer("id", "source") {}
+    layer.bindTo(style)
+    assertTrue(layer.isPersistent()!!)
+    verify { style.isStyleLayerPersistent("id") }
+  }
+}

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -8,6 +8,7 @@ import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
+import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.RenderedQueryOptions
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.extension.style.StyleInterface
@@ -22,8 +23,7 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression.Companio
 import com.mapbox.maps.extension.style.image.addImage
 import com.mapbox.maps.extension.style.image.image
 import com.mapbox.maps.extension.style.layers.Layer
-import com.mapbox.maps.extension.style.layers.addLayer
-import com.mapbox.maps.extension.style.layers.addLayerBelow
+import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
 import com.mapbox.maps.extension.style.layers.generated.SymbolLayer
 import com.mapbox.maps.extension.style.layers.generated.circleLayer
 import com.mapbox.maps.extension.style.layers.generated.symbolLayer
@@ -53,7 +53,6 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   final override val delegateProvider: MapDelegateProvider,
   private val annotationConfig: AnnotationConfig?
 ) : AnnotationManager<G, T, S, D, U, V, I> {
-  protected lateinit var style: StyleInterface
   private var mapCameraManagerDelegate: MapCameraManagerDelegate =
     delegateProvider.mapCameraManagerDelegate
   private var mapFeatureQueryDelegate: MapFeatureQueryDelegate =
@@ -170,7 +169,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     }
   }
 
-  protected fun initLayerAndSource() {
+  protected fun initLayerAndSource(style: StyleInterface) {
     if (layer == null || source == null) {
       initializeDataDrivenPropertyMap()
       source = createSource()
@@ -188,7 +187,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         annotationConfig?.belowLayerId?.let { belowLayerId ->
           // Check whether the below layer exists in the current style.
           if (style.styleLayerExists(belowLayerId)) {
-            style.addLayerBelow(it, annotationConfig.belowLayerId)
+            it.bindPersistentlyTo(style, LayerPosition(null, annotationConfig.belowLayerId, null))
             layerAdded = true
           } else {
             Logger.w(
@@ -198,28 +197,28 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
           }
         }
         if (!layerAdded) {
-          style.addLayer(it)
+          it.bindPersistentlyTo(style)
         }
       }
     }
     if (layer is SymbolLayer) {
       // Only apply cluster for SymbolManager
-      initClusterLayers()
+      initClusterLayers(style)
     }
-    updateSource()
+    updateSource(style)
   }
 
-  private fun initClusterLayers() {
+  private fun initClusterLayers(style: StyleInterface) {
     annotationConfig?.annotationSourceOptions?.clusterOptions?.let {
       it.colorLevels.forEachIndexed { level, _ ->
         val clusterLevelLayer = createClusterLevelLayer(level, it.colorLevels)
         if (!style.styleLayerExists(clusterLevelLayer.layerId)) {
-          style.addLayer(clusterLevelLayer)
+          clusterLevelLayer.bindPersistentlyTo(style)
         }
       }
       val clusterTextLayer = createClusterTextLayer()
       if (!style.styleLayerExists(clusterTextLayer.layerId)) {
-        style.addLayer(clusterTextLayer)
+        clusterTextLayer.bindPersistentlyTo(style)
       }
     }
   }
@@ -266,21 +265,15 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   }
 
   /**
-   * Invoked when the style is loaded
-   */
-  override fun onStyleLoaded(styleDelegate: StyleInterface) {
-    style = styleDelegate
-    initLayerAndSource()
-  }
-
-  /**
    * Create an annotation with the option
    */
   override fun create(option: S): T {
     return option.build(currentId, this).also {
       annotationMap[it.id] = it
       currentId++
-      updateSource()
+      delegateProvider.getStyle { style ->
+        updateSource(style)
+      }
     }
   }
 
@@ -294,7 +287,9 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         currentId++
       }
     }
-    updateSource()
+    delegateProvider.getStyle { style ->
+      updateSource(style)
+    }
     return list
   }
 
@@ -303,7 +298,9 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
    */
   override fun delete(annotation: T) {
     annotationMap.remove(annotation.id)
-    updateSource()
+    delegateProvider.getStyle { style ->
+      updateSource(style)
+    }
   }
 
   /**
@@ -313,7 +310,9 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     annotations.forEach {
       this.annotationMap.remove(it.id)
     }
-    updateSource()
+    delegateProvider.getStyle { style ->
+      updateSource(style)
+    }
   }
 
   /**
@@ -321,13 +320,15 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
    */
   override fun deleteAll() {
     annotationMap.clear()
-    updateSource()
+    delegateProvider.getStyle { style ->
+      updateSource(style)
+    }
   }
 
   /**
    * Trigger an update to the underlying source
    */
-  private fun updateSource() {
+  private fun updateSource(style: StyleInterface) {
     if (!styleStateDelegate.isFullyLoaded()) {
       Logger.e(TAG, "Can't update source: style is not fully loaded.")
       return
@@ -371,7 +372,9 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   override fun update(annotation: T) {
     if (annotationMap.containsKey(annotation.id)) {
       annotationMap[annotation.id] = annotation
-      updateSource()
+      delegateProvider.getStyle { style ->
+        updateSource(style)
+      }
     } else {
       Logger.e(
         TAG,
@@ -394,21 +397,25 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         )
       }
     }
-    updateSource()
+    delegateProvider.getStyle { style ->
+      updateSource(style)
+    }
   }
 
   /**
    * Invoked when Mapview or Annotation manager is destroyed.
    */
   override fun onDestroy() {
-    layer?.let {
-      if (style.styleLayerExists(it.layerId)) {
-        style.removeStyleLayer(it.layerId)
+    delegateProvider.getStyle { style ->
+      layer?.let {
+        if (style.styleLayerExists(it.layerId)) {
+          style.removeStyleLayer(it.layerId)
+        }
       }
-    }
-    source?.let {
-      if (style.styleSourceExists(it.sourceId)) {
-        style.removeStyleSource(it.sourceId)
+      source?.let {
+        if (style.styleSourceExists(it.sourceId)) {
+          style.removeStyleSource(it.sourceId)
+        }
       }
     }
 
@@ -534,7 +541,9 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         }
         shiftedGeometry?.let { geometry ->
           annotation.geometry = geometry
-          updateSource()
+          delegateProvider.getStyle { style ->
+            updateSource(style)
+          }
           dragListeners.forEach {
             it.onAnnotationDrag(annotation)
           }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -23,7 +23,7 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression.Companio
 import com.mapbox.maps.extension.style.image.addImage
 import com.mapbox.maps.extension.style.image.image
 import com.mapbox.maps.extension.style.layers.Layer
-import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
+import com.mapbox.maps.extension.style.layers.addPersistentLayer
 import com.mapbox.maps.extension.style.layers.generated.SymbolLayer
 import com.mapbox.maps.extension.style.layers.generated.circleLayer
 import com.mapbox.maps.extension.style.layers.generated.symbolLayer
@@ -187,7 +187,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         annotationConfig?.belowLayerId?.let { belowLayerId ->
           // Check whether the below layer exists in the current style.
           if (style.styleLayerExists(belowLayerId)) {
-            it.bindPersistentlyTo(style, LayerPosition(null, annotationConfig.belowLayerId, null))
+            style.addPersistentLayer(it, LayerPosition(null, annotationConfig.belowLayerId, null))
             layerAdded = true
           } else {
             Logger.w(
@@ -197,7 +197,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
           }
         }
         if (!layerAdded) {
-          it.bindPersistentlyTo(style)
+          style.addPersistentLayer(it)
         }
       }
     }
@@ -213,12 +213,12 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
       it.colorLevels.forEachIndexed { level, _ ->
         val clusterLevelLayer = createClusterLevelLayer(level, it.colorLevels)
         if (!style.styleLayerExists(clusterLevelLayer.layerId)) {
-          clusterLevelLayer.bindPersistentlyTo(style)
+          style.addPersistentLayer(clusterLevelLayer)
         }
       }
       val clusterTextLayer = createClusterTextLayer()
       if (!style.styleLayerExists(clusterTextLayer.layerId)) {
-        clusterTextLayer.bindPersistentlyTo(style)
+        style.addPersistentLayer(clusterTextLayer)
       }
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
@@ -2,7 +2,6 @@ package com.mapbox.maps.plugin.annotation
 
 import android.view.View
 import androidx.annotation.VisibleForTesting
-import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
@@ -85,13 +84,6 @@ class AnnotationPluginImpl : AnnotationPlugin {
     this.width = width
     this.height = height
     managerList.forEach { it.get()?.onSizeChanged(width, height) }
-  }
-
-  /**
-   * Called when a new Style is loaded.
-   */
-  override fun onStyleChanged(styleDelegate: StyleInterface) {
-    managerList.forEach { it.get()?.onStyleLoaded(styleDelegate) }
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps.plugin.annotation
 
 import android.view.View
 import androidx.annotation.VisibleForTesting
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.annotation.generated.*
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
@@ -84,6 +85,15 @@ class AnnotationPluginImpl : AnnotationPlugin {
     this.width = width
     this.height = height
     managerList.forEach { it.get()?.onSizeChanged(width, height) }
+  }
+
+  /**
+   * Called when a new Style is loaded.
+   *
+   * @param styleDelegate
+   */
+  override fun onStyleChanged(styleDelegate: StyleInterface) {
+    // no-ops
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
@@ -33,8 +33,7 @@ class CircleAnnotationManager(
 
   init {
     delegateProvider.getStyle {
-      style = it
-      initLayerAndSource()
+      initLayerAndSource(it)
     }
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
@@ -33,8 +33,7 @@ class PointAnnotationManager(
 
   init {
     delegateProvider.getStyle {
-      style = it
-      initLayerAndSource()
+      initLayerAndSource(it)
       // Show all icons and texts by default. 
       iconAllowOverlap = true
       textAllowOverlap = true

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
@@ -33,8 +33,7 @@ class PolygonAnnotationManager(
 
   init {
     delegateProvider.getStyle {
-      style = it
-      initLayerAndSource()
+      initLayerAndSource(it)
     }
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
@@ -33,8 +33,7 @@ class PolylineAnnotationManager(
 
   init {
     delegateProvider.getStyle {
-      style = it
-      initLayerAndSource()
+      initLayerAndSource(it)
     }
   }
 

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImplTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImplTest.kt
@@ -69,9 +69,5 @@ class AnnotationPluginImplTest {
     annotationPluginImpl.removeAnnotationManager(polygonAnnotationManager)
     annotationPluginImpl.removeAnnotationManager(polylineAnnotationManager)
     assertEquals(0, annotationPluginImpl.managerList.size)
-    verify { circleAnnotationManager.onDestroy() }
-    verify { pointAnnotationManager.onDestroy() }
-    verify { polygonAnnotationManager.onDestroy() }
-    verify { polylineAnnotationManager.onDestroy() }
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImplTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImplTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.plugin.annotation
 
 import android.view.View
+import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.sources.addSource
@@ -38,6 +39,7 @@ class AnnotationPluginImplTest {
     every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
     every { style.addLayer(any()) } just Runs
+    every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { delegateProvider.mapPluginProviderDelegate.getPlugin(any<Class<GesturesPlugin>>()) } returns gesturesPlugin
@@ -71,27 +73,5 @@ class AnnotationPluginImplTest {
     verify { pointAnnotationManager.onDestroy() }
     verify { polygonAnnotationManager.onDestroy() }
     verify { polylineAnnotationManager.onDestroy() }
-  }
-
-  @Test
-  fun onStyleChanged() {
-    val circleAnnotationManager =
-      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.CircleAnnotation, null)
-    assert(circleAnnotationManager is CircleAnnotationManager)
-    val pointAnnotationManager =
-      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.PointAnnotation, null)
-    assert(pointAnnotationManager is PointAnnotationManager)
-    val polygonAnnotationManager =
-      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.PolygonAnnotation, null)
-    assert(polygonAnnotationManager is PolygonAnnotationManager)
-    val polylineAnnotationManager =
-      annotationPluginImpl.createAnnotationManager(mapView, AnnotationType.PolylineAnnotation, null)
-    assert(polylineAnnotationManager is PolylineAnnotationManager)
-    assertEquals(4, annotationPluginImpl.managerList.size)
-    annotationPluginImpl.onStyleChanged(style)
-    verify { circleAnnotationManager.onStyleLoaded(style) }
-    verify { pointAnnotationManager.onStyleLoaded(style) }
-    verify { polygonAnnotationManager.onStyleLoaded(style) }
-    verify { polylineAnnotationManager.onStyleLoaded(style) }
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -14,13 +14,14 @@ import com.mapbox.common.ValueConverter
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
+import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.QueriedFeature
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
-import com.mapbox.maps.extension.style.layers.addLayer
-import com.mapbox.maps.extension.style.layers.addLayerBelow
+import com.mapbox.maps.extension.style.layers.Layer
+import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
 import com.mapbox.maps.extension.style.layers.generated.CircleLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
@@ -60,7 +61,7 @@ class CircleAnnotationManagerTest {
   private lateinit var manager: CircleAnnotationManager
   @Before
   fun setUp() {
-    mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+    mockkStatic("com.mapbox.maps.extension.style.layers.LayerExtKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
@@ -74,9 +75,9 @@ class CircleAnnotationManagerTest {
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate
     every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
-    every { style.addLayer(any()) } just Runs
-    every { style.addLayerBelow(any(), any()) } just Runs
     every { style.getSource(any()) } returns null
+    every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { any<Layer>().bindPersistentlyTo(any(), any()) } just Runs
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { style.removeStyleLayer(any()) } returns mockk()
@@ -132,11 +133,11 @@ class CircleAnnotationManagerTest {
     verify { gesturesPlugin.addOnMapLongClickListener(any()) }
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(CircleAnnotation.ID_KEY, manager.getAnnotationIdKey())
-    verify { style.addLayer(any()) }
+    verify { any<Layer>().bindPersistentlyTo(any(), null) }
     every { style.styleLayerExists("test_layer") } returns true
 
     manager = CircleAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
-    verify { style.addLayerBelow(any(), "test_layer") }
+    verify { any<Layer>().bindPersistentlyTo(any(), LayerPosition(null, "test_layer", null)) }
 
     manager.addClickListener(mockk())
     manager.addDragListener(mockk())

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -20,8 +20,7 @@ import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
-import com.mapbox.maps.extension.style.layers.Layer
-import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
+import com.mapbox.maps.extension.style.layers.addPersistentLayer
 import com.mapbox.maps.extension.style.layers.generated.CircleLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
@@ -77,7 +76,7 @@ class CircleAnnotationManagerTest {
     every { style.addSource(any()) } just Runs
     every { style.getSource(any()) } returns null
     every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
-    every { any<Layer>().bindPersistentlyTo(any(), any()) } just Runs
+    every { style.addPersistentLayer(any(), any()) } just Runs
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { style.removeStyleLayer(any()) } returns mockk()
@@ -133,11 +132,11 @@ class CircleAnnotationManagerTest {
     verify { gesturesPlugin.addOnMapLongClickListener(any()) }
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(CircleAnnotation.ID_KEY, manager.getAnnotationIdKey())
-    verify { any<Layer>().bindPersistentlyTo(any(), null) }
+    verify { style.addPersistentLayer(any(), null) }
     every { style.styleLayerExists("test_layer") } returns true
 
     manager = CircleAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
-    verify { any<Layer>().bindPersistentlyTo(any(), LayerPosition(null, "test_layer", null)) }
+    verify { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
 
     manager.addClickListener(mockk())
     manager.addDragListener(mockk())

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -78,9 +78,9 @@ class PointAnnotationManagerTest {
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate
     every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
-    every { style.addLayer(any()) } just Runs
     every { style.addLayerBelow(any(), any()) } just Runs
     every { style.getSource(any()) } returns null
+    every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { style.removeStyleLayer(any()) } returns mockk()

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -16,13 +16,14 @@ import com.mapbox.common.ValueConverter
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
+import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.QueriedFeature
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
-import com.mapbox.maps.extension.style.layers.addLayer
-import com.mapbox.maps.extension.style.layers.addLayerBelow
+import com.mapbox.maps.extension.style.layers.Layer
+import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
 import com.mapbox.maps.extension.style.layers.generated.SymbolLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.extension.style.sources.addSource
@@ -64,7 +65,7 @@ class PointAnnotationManagerTest {
   val bitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
   @Before
   fun setUp() {
-    mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+    mockkStatic("com.mapbox.maps.extension.style.layers.LayerExtKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
@@ -78,9 +79,9 @@ class PointAnnotationManagerTest {
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate
     every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
-    every { style.addLayerBelow(any(), any()) } just Runs
     every { style.getSource(any()) } returns null
     every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { any<Layer>().bindPersistentlyTo(any(), any()) } just Runs
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { style.removeStyleLayer(any()) } returns mockk()
@@ -157,11 +158,11 @@ class PointAnnotationManagerTest {
     verify { gesturesPlugin.addOnMapLongClickListener(any()) }
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(PointAnnotation.ID_KEY, manager.getAnnotationIdKey())
-    verify { style.addLayer(any()) }
+    verify { any<Layer>().bindPersistentlyTo(any(), null) }
     every { style.styleLayerExists("test_layer") } returns true
 
     manager = PointAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
-    verify { style.addLayerBelow(any(), "test_layer") }
+    verify { any<Layer>().bindPersistentlyTo(any(), LayerPosition(null, "test_layer", null)) }
 
     manager.addClickListener(mockk())
     manager.addDragListener(mockk())

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -22,8 +22,7 @@ import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
-import com.mapbox.maps.extension.style.layers.Layer
-import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
+import com.mapbox.maps.extension.style.layers.addPersistentLayer
 import com.mapbox.maps.extension.style.layers.generated.SymbolLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.extension.style.sources.addSource
@@ -81,7 +80,7 @@ class PointAnnotationManagerTest {
     every { style.addSource(any()) } just Runs
     every { style.getSource(any()) } returns null
     every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
-    every { any<Layer>().bindPersistentlyTo(any(), any()) } just Runs
+    every { style.addPersistentLayer(any(), any()) } just Runs
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { style.removeStyleLayer(any()) } returns mockk()
@@ -158,11 +157,11 @@ class PointAnnotationManagerTest {
     verify { gesturesPlugin.addOnMapLongClickListener(any()) }
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(PointAnnotation.ID_KEY, manager.getAnnotationIdKey())
-    verify { any<Layer>().bindPersistentlyTo(any(), null) }
+    verify { style.addPersistentLayer(any(), null) }
     every { style.styleLayerExists("test_layer") } returns true
 
     manager = PointAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
-    verify { any<Layer>().bindPersistentlyTo(any(), LayerPosition(null, "test_layer", null)) }
+    verify { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
 
     manager.addClickListener(mockk())
     manager.addDragListener(mockk())

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -15,13 +15,14 @@ import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.Polygon
+import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.QueriedFeature
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
-import com.mapbox.maps.extension.style.layers.addLayer
-import com.mapbox.maps.extension.style.layers.addLayerBelow
+import com.mapbox.maps.extension.style.layers.Layer
+import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
 import com.mapbox.maps.extension.style.layers.generated.FillLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
@@ -61,7 +62,7 @@ class PolygonAnnotationManagerTest {
   private lateinit var manager: PolygonAnnotationManager
   @Before
   fun setUp() {
-    mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+    mockkStatic("com.mapbox.maps.extension.style.layers.LayerExtKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
@@ -75,9 +76,9 @@ class PolygonAnnotationManagerTest {
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate
     every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
-    every { style.addLayer(any()) } just Runs
-    every { style.addLayerBelow(any(), any()) } just Runs
     every { style.getSource(any()) } returns null
+    every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { any<Layer>().bindPersistentlyTo(any(), any()) } just Runs
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { style.removeStyleLayer(any()) } returns mockk()
@@ -130,11 +131,11 @@ class PolygonAnnotationManagerTest {
     verify { gesturesPlugin.addOnMapLongClickListener(any()) }
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(PolygonAnnotation.ID_KEY, manager.getAnnotationIdKey())
-    verify { style.addLayer(any()) }
+    verify { any<Layer>().bindPersistentlyTo(any(), null) }
     every { style.styleLayerExists("test_layer") } returns true
 
     manager = PolygonAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
-    verify { style.addLayerBelow(any(), "test_layer") }
+    verify { any<Layer>().bindPersistentlyTo(any(), LayerPosition(null, "test_layer", null)) }
 
     manager.addClickListener(mockk())
     manager.addDragListener(mockk())

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -21,8 +21,7 @@ import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
-import com.mapbox.maps.extension.style.layers.Layer
-import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
+import com.mapbox.maps.extension.style.layers.addPersistentLayer
 import com.mapbox.maps.extension.style.layers.generated.FillLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
@@ -78,7 +77,7 @@ class PolygonAnnotationManagerTest {
     every { style.addSource(any()) } just Runs
     every { style.getSource(any()) } returns null
     every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
-    every { any<Layer>().bindPersistentlyTo(any(), any()) } just Runs
+    every { style.addPersistentLayer(any(), any()) } just Runs
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { style.removeStyleLayer(any()) } returns mockk()
@@ -131,11 +130,11 @@ class PolygonAnnotationManagerTest {
     verify { gesturesPlugin.addOnMapLongClickListener(any()) }
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(PolygonAnnotation.ID_KEY, manager.getAnnotationIdKey())
-    verify { any<Layer>().bindPersistentlyTo(any(), null) }
+    verify { style.addPersistentLayer(any(), null) }
     every { style.styleLayerExists("test_layer") } returns true
 
     manager = PolygonAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
-    verify { any<Layer>().bindPersistentlyTo(any(), LayerPosition(null, "test_layer", null)) }
+    verify { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
 
     manager.addClickListener(mockk())
     manager.addDragListener(mockk())

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -21,8 +21,7 @@ import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
-import com.mapbox.maps.extension.style.layers.Layer
-import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
+import com.mapbox.maps.extension.style.layers.addPersistentLayer
 import com.mapbox.maps.extension.style.layers.generated.LineLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.extension.style.sources.addSource
@@ -79,7 +78,7 @@ class PolylineAnnotationManagerTest {
     every { style.addSource(any()) } just Runs
     every { style.getSource(any()) } returns null
     every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
-    every { any<Layer>().bindPersistentlyTo(any(), any()) } just Runs
+    every { style.addPersistentLayer(any(), any()) } just Runs
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { style.removeStyleLayer(any()) } returns mockk()
@@ -136,11 +135,11 @@ class PolylineAnnotationManagerTest {
     verify { gesturesPlugin.addOnMapLongClickListener(any()) }
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(PolylineAnnotation.ID_KEY, manager.getAnnotationIdKey())
-    verify { any<Layer>().bindPersistentlyTo(any(), null) }
+    verify { style.addPersistentLayer(any(), null) }
     every { style.styleLayerExists("test_layer") } returns true
 
     manager = PolylineAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
-    verify { any<Layer>().bindPersistentlyTo(any(), LayerPosition(null, "test_layer", null)) }
+    verify { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
 
     manager.addClickListener(mockk())
     manager.addDragListener(mockk())

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -15,13 +15,14 @@ import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
+import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.QueriedFeature
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.generated.Expression
-import com.mapbox.maps.extension.style.layers.addLayer
-import com.mapbox.maps.extension.style.layers.addLayerBelow
+import com.mapbox.maps.extension.style.layers.Layer
+import com.mapbox.maps.extension.style.layers.bindPersistentlyTo
 import com.mapbox.maps.extension.style.layers.generated.LineLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.extension.style.sources.addSource
@@ -62,7 +63,7 @@ class PolylineAnnotationManagerTest {
   private lateinit var manager: PolylineAnnotationManager
   @Before
   fun setUp() {
-    mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+    mockkStatic("com.mapbox.maps.extension.style.layers.LayerExtKt")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     mockkStatic(ValueConverter::class)
     every { ValueConverter.fromJson(any()) } returns ExpectedFactory.createValue(
@@ -76,9 +77,9 @@ class PolylineAnnotationManagerTest {
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate
     every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
-    every { style.addLayer(any()) } just Runs
-    every { style.addLayerBelow(any(), any()) } just Runs
     every { style.getSource(any()) } returns null
+    every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { any<Layer>().bindPersistentlyTo(any(), any()) } just Runs
     every { style.styleSourceExists(any()) } returns false
     every { style.styleLayerExists(any()) } returns false
     every { style.removeStyleLayer(any()) } returns mockk()
@@ -135,11 +136,11 @@ class PolylineAnnotationManagerTest {
     verify { gesturesPlugin.addOnMapLongClickListener(any()) }
     verify { gesturesPlugin.addOnMoveListener(any()) }
     assertEquals(PolylineAnnotation.ID_KEY, manager.getAnnotationIdKey())
-    verify { style.addLayer(any()) }
+    verify { any<Layer>().bindPersistentlyTo(any(), null) }
     every { style.styleLayerExists("test_layer") } returns true
 
     manager = PolylineAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
-    verify { style.addLayerBelow(any(), "test_layer") }
+    verify { any<Layer>().bindPersistentlyTo(any(), LayerPosition(null, "test_layer", null)) }
 
     manager.addClickListener(mockk())
     manager.addDragListener(mockk())

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
@@ -7,6 +7,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import com.mapbox.geojson.Point
 import com.mapbox.maps.RenderedQueryOptions
+import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.LOCATION_INDICATOR_LAYER
@@ -276,6 +277,15 @@ class LocationComponentPluginImpl : LocationComponentPlugin, LocationConsumer,
    */
   override fun onDelegateProvider(delegateProvider: MapDelegateProvider) {
     this.delegateProvider = delegateProvider
+  }
+
+  /**
+   * Called when a new Style is loaded.
+   *
+   * @param styleDelegate
+   */
+  override fun onStyleChanged(styleDelegate: StyleInterface) {
+    // no-ops
   }
 
   override lateinit var internalSettings: LocationComponentSettings

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
@@ -7,7 +7,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import com.mapbox.geojson.Point
 import com.mapbox.maps.RenderedQueryOptions
-import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.LOCATION_INDICATOR_LAYER
@@ -142,18 +141,6 @@ class LocationComponentPluginImpl : LocationComponentPlugin, LocationConsumer,
    */
   override fun getLocationProvider(): LocationProvider? {
     return locationProvider
-  }
-
-  /**
-   * Called when a new Style is loaded.
-   */
-  override fun onStyleChanged(styleDelegate: StyleInterface) {
-    applySettings()
-    locationPuckManager?.let {
-      if (!it.isLayerInitialised()) {
-        it.initialize(styleDelegate)
-      }
-    }
   }
 
   /**

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationLayerWrapper.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationLayerWrapper.kt
@@ -12,7 +12,7 @@ internal open class LocationLayerWrapper(val layerId: String) {
 
   fun bindTo(mapStyleDelegate: StyleManagerInterface, position: LayerPosition? = null) {
     this.mapStyleDelegate = mapStyleDelegate
-    val expected = mapStyleDelegate.addStyleLayer(toValue(), position)
+    val expected = mapStyleDelegate.addPersistentStyleLayer(toValue(), position)
     expected.error?.let {
       throw RuntimeException("Add layer failed: $it")
     }

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
@@ -326,7 +326,7 @@ class LocationComponentPluginImplTest {
 
   @Test
   fun testLocationProviderRegisterDisableEnable() {
-    every { style.addStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
 
     preparePluginInitialisationWithEnabled()
 
@@ -341,7 +341,7 @@ class LocationComponentPluginImplTest {
     if (styleCallbackSlot.isCaptured) {
       styleCallbackSlot.captured.invoke(style)
     }
-    verify(exactly = 1) { style.addStyleLayer(any(), any()) }
+    verify(exactly = 1) { style.addPersistentStyleLayer(any(), any()) }
     verify(exactly = 2) { locationProvider.registerLocationConsumer(any()) }
     verify(exactly = 1) { locationProvider.unRegisterLocationConsumer(any()) }
   }

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
@@ -203,9 +203,6 @@ class LocationComponentPluginImplTest {
     preparePluginInitialisationWithEnabled()
     verify(exactly = 2) { locationPuckManager.isLayerInitialised() }
     verify(exactly = 1) { locationPuckManager.initialize(style) }
-    locationComponentPlugin.onStyleChanged(style)
-    verify(exactly = 3) { locationPuckManager.isLayerInitialised() }
-    verify(exactly = 2) { locationPuckManager.initialize(style) }
   }
 
   @Test
@@ -213,9 +210,6 @@ class LocationComponentPluginImplTest {
     every { locationPuckManager.isLayerInitialised() } returns true
     preparePluginInitialisationWithEnabled()
     verify(exactly = 2) { locationPuckManager.isLayerInitialised() }
-    verify(exactly = 0) { locationPuckManager.initialize(style) }
-    locationComponentPlugin.onStyleChanged(style)
-    verify(exactly = 3) { locationPuckManager.isLayerInitialised() }
     verify(exactly = 0) { locationPuckManager.initialize(style) }
   }
 

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapperTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapperTest.kt
@@ -26,7 +26,7 @@ class LocationIndicatorLayerWrapperTest {
   @Before
   fun setup() {
     every { style.styleLayerExists(any()) } returns true
-    every { style.addStyleLayer(any(), any()) } returns expected
+    every { style.addPersistentStyleLayer(any(), any()) } returns expected
     every { style.setStyleLayerProperty(any(), any(), any()) } returns expected
     every { expected.error } returns null
 

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationLayerWrapperTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationLayerWrapperTest.kt
@@ -4,7 +4,7 @@ import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.bindgen.Value
 import com.mapbox.common.ShadowLogger
 import com.mapbox.maps.LayerPosition
-import com.mapbox.maps.StyleManagerInterface
+import com.mapbox.maps.extension.style.StyleInterface
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -20,7 +20,7 @@ import java.lang.RuntimeException
 class LocationLayerWrapperTest {
   private lateinit var locationLayerWrapper: LocationLayerWrapper
   private val layerId = "testLayerId"
-  private val mapStyleDelegate = mockk<StyleManagerInterface>(relaxed = true)
+  private val mapStyleDelegate = mockk<StyleInterface>(relaxed = true)
 
   @Before
   fun setup() {
@@ -29,23 +29,23 @@ class LocationLayerWrapperTest {
 
   @Test
   fun testBindTo() {
-    every { mapStyleDelegate.addStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { mapStyleDelegate.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
     val position = LayerPosition("above", "below", 0)
     locationLayerWrapper.bindTo(mapStyleDelegate, position)
-    verify { mapStyleDelegate.addStyleLayer(any(), position) }
+    verify { mapStyleDelegate.addPersistentStyleLayer(any(), position) }
   }
 
   @Test(expected = RuntimeException::class)
   fun testBindToAddLayerFailed() {
-    every { mapStyleDelegate.addStyleLayer(any(), any()) } returns ExpectedFactory.createError("error")
+    every { mapStyleDelegate.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createError("error")
     val position = LayerPosition("above", "below", 0)
     locationLayerWrapper.bindTo(mapStyleDelegate, position)
-    verify { mapStyleDelegate.addStyleLayer(any(), position) }
+    verify { mapStyleDelegate.addPersistentStyleLayer(any(), position) }
   }
 
   @Test
   fun testVisibilityWhenLayerExists() {
-    every { mapStyleDelegate.addStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { mapStyleDelegate.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
     every { mapStyleDelegate.setStyleLayerProperty(layerId, any(), any()) } returns ExpectedFactory.createNone()
     every { mapStyleDelegate.styleLayerExists(any()) } returns true
     val position = LayerPosition("above", "below", 0)
@@ -56,7 +56,7 @@ class LocationLayerWrapperTest {
 
   @Test
   fun testVisibilityWhenLayerNotExist() {
-    every { mapStyleDelegate.addStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { mapStyleDelegate.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
     every { mapStyleDelegate.setStyleLayerProperty(layerId, any(), any()) } returns ExpectedFactory.createNone()
     every { mapStyleDelegate.styleLayerExists(any()) } returns false
     val position = LayerPosition("above", "below", 0)
@@ -67,7 +67,7 @@ class LocationLayerWrapperTest {
 
   @Test(expected = RuntimeException::class)
   fun testVisibilityWhenLayerExistSetPropertyFailed() {
-    every { mapStyleDelegate.addStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
+    every { mapStyleDelegate.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
     every { mapStyleDelegate.setStyleLayerProperty(layerId, any(), any()) } returns ExpectedFactory.createError("error")
     every { mapStyleDelegate.styleLayerExists(any()) } returns true
     val position = LayerPosition("above", "below", 0)

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapperTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapperTest.kt
@@ -27,7 +27,7 @@ class ModelLayerWrapperTest {
   @Before
   fun setup() {
     every { style.styleLayerExists(any()) } returns true
-    every { style.addStyleLayer(any(), any()) } returns expected
+    every { style.addPersistentStyleLayer(any(), any()) } returns expected
     every { style.setStyleLayerProperty(any(), any(), any()) } returns expected
     every { expected.error } returns null
     val styleState = mockk<MapStyleStateDelegate>()

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManager.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManager.kt
@@ -1,7 +1,6 @@
 package com.mapbox.maps.plugin.annotation
 
 import com.mapbox.geojson.Geometry
-import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 
 /**
@@ -70,11 +69,6 @@ interface AnnotationManager<
    * @param height the height of mapView
    */
   fun onSizeChanged(width: Int, height: Int)
-
-  /**
-   * Invoked when the style is loaded
-   */
-  fun onStyleLoaded(styleDelegate: StyleInterface)
 
   /**
    * The delegateProvider

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
@@ -3,12 +3,11 @@ package com.mapbox.maps.plugin.annotation
 import android.view.View
 import com.mapbox.maps.plugin.MapPlugin
 import com.mapbox.maps.plugin.MapSizePlugin
-import com.mapbox.maps.plugin.MapStyleObserverPlugin
 
 /**
  * Plugin interface for the annotation.
  */
-interface AnnotationPlugin : MapPlugin, MapSizePlugin, MapStyleObserverPlugin {
+interface AnnotationPlugin : MapPlugin, MapSizePlugin {
   /**
    * Get an annotation manger
    *

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPlugin.kt
@@ -3,11 +3,12 @@ package com.mapbox.maps.plugin.annotation
 import android.view.View
 import com.mapbox.maps.plugin.MapPlugin
 import com.mapbox.maps.plugin.MapSizePlugin
+import com.mapbox.maps.plugin.MapStyleObserverPlugin
 
 /**
  * Plugin interface for the annotation.
  */
-interface AnnotationPlugin : MapPlugin, MapSizePlugin {
+interface AnnotationPlugin : MapPlugin, MapSizePlugin, MapStyleObserverPlugin {
   /**
    * Get an annotation manger
    *

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPlugin.kt
@@ -9,7 +9,6 @@ import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSetti
  */
 interface LocationComponentPlugin :
   MapPlugin,
-  MapStyleObserverPlugin,
   LifecyclePlugin,
   ContextBinder,
   LocationComponentSettingsInterface {

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPlugin.kt
@@ -9,6 +9,7 @@ import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSetti
  */
 interface LocationComponentPlugin :
   MapPlugin,
+  MapStyleObserverPlugin,
   LifecyclePlugin,
   ContextBinder,
   LocationComponentSettingsInterface {

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -156,7 +156,7 @@ class Style internal constructor(
    * Load style from provided URI.
    *
    * This is an asynchronous call. In order to get result of this operation please use [OnStyleLoadedListener],
-   * [OnStyleDataLoadedListener] or [ONMapLoadErrorListener]. In case of successful style load you should
+   * [OnStyleDataLoadedListener] or [OnMapLoadErrorListener]. In case of successful style load you should
    * get notified by [OnStyleLoadedListener].
    *
    * And in case of error @see MapLoadError#StyleLoadError will be generated.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Use addPersistentStyleLayer API to improve the performance of Annotation Plugin and Location Component Plugin during the style change.</changelog>`.

### Summary of changes

This PR integrates the experimental `addPersistentStyleLayer` API to annotation plugin and location component plugin, and improves the performance of Annotation Plugin and Location Component Plugin during the style change. 

### User impact (optional)
Before:

https://user-images.githubusercontent.com/2764714/119505810-0144aa80-bd76-11eb-93ab-88ef3acc3f1a.mp4


After:

https://user-images.githubusercontent.com/2764714/119505828-0570c800-bd76-11eb-92d8-6bb345ebfa7a.mp4


