### PR TITLE
[style] rename setter for Terrain object from add to set

### DIFF
--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/BaseStyleTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/BaseStyleTest.kt
@@ -12,7 +12,7 @@ import com.mapbox.maps.extension.style.StyleContract
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.light.generated.setLight
 import com.mapbox.maps.extension.style.sources.addSource
-import com.mapbox.maps.extension.style.terrain.generated.addTerrain
+import com.mapbox.maps.extension.style.terrain.generated.setTerrain
 import com.mapbox.maps.extension.testapp.R
 import org.junit.After
 import org.junit.Before
@@ -85,7 +85,7 @@ abstract class BaseStyleTest {
   }
 
   fun setupTerrain(terrain: StyleContract.StyleTerrainExtension) {
-    style.addTerrain(terrain)
+    style.setTerrain(terrain)
   }
 
   fun setupSource(source: StyleContract.StyleSourceExtension) {

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/StyleExtensionImpl.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/StyleExtensionImpl.kt
@@ -114,7 +114,7 @@ class StyleExtensionImpl private constructor(
      *
      * Apply +[Terrain] will add the terrain to the [StyleExtensionImpl].
      */
-    @JvmName("addTerrain")
+    @JvmName("setTerrain")
     operator fun Terrain.unaryPlus() {
       terrain = this
     }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/terrain/generated/Terrain.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/terrain/generated/Terrain.kt
@@ -177,11 +177,11 @@ fun StyleInterface.getTerrain(sourceId: String): Terrain {
 }
 
 /**
- * Extension function to add a Terrain provided by the Style Extension to the Style.
+ * Extension function to set the Terrain provided by the Style Extension to the Style.
  *
- * @param terrain The terrain to be added
+ * @param terrain The terrain to be set
  */
-fun StyleInterface.addTerrain(terrain: StyleContract.StyleTerrainExtension) {
+fun StyleInterface.setTerrain(terrain: StyleContract.StyleTerrainExtension) {
   terrain.bindTo(this)
 }
 


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Rename setter for Terrain object from add to set</changelog>`.

### Summary of changes

Rename setter for Terrain object from add to set, this is to align more with gl-js and other platforms. 