### PR TITLE
Geojson async data parsing: fixes and improvements

### DIFF
--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -89,6 +89,9 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
 
   /**
    * A URL to a GeoJSON file, or inline GeoJSON.
+   *
+   * If method is called while another asynchronous method is parsing data - asynchronous method will not
+   * apply when data is parsed.
    */
   fun data(value: String) = apply {
     ignoreParsedGeoJson = true
@@ -98,6 +101,9 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
 
   /**
    * A URL to a GeoJSON file, or inline GeoJSON.
+   *
+   * If method is called while another asynchronous method is parsing data - asynchronous method will not
+   * apply when data is parsed.
    */
   fun data(value: Expression) = apply {
     ignoreParsedGeoJson = true
@@ -526,6 +532,9 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
    * If [onDataParsed] is provided and not null - data will be loaded in async mode.
    * Otherwise method will be synchronous.
    *
+   * If synchronous method is called while another asynchronous method is parsing data -
+   * asynchronous method will not apply when data is parsed.
+   *
    * @param value the feature collection
    * @param onDataParsed optional callback notifying when data is parsed on a worker thread
    */
@@ -539,6 +548,9 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
    * If [onDataParsed] is provided and not null - data will be loaded in async mode.
    * Otherwise method will be synchronous.
    *
+   * If synchronous method is called while another asynchronous method is parsing data -
+   * asynchronous method will not apply when data is parsed.
+   *
    * @param value the feature collection
    * @param onDataParsed optional callback notifying when data is parsed on a worker thread
    */
@@ -551,6 +563,9 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
    * Add a Geometry to the GeojsonSource.
    * If [onDataParsed] is provided and not null - data will be loaded in async mode.
    * Otherwise method will be synchronous.
+   *
+   * If synchronous method is called while another asynchronous method is parsing data -
+   * asynchronous method will not apply when data is parsed.
    *
    * @param value the feature collection
    * @param onDataParsed optional callback notifying when data is parsed on a worker thread

--- a/sdk/src/androidTest/java/com/mapbox/maps/MapIntegrationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/MapIntegrationTest.kt
@@ -4,8 +4,12 @@ import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.mapbox.geojson.Feature
+import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
+import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.generated.circleLayer
+import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
 import com.mapbox.maps.extension.style.style
 import org.junit.After
@@ -79,6 +83,248 @@ class MapIntegrationTest {
           }
         ) {
           countDownLatch.countDown()
+        }
+        mapView.onStart()
+      }
+    }
+    if (!countDownLatch.await(5, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun testApplySyncDataToGeoJson1() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      it.runOnUiThread {
+        mapView = MapView(it)
+        mapboxMap = mapView.getMapboxMap()
+        it.frameLayout.addView(mapView)
+        mapboxMap.setCamera(
+          CameraOptions.Builder()
+            .center(Point.fromLngLat(0.1, 0.1))
+            .zoom(9.0)
+            .build()
+        )
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) { style ->
+          // prepare layer
+          val layer = circleLayer("layer", "source") {
+            circleColor("red")
+            circleRadius(10.0)
+          }
+          // async loading
+          val source = geoJsonSource("source") {
+            geometry(Point.fromLngLat(0.0, 0.0))
+          }
+          source.geometry(Point.fromLngLat(0.0, 0.0)) {}
+          source.feature(Feature.fromGeometry(Point.fromLngLat(0.0, 0.0))) {}
+          source.featureCollection(
+            FeatureCollection.fromFeature(
+              Feature.fromGeometry(
+                Point.fromLngLat(
+                  0.0,
+                  0.0
+                )
+              )
+            )
+          ) {}
+          // sync method must clear async queue and not allow current running async task apply changes
+          source.geometry(Point.fromLngLat(0.1, 0.1))
+          style.addSource(source)
+          style.addLayer(layer)
+          mapView.postDelayed(
+            {
+              mapboxMap.queryRenderedFeatures(
+                ScreenCoordinate(mapView.width / 2.0, mapView.height / 2.0),
+                RenderedQueryOptions(listOf("layer"), null)
+              ) { result ->
+                if (result.value?.size == 1) {
+                  countDownLatch.countDown()
+                }
+              }
+            },
+            1_000L
+          )
+        }
+        mapView.onStart()
+      }
+    }
+    if (!countDownLatch.await(5, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun testApplySyncDataToGeoJson2() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      it.runOnUiThread {
+        mapView = MapView(it)
+        mapboxMap = mapView.getMapboxMap()
+        it.frameLayout.addView(mapView)
+        mapboxMap.setCamera(
+          CameraOptions.Builder()
+            .center(Point.fromLngLat(0.1, 0.1))
+            .zoom(9.0)
+            .build()
+        )
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) { style ->
+          // prepare layer
+          val layer = circleLayer("layer", "source") {
+            circleColor("red")
+            circleRadius(10.0)
+          }
+          // async loading
+          val source = geoJsonSource("source") {
+            geometry(Point.fromLngLat(0.0, 0.0))
+          }
+          // sync method must clear async queue and not allow current running async task apply changes
+          source.data(
+            """
+            {
+              "type": "FeatureCollection",
+              "features": [
+                {
+                  "type": "Feature",
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                      0.1,
+                      0.1
+                    ]
+                  },
+                  "properties": {
+                    "icon-image": "cafe-15",
+                    "is-draggable": true
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+          )
+          style.addSource(source)
+          style.addLayer(layer)
+          mapView.postDelayed(
+            {
+              mapboxMap.queryRenderedFeatures(
+                ScreenCoordinate(mapView.width / 2.0, mapView.height / 2.0),
+                RenderedQueryOptions(listOf("layer"), null)
+              ) { result ->
+                if (result.value?.size == 1) {
+                  countDownLatch.countDown()
+                }
+              }
+            },
+            1_000L
+          )
+        }
+        mapView.onStart()
+      }
+    }
+    if (!countDownLatch.await(5, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun testApplySyncDataToGeoJson3() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      it.runOnUiThread {
+        mapView = MapView(it)
+        mapboxMap = mapView.getMapboxMap()
+        it.frameLayout.addView(mapView)
+        mapboxMap.setCamera(
+          CameraOptions.Builder()
+            .center(Point.fromLngLat(0.2, 0.2))
+            .zoom(9.0)
+            .build()
+        )
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) { style ->
+          // prepare layer
+          val layer = circleLayer("layer", "source") {
+            circleColor("red")
+            circleRadius(10.0)
+          }
+          // async loading
+          val source = geoJsonSource("source") {
+            geometry(Point.fromLngLat(0.0, 0.0))
+          }
+          // sync method must clear async queue and not allow current running async task apply changes
+          source.geometry(Point.fromLngLat(0.1, 0.1))
+          // follow up with new async that must take effect
+          source.geometry(Point.fromLngLat(0.2, 0.2)) {}
+          style.addSource(source)
+          style.addLayer(layer)
+          mapView.postDelayed(
+            {
+              mapboxMap.queryRenderedFeatures(
+                ScreenCoordinate(mapView.width / 2.0, mapView.height / 2.0),
+                RenderedQueryOptions(listOf("layer"), null)
+              ) { result ->
+                if (result.value?.size == 1) {
+                  countDownLatch.countDown()
+                }
+              }
+            },
+            1_000L
+          )
+        }
+        mapView.onStart()
+      }
+    }
+    if (!countDownLatch.await(5, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun testApplySyncDataToGeoJson4() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      it.runOnUiThread {
+        mapView = MapView(it)
+        mapboxMap = mapView.getMapboxMap()
+        it.frameLayout.addView(mapView)
+        mapboxMap.setCamera(
+          CameraOptions.Builder()
+            .center(Point.fromLngLat(0.2, 0.2))
+            .zoom(9.0)
+            .build()
+        )
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) { style ->
+          // prepare layer
+          val layer = circleLayer("layer", "source") {
+            circleColor("red")
+            circleRadius(10.0)
+          }
+          // async loading, but we proceed after parsing
+          geoJsonSource(
+            "source",
+            config = {
+              geometry(Point.fromLngLat(0.0, 0.0))
+            }
+          ) { source ->
+            // sync method
+            source.geometry(Point.fromLngLat(0.1, 0.1))
+            // follow up with new async that must take effect
+            source.geometry(Point.fromLngLat(0.2, 0.2)) {}
+            style.addSource(source)
+            style.addLayer(layer)
+            mapView.postDelayed(
+              {
+                mapboxMap.queryRenderedFeatures(
+                  ScreenCoordinate(mapView.width / 2.0, mapView.height / 2.0),
+                  RenderedQueryOptions(listOf("layer"), null)
+                ) { result ->
+                  if (result.value?.size == 1) {
+                    countDownLatch.countDown()
+                  }
+                }
+              },
+              1_000L
+            )
+          }
         }
         mapView.onStart()
       }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Geojson async data parsing: fixes and improvements.</changelog>`.

### Summary of changes

This PR brings following changes to async geojson behavior:

- If __synchronised__ method is called to change `data` property (those are `GeoJsonSource.data(...)`, `GeoJsonSource.feature(value: Feature)`, `GeoJsonSource.featureCollection(value: FeatureCollection)`, `GeoJsonSource.geometry(value: Geometry)`) while worker thread is already busy parsing some previous data - handler thread queue should be cleared, current task should be canceled and new `data` should be applied immediately.
 - If __async__ method is called to change `data` property (those are  `GeoJsonSource.feature(value: Feature, { ... })`, `GeoJsonSource.featureCollection(value: FeatureCollection, { ... })`, `GeoJsonSource.geometry(value: Geometry, { ... })`) while worker thread is already busy parsing some previous data - handler thread queue should be cleared, current task should __not__ be canceled and new `data` parsing should be added to worker thread queue. This is done because mid updates in queue will make no sense as they will be overwritten by upcoming updates but current task being executed should be finished successfully in order to apply changes.
 - If using `data` function when preparing `GeoJsonSource` with `Builder` after calling function `GeoJsonSource.feature(value: Feature)`, `GeoJsonSource.featureCollection(value: FeatureCollection)` or `GeoJsonSource.geometry(value: Geometry)` in builder block - it will be applied correctly.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->