### PR TITLE
Move text-font property from PointAnnotation to PointAnnotationManager

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/UpdateAnnotationTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/UpdateAnnotationTest.kt
@@ -50,6 +50,8 @@ class UpdateAnnotationTest : BaseMapTest(), OnMapLoadedListener {
       it.runOnUiThread {
         mapboxMap.loadStyleUri(AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]) {
           pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
+          pointAnnotationManager.textFont = listOf("Open Sans Regular")
+
           pointAnnotation = pointAnnotationManager.create(
             PointAnnotationOptions()
               .withIconColor(ColorUtils.colorToRgbaString(Color.RED))
@@ -79,7 +81,6 @@ class UpdateAnnotationTest : BaseMapTest(), OnMapLoadedListener {
               .withTextOpacity(0.8)
               .withTextOffset(listOf(1.0, 2.0))
               .withTextMaxWidth(10.0)
-              .withTextFont(listOf("Open Sans Regular"))
               .withPoint(Point.fromLngLat(0.0, 0.0))
           )
           Assert.assertEquals(pointAnnotation, pointAnnotationManager.annotations[0])

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PointAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PointAnnotationManagerAndroidTest.kt
@@ -138,6 +138,14 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
   }
 
   @Test
+  fun testTextFont() {
+    val testValue = listOf("a", "b", "c")
+    val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
+    pointAnnotationManager.textFont = testValue
+    assertEquals(testValue, pointAnnotationManager.textFont)
+  }
+
+  @Test
   fun testTextIgnorePlacement() {
     val testValue = true
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PointAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/annotation/PointAnnotationActivity.kt
@@ -48,6 +48,8 @@ class PointAnnotationActivity : AppCompatActivity() {
     mapView.getMapboxMap().loadStyleUri(nextStyle) {
       annotationPlugin = mapView.annotations
       symbolManager = annotationPlugin.createPointAnnotationManager(mapView).apply {
+        textFont = listOf("Arial Unicode MS Bold", "Open Sans Regular")
+
         addClickListener(
           OnPointAnnotationClickListener {
             Toast.makeText(this@PointAnnotationActivity, "Click: ${it.id}", Toast.LENGTH_SHORT)
@@ -90,12 +92,6 @@ class PointAnnotationActivity : AppCompatActivity() {
           val pointAnnotationOptions: PointAnnotationOptions = PointAnnotationOptions()
             .withPoint(Point.fromLngLat(AIRPORT_LONGITUDE, AIRPORT_LATITUDE))
             .withIconImage(it)
-            .withTextFont(
-              listOf(
-                "Arial Unicode MS Bold",
-                "Open Sans Regular"
-              )
-            )
             .withTextField(ID_ICON_AIRPORT)
             .withTextOffset(listOf(0.0, -2.0))
             .withTextColor(Color.RED)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
@@ -68,7 +68,15 @@ class CircleAnnotationManager(
    * CircleAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR - String   * CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR - String   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR - String
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR - String
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH - Double
+   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the circleAnnotation should be draggable, false otherwise
@@ -86,7 +94,15 @@ class CircleAnnotationManager(
    * CircleAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR - String   * CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR - String   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY - Double   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR - String
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR - String
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY - Double
+   * CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH - Double
+   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the circleAnnotation should be draggable, false otherwise

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
@@ -13,8 +13,6 @@ import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.Annotation
 import com.mapbox.maps.plugin.annotation.AnnotationManager
 import com.mapbox.maps.plugin.annotation.AnnotationType
-import com.mapbox.maps.plugin.annotation.ConvertUtils.convertStringArray
-import com.mapbox.maps.plugin.annotation.ConvertUtils.toStringArray
 import com.mapbox.maps.plugin.delegates.MapCameraManagerDelegate
 
 /**
@@ -317,34 +315,6 @@ class PointAnnotation(
       value?.let {
         jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_FIELD, it)
       }
-    }
-
-  /**
-   * The textFont property
-   * Font stack to use for displaying text.
-   */
-  var textFont: List<String>?
-    /**
-     * Get the textFont property
-     *
-     * @return property wrapper value around List<String>
-     */
-    get() {
-      val value = jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_FONT)
-      value?.let {
-        return toStringArray(it as JsonArray)
-      }
-      return null
-    }
-    /**
-     * Set the textFont property.
-     * To update the pointAnnotation on the map use {@link pointAnnotationManager#update(Annotation)}.
-     *
-     * @param value constant property value for List<String>
-     */
-    set(value) {
-      val jsonArray = convertStringArray(value)
-      jsonObject.add(PointAnnotationOptions.PROPERTY_TEXT_FONT, jsonArray)
     }
 
   /**
@@ -1068,9 +1038,6 @@ class PointAnnotation(
     }
     jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_FIELD)?.let {
       annotationManager.enableDataDrivenProperty(PointAnnotationOptions.PROPERTY_TEXT_FIELD)
-    }
-    jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_FONT)?.let {
-      annotationManager.enableDataDrivenProperty(PointAnnotationOptions.PROPERTY_TEXT_FONT)
     }
     jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)?.let {
       annotationManager.enableDataDrivenProperty(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
@@ -52,7 +52,6 @@ class PointAnnotationManager(
     dataDrivenPropertyUsageMap[PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY] = false
     dataDrivenPropertyUsageMap[PointAnnotationOptions.PROPERTY_TEXT_ANCHOR] = false
     dataDrivenPropertyUsageMap[PointAnnotationOptions.PROPERTY_TEXT_FIELD] = false
-    dataDrivenPropertyUsageMap[PointAnnotationOptions.PROPERTY_TEXT_FONT] = false
     dataDrivenPropertyUsageMap[PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY] = false
     dataDrivenPropertyUsageMap[PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING] = false
     dataDrivenPropertyUsageMap[PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH] = false
@@ -83,7 +82,6 @@ class PointAnnotationManager(
       PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY -> layer?.symbolSortKey(get(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY))
       PointAnnotationOptions.PROPERTY_TEXT_ANCHOR -> layer?.textAnchor(get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR))
       PointAnnotationOptions.PROPERTY_TEXT_FIELD -> layer?.textField(get(PointAnnotationOptions.PROPERTY_TEXT_FIELD))
-      PointAnnotationOptions.PROPERTY_TEXT_FONT -> layer?.textFont(get(PointAnnotationOptions.PROPERTY_TEXT_FONT))
       PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY -> layer?.textJustify(get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY))
       PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING -> layer?.textLetterSpacing(get(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING))
       PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH -> layer?.textMaxWidth(get(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH))
@@ -111,7 +109,7 @@ class PointAnnotationManager(
    * PointAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * PointAnnotationOptions.PROPERTY_ICON_ANCHOR - IconAnchor   * PointAnnotationOptions.PROPERTY_ICON_IMAGE - String   * PointAnnotationOptions.PROPERTY_ICON_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_ICON_ROTATE - Double   * PointAnnotationOptions.PROPERTY_ICON_SIZE - Double   * PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY - Double   * PointAnnotationOptions.PROPERTY_TEXT_ANCHOR - TextAnchor   * PointAnnotationOptions.PROPERTY_TEXT_FIELD - String   * PointAnnotationOptions.PROPERTY_TEXT_FONT - List<String>   * PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY - TextJustify   * PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING - Double   * PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET - Double   * PointAnnotationOptions.PROPERTY_TEXT_ROTATE - Double   * PointAnnotationOptions.PROPERTY_TEXT_SIZE - Double   * PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM - TextTransform   * PointAnnotationOptions.PROPERTY_ICON_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_ICON_OPACITY - Double   * PointAnnotationOptions.PROPERTY_TEXT_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OPACITY - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * PointAnnotationOptions.PROPERTY_ICON_ANCHOR - IconAnchor   * PointAnnotationOptions.PROPERTY_ICON_IMAGE - String   * PointAnnotationOptions.PROPERTY_ICON_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_ICON_ROTATE - Double   * PointAnnotationOptions.PROPERTY_ICON_SIZE - Double   * PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY - Double   * PointAnnotationOptions.PROPERTY_TEXT_ANCHOR - TextAnchor   * PointAnnotationOptions.PROPERTY_TEXT_FIELD - String   * PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY - TextJustify   * PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING - Double   * PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET - Double   * PointAnnotationOptions.PROPERTY_TEXT_ROTATE - Double   * PointAnnotationOptions.PROPERTY_TEXT_SIZE - Double   * PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM - TextTransform   * PointAnnotationOptions.PROPERTY_ICON_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_ICON_OPACITY - Double   * PointAnnotationOptions.PROPERTY_TEXT_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OPACITY - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the pointAnnotation should be draggable, false otherwise
@@ -129,7 +127,7 @@ class PointAnnotationManager(
    * PointAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * PointAnnotationOptions.PROPERTY_ICON_ANCHOR - IconAnchor   * PointAnnotationOptions.PROPERTY_ICON_IMAGE - String   * PointAnnotationOptions.PROPERTY_ICON_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_ICON_ROTATE - Double   * PointAnnotationOptions.PROPERTY_ICON_SIZE - Double   * PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY - Double   * PointAnnotationOptions.PROPERTY_TEXT_ANCHOR - TextAnchor   * PointAnnotationOptions.PROPERTY_TEXT_FIELD - String   * PointAnnotationOptions.PROPERTY_TEXT_FONT - List<String>   * PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY - TextJustify   * PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING - Double   * PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET - Double   * PointAnnotationOptions.PROPERTY_TEXT_ROTATE - Double   * PointAnnotationOptions.PROPERTY_TEXT_SIZE - Double   * PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM - TextTransform   * PointAnnotationOptions.PROPERTY_ICON_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_ICON_OPACITY - Double   * PointAnnotationOptions.PROPERTY_TEXT_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OPACITY - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * PointAnnotationOptions.PROPERTY_ICON_ANCHOR - IconAnchor   * PointAnnotationOptions.PROPERTY_ICON_IMAGE - String   * PointAnnotationOptions.PROPERTY_ICON_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_ICON_ROTATE - Double   * PointAnnotationOptions.PROPERTY_ICON_SIZE - Double   * PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY - Double   * PointAnnotationOptions.PROPERTY_TEXT_ANCHOR - TextAnchor   * PointAnnotationOptions.PROPERTY_TEXT_FIELD - String   * PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY - TextJustify   * PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING - Double   * PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET - Double   * PointAnnotationOptions.PROPERTY_TEXT_ROTATE - Double   * PointAnnotationOptions.PROPERTY_TEXT_SIZE - Double   * PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM - TextTransform   * PointAnnotationOptions.PROPERTY_ICON_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_ICON_OPACITY - Double   * PointAnnotationOptions.PROPERTY_TEXT_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OPACITY - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the pointAnnotation should be draggable, false otherwise
@@ -466,6 +464,30 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textAllowOverlap(it)
+      }
+    }
+
+  /**
+   * The TextFont property
+   *
+   * Font stack to use for displaying text.
+   */
+  var textFont: List<String>?
+    /**
+     * Get the TextFont property
+     *
+     * @return property wrapper value around List<String>
+     */
+    get(): List<String>? {
+      return layer?.textFont
+    }
+    /**
+     * Set the TextFont property
+     * @param value property wrapper value around List<String>
+     */
+    set(value) {
+      value?.let {
+        layer?.textFont(it)
       }
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
@@ -109,7 +109,33 @@ class PointAnnotationManager(
    * PointAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * PointAnnotationOptions.PROPERTY_ICON_ANCHOR - IconAnchor   * PointAnnotationOptions.PROPERTY_ICON_IMAGE - String   * PointAnnotationOptions.PROPERTY_ICON_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_ICON_ROTATE - Double   * PointAnnotationOptions.PROPERTY_ICON_SIZE - Double   * PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY - Double   * PointAnnotationOptions.PROPERTY_TEXT_ANCHOR - TextAnchor   * PointAnnotationOptions.PROPERTY_TEXT_FIELD - String   * PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY - TextJustify   * PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING - Double   * PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET - Double   * PointAnnotationOptions.PROPERTY_TEXT_ROTATE - Double   * PointAnnotationOptions.PROPERTY_TEXT_SIZE - Double   * PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM - TextTransform   * PointAnnotationOptions.PROPERTY_ICON_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_ICON_OPACITY - Double   * PointAnnotationOptions.PROPERTY_TEXT_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OPACITY - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * PointAnnotationOptions.PROPERTY_ICON_ANCHOR - IconAnchor
+   * PointAnnotationOptions.PROPERTY_ICON_IMAGE - String
+   * PointAnnotationOptions.PROPERTY_ICON_OFFSET - List<Double>
+   * PointAnnotationOptions.PROPERTY_ICON_ROTATE - Double
+   * PointAnnotationOptions.PROPERTY_ICON_SIZE - Double
+   * PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_ANCHOR - TextAnchor
+   * PointAnnotationOptions.PROPERTY_TEXT_FIELD - String
+   * PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY - TextJustify
+   * PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_OFFSET - List<Double>
+   * PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_ROTATE - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_SIZE - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM - TextTransform
+   * PointAnnotationOptions.PROPERTY_ICON_COLOR - String
+   * PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR - Double
+   * PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR - String
+   * PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH - Double
+   * PointAnnotationOptions.PROPERTY_ICON_OPACITY - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_COLOR - String
+   * PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR - String
+   * PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_OPACITY - Double
+   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the pointAnnotation should be draggable, false otherwise
@@ -127,7 +153,33 @@ class PointAnnotationManager(
    * PointAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * PointAnnotationOptions.PROPERTY_ICON_ANCHOR - IconAnchor   * PointAnnotationOptions.PROPERTY_ICON_IMAGE - String   * PointAnnotationOptions.PROPERTY_ICON_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_ICON_ROTATE - Double   * PointAnnotationOptions.PROPERTY_ICON_SIZE - Double   * PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY - Double   * PointAnnotationOptions.PROPERTY_TEXT_ANCHOR - TextAnchor   * PointAnnotationOptions.PROPERTY_TEXT_FIELD - String   * PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY - TextJustify   * PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING - Double   * PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OFFSET - List<Double>   * PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET - Double   * PointAnnotationOptions.PROPERTY_TEXT_ROTATE - Double   * PointAnnotationOptions.PROPERTY_TEXT_SIZE - Double   * PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM - TextTransform   * PointAnnotationOptions.PROPERTY_ICON_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_ICON_OPACITY - Double   * PointAnnotationOptions.PROPERTY_TEXT_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR - Double   * PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR - String   * PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH - Double   * PointAnnotationOptions.PROPERTY_TEXT_OPACITY - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * PointAnnotationOptions.PROPERTY_ICON_ANCHOR - IconAnchor
+   * PointAnnotationOptions.PROPERTY_ICON_IMAGE - String
+   * PointAnnotationOptions.PROPERTY_ICON_OFFSET - List<Double>
+   * PointAnnotationOptions.PROPERTY_ICON_ROTATE - Double
+   * PointAnnotationOptions.PROPERTY_ICON_SIZE - Double
+   * PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_ANCHOR - TextAnchor
+   * PointAnnotationOptions.PROPERTY_TEXT_FIELD - String
+   * PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY - TextJustify
+   * PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_OFFSET - List<Double>
+   * PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_ROTATE - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_SIZE - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM - TextTransform
+   * PointAnnotationOptions.PROPERTY_ICON_COLOR - String
+   * PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR - Double
+   * PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR - String
+   * PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH - Double
+   * PointAnnotationOptions.PROPERTY_ICON_OPACITY - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_COLOR - String
+   * PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR - String
+   * PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH - Double
+   * PointAnnotationOptions.PROPERTY_TEXT_OPACITY - Double
+   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the pointAnnotation should be draggable, false otherwise

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationOptions.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationOptions.kt
@@ -16,9 +16,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.AnnotationManager
 import com.mapbox.maps.plugin.annotation.AnnotationOptions
 import com.mapbox.maps.plugin.annotation.ConvertUtils.convertDoubleArray
-import com.mapbox.maps.plugin.annotation.ConvertUtils.convertStringArray
 import com.mapbox.maps.plugin.annotation.ConvertUtils.toDoubleArray
-import com.mapbox.maps.plugin.annotation.ConvertUtils.toStringArray
 
 /**
  * Builder class from which a pointAnnotation is created.
@@ -183,24 +181,6 @@ class PointAnnotationOptions : AnnotationOptions<Point, PointAnnotation> {
    */
   fun withTextField(textField: String): PointAnnotationOptions {
     this.textField = textField
-    return this
-  }
-
-  /**
-   * Font stack to use for displaying text.
-   */
-  var textFont: List<String>? = null
-
-  /**
-   * Set text-font to initialise the pointAnnotation with.
-   *
-   * Font stack to use for displaying text.
-   *
-   * @param textFont the text-font value
-   * @return this
-   */
-  fun withTextFont(textFont: List<String>): PointAnnotationOptions {
-    this.textFont = textFont
     return this
   }
 
@@ -699,9 +679,6 @@ class PointAnnotationOptions : AnnotationOptions<Point, PointAnnotation> {
     textField?.let {
       jsonObject.addProperty(PROPERTY_TEXT_FIELD, it)
     }
-    textFont?.let {
-      jsonObject.add(PROPERTY_TEXT_FONT, convertStringArray(it))
-    }
     textJustify?.let {
       jsonObject.addProperty(PROPERTY_TEXT_JUSTIFY, it.value)
     }
@@ -793,9 +770,6 @@ class PointAnnotationOptions : AnnotationOptions<Point, PointAnnotation> {
 
     /** The property for text-field */
     const val PROPERTY_TEXT_FIELD = "text-field"
-
-    /** The property for text-font */
-    const val PROPERTY_TEXT_FONT = "text-font"
 
     /** The property for text-justify */
     const val PROPERTY_TEXT_JUSTIFY = "text-justify"
@@ -893,9 +867,6 @@ class PointAnnotationOptions : AnnotationOptions<Point, PointAnnotation> {
       }
       if (feature.hasProperty(PROPERTY_TEXT_FIELD)) {
         options.textField = feature.getProperty(PROPERTY_TEXT_FIELD).asString
-      }
-      if (feature.hasProperty(PROPERTY_TEXT_FONT)) {
-        options.textFont = toStringArray(feature.getProperty(PROPERTY_TEXT_FONT).asJsonArray)
       }
       if (feature.hasProperty(PROPERTY_TEXT_JUSTIFY)) {
         options.textJustify = TextJustify.valueOf(feature.getProperty(PROPERTY_TEXT_JUSTIFY).asString)

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
@@ -62,7 +62,12 @@ class PolygonAnnotationManager(
    * PolygonAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY - Double   * PolygonAnnotationOptions.PROPERTY_FILL_COLOR - String   * PolygonAnnotationOptions.PROPERTY_FILL_OPACITY - Double   * PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR - String   * PolygonAnnotationOptions.PROPERTY_FILL_PATTERN - String   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY - Double
+   * PolygonAnnotationOptions.PROPERTY_FILL_COLOR - String
+   * PolygonAnnotationOptions.PROPERTY_FILL_OPACITY - Double
+   * PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR - String
+   * PolygonAnnotationOptions.PROPERTY_FILL_PATTERN - String
+   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the polygonAnnotation should be draggable, false otherwise
@@ -80,7 +85,12 @@ class PolygonAnnotationManager(
    * PolygonAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY - Double   * PolygonAnnotationOptions.PROPERTY_FILL_COLOR - String   * PolygonAnnotationOptions.PROPERTY_FILL_OPACITY - Double   * PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR - String   * PolygonAnnotationOptions.PROPERTY_FILL_PATTERN - String   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY - Double
+   * PolygonAnnotationOptions.PROPERTY_FILL_COLOR - String
+   * PolygonAnnotationOptions.PROPERTY_FILL_OPACITY - Double
+   * PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR - String
+   * PolygonAnnotationOptions.PROPERTY_FILL_PATTERN - String
+   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the polygonAnnotation should be draggable, false otherwise

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
@@ -70,7 +70,16 @@ class PolylineAnnotationManager(
    * PolylineAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * PolylineAnnotationOptions.PROPERTY_LINE_JOIN - LineJoin   * PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY - Double   * PolylineAnnotationOptions.PROPERTY_LINE_BLUR - Double   * PolylineAnnotationOptions.PROPERTY_LINE_COLOR - String   * PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH - Double   * PolylineAnnotationOptions.PROPERTY_LINE_OFFSET - Double   * PolylineAnnotationOptions.PROPERTY_LINE_OPACITY - Double   * PolylineAnnotationOptions.PROPERTY_LINE_PATTERN - String   * PolylineAnnotationOptions.PROPERTY_LINE_WIDTH - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * PolylineAnnotationOptions.PROPERTY_LINE_JOIN - LineJoin
+   * PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_BLUR - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_COLOR - String
+   * PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_OFFSET - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_OPACITY - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_PATTERN - String
+   * PolylineAnnotationOptions.PROPERTY_LINE_WIDTH - Double
+   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the polylineAnnotation should be draggable, false otherwise
@@ -88,7 +97,16 @@ class PolylineAnnotationManager(
    * PolylineAnnotations are going to be created only for features with a matching geometry.
    *
    * All supported properties are:
-   * PolylineAnnotationOptions.PROPERTY_LINE_JOIN - LineJoin   * PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY - Double   * PolylineAnnotationOptions.PROPERTY_LINE_BLUR - Double   * PolylineAnnotationOptions.PROPERTY_LINE_COLOR - String   * PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH - Double   * PolylineAnnotationOptions.PROPERTY_LINE_OFFSET - Double   * PolylineAnnotationOptions.PROPERTY_LINE_OPACITY - Double   * PolylineAnnotationOptions.PROPERTY_LINE_PATTERN - String   * PolylineAnnotationOptions.PROPERTY_LINE_WIDTH - Double   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
+   * PolylineAnnotationOptions.PROPERTY_LINE_JOIN - LineJoin
+   * PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_BLUR - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_COLOR - String
+   * PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_OFFSET - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_OPACITY - Double
+   * PolylineAnnotationOptions.PROPERTY_LINE_PATTERN - String
+   * PolylineAnnotationOptions.PROPERTY_LINE_WIDTH - Double
+   * Learn more about above properties in the )[The online documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/).
    *
    * Out of spec properties:
    * "is-draggable" - Boolean, true if the polylineAnnotation should be draggable, false otherwise

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -131,7 +131,6 @@ class PointAnnotationManagerTest {
     every { layer.symbolSortKey(any<Expression>()) } answers { layer }
     every { layer.textAnchor(any<Expression>()) } answers { layer }
     every { layer.textField(any<Expression>()) } answers { layer }
-    every { layer.textFont(any<Expression>()) } answers { layer }
     every { layer.textJustify(any<Expression>()) } answers { layer }
     every { layer.textLetterSpacing(any<Expression>()) } answers { layer }
     every { layer.textMaxWidth(any<Expression>()) } answers { layer }
@@ -584,19 +583,6 @@ class PointAnnotationManagerTest {
     verify(exactly = 1) { manager.layer?.textField(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FIELD)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textField(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FIELD)) }
-  }
-
-  @Test
-  fun testTextFontLayerProperty() {
-    every { style.styleSourceExists(any()) } returns true
-    verify(exactly = 0) { manager.layer?.textFont(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FONT)) }
-    val options = PointAnnotationOptions()
-      .withPoint(Point.fromLngLat(0.0, 0.0))
-      .withTextFont(listOf("Open Sans Regular", "Arial Unicode MS Regular"))
-    manager.create(options)
-    verify(exactly = 1) { manager.layer?.textFont(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FONT)) }
-    manager.create(options)
-    verify(exactly = 1) { manager.layer?.textFont(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FONT)) }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Move text-font property from PointAnnotation to PointAnnotationManager</changelog>`.

### Summary of changes
Property `text-font` is a data-driven property, however, if we apply this property in `PointAnnotationOptions`

```
  val pointAnnotationOptions: PointAnnotationOptions = PointAnnotationOptions()
     .withTextFont( listOf( "Arial Unicode MS Bold",   "Open Sans Regular" ))
```
We will have the following error:
```
Layer 'mapbox-android-symbol-layer-4' has an invalid value for text-font and will not render text. Output values must be contained as literals within the expression.
``` 
This is because we are using `get` expression to apply data-driven properties with outputs not predictable.
Engine must know what are the possible outputs of an expression. Example:

- Invalid case: `"text-font": [ "get", "text-font" ]`, evaluation result can be anything, no way to know what is the output of that expression
- Valid case: `"text-font": ["match", ["get", "text-font"], "iOS", ["literal", ["SanFrancisco"]], ["literal", ["Roboto"]]]`, there are only two possible evaluation outputs: "SanFrancisco" or "Roboto"

This pr makes `text-font` not data-driven anymore.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)
Need to change text font config from `PointAnnotationOptions`
```
  val pointAnnotationOptions: PointAnnotationOptions = PointAnnotationOptions()
     .withTextFont( listOf( "Arial Unicode MS Bold",   "Open Sans Regular" ))
```
to `PointAnnotationManager`
```
 symbolManager = annotationPlugin.createPointAnnotationManager(mapView).apply {textFont = listOf("Arial Unicode MS Bold", "Open Sans Regular")
```
<!--
If this PR introduces user-facing changes, please note them here.
-->