### PR TITLE
Fix memory leak on render destroy

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -19,7 +19,6 @@ import com.mapbox.maps.renderer.MapboxSurfaceHolderRenderer
 import com.mapbox.maps.renderer.MapboxTextureViewRenderer
 import com.mapbox.maps.renderer.OnFpsChangedListener
 import com.mapbox.maps.renderer.egl.EGLCore
-import java.lang.ref.WeakReference
 
 /**
  * A [MapView] provides an embeddable map interface.
@@ -92,7 +91,7 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
     mapController = MapController(
       when (view) {
         is SurfaceView -> MapboxSurfaceHolderRenderer(view.holder)
-        is TextureView -> MapboxTextureViewRenderer(WeakReference(view))
+        is TextureView -> MapboxTextureViewRenderer(view)
         else -> throw IllegalArgumentException("Provided view has to be a texture or a surface.")
       },
       resolvedMapInitOptions

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -256,6 +256,9 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
         }
       }
       destroyCondition.await()
+      if (mapboxRenderer.needDestroy) {
+        destroy()
+      }
     }
   }
 
@@ -346,7 +349,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
   }
 
   @UiThread
-  fun destroy() {
+  internal fun destroy() {
     handlerThread.apply {
       clearMessageQueue()
       stop()

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -28,10 +28,12 @@ internal abstract class MapboxRenderer : MapClient() {
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var pixelReader: PixelReader? = null
 
+  internal var needDestroy = false
+
   @UiThread
-  @CallSuper
-  open fun onDestroy() {
-    // no-op
+  fun onDestroy() {
+    // we destroy and stop thread after surface or texture is destroyed
+    needDestroy = true
   }
 
   @AnyThread

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxSurfaceHolderRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxSurfaceHolderRenderer.kt
@@ -2,21 +2,15 @@ package com.mapbox.maps.renderer
 
 import android.view.SurfaceHolder
 import androidx.annotation.VisibleForTesting
-import java.lang.ref.WeakReference
 
 internal class MapboxSurfaceHolderRenderer : MapboxSurfaceRenderer, SurfaceHolder.Callback {
 
-  private var surfaceHolder: WeakReference<SurfaceHolder>
-
-  constructor(surfaceHolder: SurfaceHolder?) : super() {
-    this.surfaceHolder = WeakReference(surfaceHolder)
-    surfaceHolder?.addCallback(this)
+  constructor(surfaceHolder: SurfaceHolder) : super() {
+    surfaceHolder.addCallback(this)
   }
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-  internal constructor(surfaceHolder: SurfaceHolder?, renderThread: MapboxRenderThread) : super() {
-    this.surfaceHolder = WeakReference(surfaceHolder)
-  }
+  internal constructor(renderThread: MapboxRenderThread) : super(renderThread)
 
   override fun surfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {
     holder?.let {
@@ -30,10 +24,5 @@ internal class MapboxSurfaceHolderRenderer : MapboxSurfaceRenderer, SurfaceHolde
 
   override fun surfaceCreated(holder: SurfaceHolder?) {
     super.surfaceCreated()
-  }
-
-  override fun onDestroy() {
-    super.onDestroy()
-    surfaceHolder.get()?.removeCallback(this)
   }
 }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxSurfaceRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxSurfaceRenderer.kt
@@ -41,9 +41,4 @@ internal open class MapboxSurfaceRenderer : MapboxRenderer {
   fun surfaceCreated() {
     createSurface = true
   }
-
-  override fun onDestroy() {
-    super.onDestroy()
-    renderThread.destroy()
-  }
 }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxTextureViewRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxTextureViewRenderer.kt
@@ -4,27 +4,22 @@ import android.graphics.SurfaceTexture
 import android.view.Surface
 import android.view.TextureView
 import androidx.annotation.VisibleForTesting
-import java.lang.ref.WeakReference
 
 internal class MapboxTextureViewRenderer : MapboxRenderer, TextureView.SurfaceTextureListener {
 
-  private val textureView: WeakReference<TextureView>
-
-  constructor(textureView: WeakReference<TextureView>) {
-    this.textureView = textureView
+  constructor(textureView: TextureView) {
     renderThread = MapboxRenderThread(
       mapboxRenderer = this,
       translucentSurface = true
     )
-    textureView.get()?.let {
+    textureView.let {
       it.isOpaque = false
       it.surfaceTextureListener = this
     }
   }
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-  internal constructor(textureView: WeakReference<TextureView>, renderThread: MapboxRenderThread) {
-    this.textureView = textureView
+  internal constructor(renderThread: MapboxRenderThread) {
     this.renderThread = renderThread
   }
 
@@ -38,6 +33,7 @@ internal class MapboxTextureViewRenderer : MapboxRenderer, TextureView.SurfaceTe
 
   override fun onSurfaceTextureDestroyed(surface: SurfaceTexture?): Boolean {
     renderThread.onSurfaceDestroyed()
+    surface?.release()
     return true
   }
 
@@ -47,11 +43,5 @@ internal class MapboxTextureViewRenderer : MapboxRenderer, TextureView.SurfaceTe
       width = width,
       height = height
     )
-  }
-
-  override fun onDestroy() {
-    super.onDestroy()
-    textureView.get()?.surfaceTextureListener = null
-    renderThread.destroy()
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -14,6 +14,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -172,5 +173,11 @@ internal abstract class MapboxRendererTest {
     mapboxRenderer.snapshot(callback)
     Shadows.shadowOf(handlerThread.looper).idle()
     Shadows.shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  fun onDestroyTest() {
+    mapboxRenderer.onDestroy()
+    Assert.assertEquals(true, mapboxRenderer.needDestroy)
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxSurfaceHolderRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxSurfaceHolderRendererTest.kt
@@ -1,0 +1,43 @@
+package com.mapbox.maps.renderer
+
+import android.view.SurfaceHolder
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+internal class MapboxSurfaceHolderRendererTest : MapboxRendererTest() {
+
+  private lateinit var surfaceHolderRenderer: MapboxSurfaceHolderRenderer
+  private lateinit var surfaceHolder: SurfaceHolder
+
+  @Before
+  override fun setUp() {
+    super.setUp()
+    surfaceHolder = mockk(relaxed = true)
+    mapboxRenderer = MapboxSurfaceHolderRenderer(renderThread)
+    surfaceHolderRenderer = MapboxSurfaceHolderRenderer(renderThread)
+  }
+
+  @Test
+  fun surfaceChangedTest() {
+    surfaceHolderRenderer.surfaceChanged(surfaceHolder, 0, 1, 1)
+    verify { renderThread.onSurfaceSizeChanged(1, 1) }
+  }
+
+  @Test
+  fun surfaceCreatedTest() {
+    surfaceHolderRenderer.surfaceCreated(surfaceHolder)
+    surfaceHolderRenderer.surfaceChanged(surfaceHolder, 0, 1, 1)
+    verify {
+      renderThread.onSurfaceCreated(surfaceHolder.surface, 1, 1)
+      renderThread.onSurfaceSizeChanged(1, 1)
+    }
+  }
+
+  @Test
+  fun surfaceDestroyedTest() {
+    surfaceHolderRenderer.surfaceDestroyed(surfaceHolder)
+    verify { renderThread.onSurfaceDestroyed() }
+  }
+}

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxSurfaceRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxSurfaceRendererTest.kt
@@ -40,10 +40,4 @@ internal class MapboxSurfaceRendererTest : MapboxRendererTest() {
     surfaceRenderer.surfaceDestroyed()
     verify { renderThread.onSurfaceDestroyed() }
   }
-
-  @Test
-  fun onDestroyTest() {
-    surfaceRenderer.onDestroy()
-    verify { renderThread.destroy() }
-  }
 }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxTextureViewRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxTextureViewRendererTest.kt
@@ -1,11 +1,10 @@
 package com.mapbox.maps.renderer
 
-import android.view.TextureView
+import android.graphics.SurfaceTexture
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
-import java.lang.ref.WeakReference
 
 internal class MapboxTextureViewRendererTest : MapboxRendererTest() {
 
@@ -14,9 +13,8 @@ internal class MapboxTextureViewRendererTest : MapboxRendererTest() {
   @Before
   override fun setUp() {
     super.setUp()
-    val weakView = WeakReference(mockk<TextureView>(relaxed = true))
-    mapboxRenderer = MapboxTextureViewRenderer(weakView, renderThread)
-    textureViewRenderer = MapboxTextureViewRenderer(weakView, renderThread)
+    mapboxRenderer = MapboxTextureViewRenderer(renderThread)
+    textureViewRenderer = MapboxTextureViewRenderer(renderThread)
   }
 
   @Test
@@ -32,13 +30,9 @@ internal class MapboxTextureViewRendererTest : MapboxRendererTest() {
 
   @Test
   fun onSurfaceTextureDestroyedTest() {
-    textureViewRenderer.onSurfaceTextureDestroyed(mockk())
+    val surfaceTexture = mockk<SurfaceTexture>(relaxUnitFun = true)
+    textureViewRenderer.onSurfaceTextureDestroyed(surfaceTexture)
     verify { renderThread.onSurfaceDestroyed() }
-  }
-
-  @Test
-  fun onDestroyTest() {
-    textureViewRenderer.onDestroy()
-    verify { renderThread.destroy() }
+    verify { surfaceTexture.release() }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #420 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix memory leak on render destroy.</changelog>`.

### Summary of changes

This PR fixes memory leak for texture view renderer. It also improves overall render thread management - in some situations some essential code was not executed before killing render thread.
Additionally tests were added for `MapboxSurfaceHolderRenderer`.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### Visuals

After fix, surface view:

![image](https://user-images.githubusercontent.com/15800566/122063702-2c606e00-cdf9-11eb-89e7-c70945c31786.png)

After fix, texture view:

![image](https://user-images.githubusercontent.com/15800566/122063903-56199500-cdf9-11eb-8633-d20cedc3247d.png)


<!--
If this PR introduces user-facing changes, please note them here.
-->