### PR TITLE
[style] rename setter for Light object from add to set

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/RuntimeStylingActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/RuntimeStylingActivity.kt
@@ -16,8 +16,8 @@ import com.mapbox.maps.extension.style.layers.generated.fillExtrusionLayer
 import com.mapbox.maps.extension.style.layers.generated.rasterLayer
 import com.mapbox.maps.extension.style.layers.generated.symbolLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
-import com.mapbox.maps.extension.style.light.generated.addLight
 import com.mapbox.maps.extension.style.light.generated.light
+import com.mapbox.maps.extension.style.light.generated.setLight
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.*
 import com.mapbox.maps.extension.style.sources.getSource
@@ -310,7 +310,7 @@ class RuntimeStylingActivity : AppCompatActivity() {
         polarAngle = 50.0
       )
     }
-    style.addLight(light)
+    style.setLight(light)
   }
 
   private fun addImageSource(style: Style) {

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/BaseStyleTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/BaseStyleTest.kt
@@ -10,7 +10,7 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.StyleContract
 import com.mapbox.maps.extension.style.layers.addLayer
-import com.mapbox.maps.extension.style.light.generated.addLight
+import com.mapbox.maps.extension.style.light.generated.setLight
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.terrain.generated.addTerrain
 import com.mapbox.maps.extension.testapp.R
@@ -81,7 +81,7 @@ abstract class BaseStyleTest {
   }
 
   fun setupLight(light: StyleContract.StyleLightExtension) {
-    style.addLight(light)
+    style.setLight(light)
   }
 
   fun setupTerrain(terrain: StyleContract.StyleTerrainExtension) {

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/StyleExtensionImpl.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/StyleExtensionImpl.kt
@@ -104,7 +104,7 @@ class StyleExtensionImpl private constructor(
      *
      * Apply +[Light] will add the light to the [StyleExtensionImpl].
      */
-    @JvmName("addLight")
+    @JvmName("setLight")
     operator fun Light.unaryPlus() {
       light = this
     }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/light/generated/Light.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/light/generated/Light.kt
@@ -573,7 +573,7 @@ fun StyleInterface.getLight(): Light {
  *
  * @param light The light to be added
  */
-fun StyleInterface.addLight(light: StyleContract.StyleLightExtension) {
+fun StyleInterface.setLight(light: StyleContract.StyleLightExtension) {
   light.bindTo(this)
 }
 


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Rename setter for Light object from add to set. This matches API from GL-JS and clarifies there is only 1 Light object.</changelog>`.

### Summary of changes
Rename setter for Light object from add to set. This matches API from GL-JS and clarifies there is only 1 Light object.
