### PR TITLE
Include xml attribute strings from res-public to sourceSet.

### DIFF
--- a/plugin-attribution/build.gradle.kts
+++ b/plugin-attribution/build.gradle.kts
@@ -19,6 +19,11 @@ android {
       isIncludeAndroidResources = true
     }
   }
+
+  sourceSets {
+    // limit amount of exposed library resources
+    getByName("main").res.srcDirs("src/main/res-public")
+  }
 }
 
 dependencies {

--- a/plugin-attribution/src/main/res-public/values/public.xml
+++ b/plugin-attribution/src/main/res-public/values/public.xml
@@ -9,7 +9,7 @@
     <public name="mapbox_attributionIconColor" type="attr" />
 
     <!-- Defines where the attribution icon is positioned on the map -->
-    <public name="mapbox_attributionGravity" type="attr" >
+    <public name="mapbox_attributionGravity" type="attr" />
 
     <!-- Defines the margin to the left that the attribution icon honors. -->
     <public name="mapbox_attributionMarginLeft" type="attr" />

--- a/plugin-compass/build.gradle.kts
+++ b/plugin-compass/build.gradle.kts
@@ -13,6 +13,11 @@ android {
     targetSdkVersion(AndroidVersions.targetSdkVersion)
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+
+  sourceSets {
+    // limit amount of exposed library resources
+    getByName("main").res.srcDirs("src/main/res-public")
+  }
 }
 
 dependencies {

--- a/plugin-compass/src/main/res-public/values/public.xml
+++ b/plugin-compass/src/main/res-public/values/public.xml
@@ -6,7 +6,7 @@
     <public name="mapbox_compassEnabled" type="attr" />
 
     <!-- Defines where the compass is positioned on the map -->
-    <public name="mapbox_compassGravity" type="attr" >
+    <public name="mapbox_compassGravity" type="attr" />
 
     <!-- Defines the margin to the left that the compass icon honors. -->
     <public name="mapbox_compassMarginLeft" type="attr" />

--- a/plugin-gestures/build.gradle.kts
+++ b/plugin-gestures/build.gradle.kts
@@ -19,6 +19,11 @@ android {
       isIncludeAndroidResources = true
     }
   }
+
+  sourceSets {
+    // limit amount of exposed library resources
+    getByName("main").res.srcDirs("src/main/res-public")
+  }
 }
 
 dependencies {

--- a/plugin-locationcomponent/build.gradle.kts
+++ b/plugin-locationcomponent/build.gradle.kts
@@ -14,6 +14,11 @@ android {
     targetSdkVersion(AndroidVersions.targetSdkVersion)
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+
+  sourceSets {
+    // limit amount of exposed library resources
+    getByName("main").res.srcDirs("src/main/res-public")
+  }
 }
 
 dependencies {

--- a/plugin-logo/build.gradle.kts
+++ b/plugin-logo/build.gradle.kts
@@ -13,6 +13,11 @@ android {
     targetSdkVersion(AndroidVersions.targetSdkVersion)
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+
+  sourceSets {
+    // limit amount of exposed library resources
+    getByName("main").res.srcDirs("src/main/res-public")
+  }
 }
 
 dependencies {

--- a/plugin-logo/src/main/res-public/values/public.xml
+++ b/plugin-logo/src/main/res-public/values/public.xml
@@ -6,7 +6,7 @@
     <public name="mapbox_logoEnabled" type="attr" />
 
     <!-- Defines where the logo is positioned on the map -->
-    <public name="mapbox_logoGravity" type="attr" >
+    <public name="mapbox_logoGravity" type="attr" />
 
     <!-- Defines the margin to the left that the attribution icon honors. -->
     <public name="mapbox_logoMarginLeft" type="attr" />

--- a/plugin-scalebar/build.gradle.kts
+++ b/plugin-scalebar/build.gradle.kts
@@ -13,6 +13,11 @@ android {
     targetSdkVersion(AndroidVersions.targetSdkVersion)
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+
+  sourceSets {
+    // limit amount of exposed library resources
+    getByName("main").res.srcDirs("src/main/res-public")
+  }
 }
 
 dependencies {

--- a/plugin-scalebar/src/main/res-public/values/public.xml
+++ b/plugin-scalebar/src/main/res-public/values/public.xml
@@ -6,7 +6,7 @@
     <public name="mapbox_scaleBarEnabled" type="attr" />
 
     <!-- Defines where the scale bar is positioned on the map -->
-    <public name="mapbox_scaleBarGravity" type="attr" >
+    <public name="mapbox_scaleBarGravity" type="attr" />
 
     <!-- Defines the margin to the left that the scale bar honors. -->
     <public name="mapbox_scaleBarMarginLeft" type="attr" />

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -35,6 +35,11 @@ android {
       execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
   }
+
+  sourceSets {
+    // limit amount of exposed library resources
+    getByName("main").res.srcDirs("src/main/res-public")
+  }
 }
 
 dependencies {

--- a/sdk/src/main/res-public/values/public.xml
+++ b/sdk/src/main/res-public/values/public.xml
@@ -49,5 +49,5 @@
     <public name="mapbox_cameraPaddingRight" type="attr"/>
 
     <!-- The default style uri to load when no style is set. -->
-    <attr name="mapbox_styleUri" format="string" />
+    <public name="mapbox_styleUri" type="attr" />
 </resources>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fixed an issue that public resource definitions are not generated in public.txt file.</changelog>`.

### Summary of changes

We use public.xml for indicating which attributes are private vs public (more context [here](https://developer.android.com/studio/projects/android-library#PrivateResources)). With using the public.xml configuration, we should be able to find a public.txt file in the resulting aar:

> When building a library, the Android Gradle plugin gets the public resource definitions and extracts them into the public.txt file, which is then packaged inside the AAR file.

This is currently broken since we didn't configure the `src/main/res-public` to the sourceSet.

This PR includes public xml attribute strings from res-public to sourceSet.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->