### PR TITLE
Bump gl-native to v10.0.0-rc.2, introduce addPersistentLayer/isPersistentLayer API.

### DIFF
--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -67,7 +67,7 @@ object Versions {
   const val mapboxGestures = "0.7.0"
   const val mapboxJavaServices = "5.4.1"
   const val mapboxBase = "0.5.0"
-  const val mapboxGlNative = "10.0.0-rc.1"
+  const val mapboxGlNative = "10.0.0-rc.2"
   const val mapboxCommon = "14.0.1"
   const val mapboxAndroidCore = "4.0.2"
   const val mapboxAndroidTelemetry = "7.0.3"

--- a/sdk/src/main/java/com/mapbox/maps/NativeMapImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/NativeMapImpl.kt
@@ -223,6 +223,25 @@ internal class NativeMapImpl(private val map: MapInterface) :
     return map.addStyleCustomLayer(layerId, layerHost, layerPosition)
   }
 
+  override fun addPersistentStyleLayer(
+    properties: Value,
+    layerPosition: LayerPosition?
+  ): Expected<String, None> {
+    return map.addPersistentStyleLayer(properties, layerPosition)
+  }
+
+  override fun addPersistentStyleCustomLayer(
+    layerId: String,
+    layerHost: CustomLayerHost,
+    layerPosition: LayerPosition?
+  ): Expected<String, None> {
+    return map.addPersistentStyleCustomLayer(layerId, layerHost, layerPosition)
+  }
+
+  override fun isStyleLayerPersistent(layerId: String): Expected<String, Boolean> {
+    return map.isStyleLayerPersistent(layerId)
+  }
+
   override fun getResourceOptions(): ResourceOptions {
     return map.resourceOptions
   }

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -614,6 +614,81 @@ class Style internal constructor(
   }
 
   /**
+   * Adds a new [style layer](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layers).
+   *
+   * Note: This is an experimental API and is a subject to change.
+   *
+   * Whenever a new style is being parsed and currently used style has persistent layers,
+   * an engine will try to do following:
+   *   - keep the persistent layer at its relative position
+   *   - keep the source used by a persistent layer
+   *   - keep images added through `addStyleImage` method
+   *
+   * In cases when a new style has the same layer, source or image resource, style's resources would be
+   * used instead and `MapLoadingError` event will be emitted.
+   *
+   * @param properties A map of style layer properties.
+   * @param layerPosition If not empty, the new layer will be positioned according to `layer position` parameters.
+   *
+   * @return A string describing an error if the operation was not successful, or empty otherwise.
+   */
+  @MapboxExperimental
+  override fun addPersistentStyleLayer(
+    properties: Value,
+    layerPosition: LayerPosition?
+  ): Expected<String, None> {
+    return styleManagerRef.call {
+      this.addPersistentStyleLayer(properties, layerPosition)
+    }
+  }
+
+  /**
+   * Adds a new [style custom layer](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layers).
+   *
+   * Note: This is an experimental API and is a subject to change.
+   *
+   * Whenever a new style is being parsed and currently used style has persistent layers,
+   * an engine will try to do following:
+   *   - keep the persistent layer at its relative position
+   *   - keep the source used by a persistent layer
+   *   - keep images added through `addStyleImage` method
+   *
+   * In cases when a new style has the same layer, source or image resource, style's resources would be
+   * used instead and `MapLoadingError` event will be emitted.
+   *
+   * @param layerId A style layer identifier.
+   * @param layerHost The `custom layer host`.
+   * @param layerPosition If not empty, the new layer will be positioned according to `layer position` parameters.
+   *
+   * @return A string describing an error if the operation was not successful, or empty otherwise.
+   */
+  @MapboxExperimental
+  override fun addPersistentStyleCustomLayer(
+    layerId: String,
+    layerHost: CustomLayerHost,
+    layerPosition: LayerPosition?
+  ): Expected<String, None> {
+    return styleManagerRef.call {
+      this.addPersistentStyleCustomLayer(layerId, layerHost, layerPosition)
+    }
+  }
+
+  /**
+   * Checks if a style layer is persistent.
+   *
+   * Note: This is an experimental API and is a subject to change.
+   *
+   * @param layerId A style layer identifier.
+   * @return A string describing an error if the operation was not successful, boolean representing state otherwise.
+   */
+  @MapboxExperimental
+  override fun isStyleLayerPersistent(layerId: String): Expected<String, Boolean> {
+    return styleManagerRef.call {
+      this.isStyleLayerPersistent(layerId)
+    }
+  }
+
+  /**
    * Adds a custom geometry to be used in the style. To add the data, implement the fetchTileFunction callback in the options and call setStyleCustomGeometrySourceTileData()
    *
    * @param sourceId Style source identifier

--- a/sdk/src/test/java/com/mapbox/maps/NativeMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeMapTest.kt
@@ -116,6 +116,31 @@ class NativeMapTest {
   }
 
   @Test
+  fun addPersistentStyleLayer() {
+    val value = mockk<Value>()
+    val layerPosition = LayerPosition(null, null, null)
+    val nativeMap = NativeMapImpl(map)
+    nativeMap.addPersistentStyleLayer(value, layerPosition)
+    verify { map.addPersistentStyleLayer(value, layerPosition) }
+  }
+
+  @Test
+  fun addPersistentStyleCustomLayer() {
+    val value = mockk<CustomLayerHost>()
+    val layerPosition = LayerPosition(null, null, null)
+    val nativeMap = NativeMapImpl(map)
+    nativeMap.addPersistentStyleCustomLayer("foobar", value, layerPosition)
+    verify { map.addPersistentStyleCustomLayer("foobar", value, layerPosition) }
+  }
+
+  @Test
+  fun isStyleLayerPersistent() {
+    val nativeMap = NativeMapImpl(map)
+    nativeMap.isStyleLayerPersistent("foobar")
+    verify { map.isStyleLayerPersistent("foobar") }
+  }
+
+  @Test
   fun removeStyleLayer() {
     val nativeMap = NativeMapImpl(map)
     nativeMap.removeStyleLayer("foobar")

--- a/sdk/src/test/java/com/mapbox/maps/StyleTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleTest.kt
@@ -247,6 +247,28 @@ class StyleTest {
   }
 
   @Test
+  fun addPersistentStyleLayer() {
+    val value = mockk<Value>()
+    val position = mockk<LayerPosition>()
+    style.addPersistentStyleLayer(value, position)
+    verify { nativeMap.addPersistentStyleLayer(value, position) }
+  }
+
+  @Test
+  fun addPersistentStyleCustomLayer() {
+    val layerHost = mockk<CustomLayerHost>()
+    val layerPosition = mockk<LayerPosition>()
+    style.addPersistentStyleCustomLayer("id", layerHost, layerPosition)
+    verify { nativeMap.addPersistentStyleCustomLayer("id", layerHost, layerPosition) }
+  }
+
+  @Test
+  fun isStyleLayerPersistent() {
+    style.isStyleLayerPersistent("id")
+    verify { nativeMap.isStyleLayerPersistent("id") }
+  }
+
+  @Test
   fun setJson() {
     style.styleJSON = "foobar"
     verify { nativeMap.styleJSON = "foobar" }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Bump gl-native to v10.0.0-rc.2; Introduce experimental Style#addPersistentStyleLayer, Style#addPersistentStyleCustomLayer and Style#isStyleLayerPersistent API.</changelog>`.

### Summary of changes

* Bump gl-native to v10.0.0-rc.2
* Introduce experimental Style#addPersistentStyleLayer, Style#addPersistentStyleCustomLayer and Style#isStyleLayerPersistent API.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->