### PR TITLE
Use the default dataPath from core.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/OfflineActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/OfflineActivity.kt
@@ -296,7 +296,7 @@ class OfflineActivity : AppCompatActivity() {
     offlineManager.removeStylePack(Style.OUTDOORS)
 
     // Fixme add method to clear cached data(style pack)
-    File(ResourceOptionsManager.getDefault(this).resourceOptions.dataPath).listFiles().forEach { it.delete() }
+    File("${this.filesDir.absolutePath}/.mapbox/map_data/map_data.db").delete()
 
     // Reset progressbar.
     updateStylePackDownloadProgress(0, 0)

--- a/sdk/src/androidTest/java/com/mapbox/maps/MapboxMapIntegrationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/MapboxMapIntegrationTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -37,7 +38,8 @@ class MapboxMapIntegrationTest {
     val defaultOptions = MapInitOptions.getDefaultResourceOptions(mapView.context)
     val currentOptions = mapboxMap.getResourceOptions()
     assertEquals(defaultOptions.accessToken, currentOptions.accessToken)
-    assertEquals(defaultOptions.dataPath, currentOptions.dataPath)
+    assertNull(defaultOptions.dataPath)
+    assertEquals("${mapView.context.filesDir.absolutePath}/.mapbox/map_data/", currentOptions.dataPath)
   }
 
   @UiThreadTest

--- a/sdk/src/androidTest/java/com/mapbox/maps/OfflineTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/OfflineTest.kt
@@ -16,6 +16,7 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.*
 import org.junit.runner.RunWith
+import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -52,6 +53,8 @@ class OfflineTest {
       offlineManager.removeStylePack(STYLE)
       tileStore.removeTileRegion(TILE_REGION_ID)
       tileStore.setOption(TileStoreOptions.DISK_QUOTA, Value(0))
+      // Fixme add method to clear cached data(style pack)
+      File("${InstrumentationRegistry.getInstrumentation().targetContext.filesDir.absolutePath}/.mapbox/map_data/map_data.db").delete()
     }
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt
@@ -104,6 +104,4 @@ fun ResourceOptions.Builder.applyDefaultParams(
   if (tokenResId != 0) {
     accessToken(context.getString(tokenResId))
   }
-
-  dataPath("${context.filesDir.absolutePath}/$DATA_PATH")
 }

--- a/sdk/src/main/java/com/mapbox/maps/MapboxConstants.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxConstants.kt
@@ -5,15 +5,6 @@ package com.mapbox.maps
 import java.util.*
 
 /**
- * The path to the map data folder. The DATA_PATH will be relative(appended) to the application's files directory.
- *
- * The implementation will use this folder for storing offline style packages and temporary data.
- *
- * The application must have sufficient permissions to create files within the provided directory.
- */
-const val DATA_PATH = ".mapbox/maps/"
-
-/**
  * Default Locale for data processing (ex: String.toLowerCase(com.mapbox.maps.getMAPBOX_LOCALE, "foo"))
  */
 val MAPBOX_LOCALE: Locale = Locale.US

--- a/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapInitOptionsTest.kt
@@ -7,8 +7,7 @@ import com.mapbox.maps.plugin.*
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -91,7 +90,7 @@ class MapInitOptionsTest {
   fun defaultResourceOptions() {
     val mapboxMapOptions = MapInitOptions(context)
     assertEquals("token", mapboxMapOptions.resourceOptions.accessToken)
-    assertTrue(mapboxMapOptions.resourceOptions.dataPath!!.endsWith("foobar/.mapbox/maps/"))
+    assertNull(mapboxMapOptions.resourceOptions.dataPath)
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/ResourceAttributeParserTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ResourceAttributeParserTest.kt
@@ -7,6 +7,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import java.io.File
@@ -40,8 +41,8 @@ class ResourceAttributeParserTest {
     val resourceOptions =
       ResourcesAttributeParser.parseResourcesOptions(context, typedArray)
     assertEquals("pk.foobar", resourceOptions.accessToken)
-    assertEquals(null, resourceOptions.baseURL)
-    assertEquals("/foobar/.mapbox/maps/", resourceOptions.dataPath)
+    assertNull(resourceOptions.baseURL)
+    assertNull(resourceOptions.dataPath)
   }
 
   @Test
@@ -80,7 +81,7 @@ class ResourceAttributeParserTest {
   fun cachePath() {
     val resourceOptions =
       ResourcesAttributeParser.parseResourcesOptions(context, typedArray)
-    assertEquals("/foobar/.mapbox/maps/", resourceOptions.dataPath)
+    assertNull(resourceOptions.dataPath)
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/ResourceOptionsManagerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ResourceOptionsManagerTest.kt
@@ -5,8 +5,8 @@ import com.mapbox.common.TileStore
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.After
-import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -66,7 +66,7 @@ class ResourceOptionsManagerTest {
   fun getDefaultTest() {
     var defaultResourceOptionsManager = ResourceOptionsManager.getDefault(context)
     assertEquals("token", defaultResourceOptionsManager.resourceOptions.accessToken)
-    Assert.assertTrue(defaultResourceOptionsManager.resourceOptions.dataPath!!.endsWith(DATA_PATH))
+    assertNull(defaultResourceOptionsManager.resourceOptions.dataPath)
 
     defaultResourceOptionsManager = ResourceOptionsManager.getDefault(context, "newToken")
     assertEquals("newToken", defaultResourceOptionsManager.resourceOptions.accessToken)
@@ -102,6 +102,6 @@ class ResourceOptionsManagerTest {
     ResourceOptionsManager.destroyDefault()
     defaultResourceOptionsManager = ResourceOptionsManager.getDefault(context)
     assertEquals("token", defaultResourceOptionsManager.resourceOptions.accessToken)
-    Assert.assertTrue(defaultResourceOptionsManager.resourceOptions.dataPath!!.endsWith(DATA_PATH))
+    assertNull(defaultResourceOptionsManager.resourceOptions.dataPath)
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Change the default ResourceOptions#dataPath to files/.mapbox/map_data/ , and change the database name to map_data.db</changelog>`.

### Summary of changes

This PR changes the default dataPath to the one core sets, i.e. `"${context.filesDir.absolutePath}/.mapbox/map_data/"`,
the path to the database file will be changed to `"${context.filesDir.absolutePath}/.mapbox/map_data/map_data.db"` by default.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->