### PR TITLE
Change default ambient cache path to .mabox/maps/ambient_cache.db

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapboxConstants.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxConstants.kt
@@ -12,7 +12,7 @@ const val DATABASE_NAME = "ambient_cache.db"
 /**
  * Path of the database file.
  */
-const val DATABASE_PATH = "mapbox/maps"
+const val DATABASE_PATH = ".mapbox/maps"
 
 /**
  * The default cache size, which is 50MB

--- a/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
@@ -85,7 +85,7 @@ class MapInitOptionsTest {
   fun defaultResourceOptions() {
     val mapboxMapOptions = MapInitOptions(context)
     assertEquals("token", mapboxMapOptions.resourceOptions.accessToken)
-    assertTrue(mapboxMapOptions.resourceOptions.cachePath!!.endsWith("foobar/mapbox/maps/ambient_cache.db"))
+    assertTrue(mapboxMapOptions.resourceOptions.cachePath!!.endsWith("foobar/.mapbox/maps/ambient_cache.db"))
     assertEquals(DEFAULT_CACHE_SIZE, mapboxMapOptions.resourceOptions.cacheSize)
   }
 

--- a/sdk/src/test/java/com/mapbox/maps/ResourceAttributeParserTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ResourceAttributeParserTest.kt
@@ -35,7 +35,7 @@ class ResourceAttributeParserTest {
       ResourcesAttributeParser.parseResourcesOptions(context, typedArray, CredentialsManager.default)
     assertEquals("pk.foobar", resourceOptions.accessToken)
     assertEquals(null, resourceOptions.baseURL)
-    assertEquals("/foobar/mapbox/maps/ambient_cache.db", resourceOptions.cachePath)
+    assertEquals("/foobar/.mapbox/maps/ambient_cache.db", resourceOptions.cachePath)
     assertEquals(99L, resourceOptions.cacheSize)
   }
 
@@ -51,7 +51,7 @@ class ResourceAttributeParserTest {
   fun cachePath() {
     val resourceOptions =
       ResourcesAttributeParser.parseResourcesOptions(context, typedArray, CredentialsManager.default)
-    assertEquals("/foobar/mapbox/maps/ambient_cache.db", resourceOptions.cachePath)
+    assertEquals("/foobar/.mapbox/maps/ambient_cache.db", resourceOptions.cachePath)
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/ResourceOptionsManagerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ResourceOptionsManagerTest.kt
@@ -36,7 +36,7 @@ class ResourceOptionsManagerTest {
   fun getDefaultResourceOptionsManagerTest() {
     val defaultResourceOptionsManager = ResourceOptionsManager.getDefault(context)
     assertEquals("token", defaultResourceOptionsManager.resourceOptions.accessToken)
-    Assert.assertTrue(defaultResourceOptionsManager.resourceOptions.cachePath!!.endsWith("/mapbox/maps/ambient_cache.db"))
+    Assert.assertTrue(defaultResourceOptionsManager.resourceOptions.cachePath!!.endsWith("/.mapbox/maps/ambient_cache.db"))
     assertEquals(DEFAULT_CACHE_SIZE, defaultResourceOptionsManager.resourceOptions.cacheSize)
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Change the default ambient cache path to .mabox/maps/ambient_cache.db</changelog>`.

### Summary of changes

This PR changes the default ambient cache path to `.mabox/maps/ambient_cache.db` to align with default tile_store path.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->