### PR TITLE
Add activity showcasing style cross fading

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -985,5 +985,17 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ExampleOverviewActivity" />
         </activity>
+        <activity
+            android:name=".examples.StyleCrossFadeAnimationActivity"
+            android:description="@string/description_style_cross_fade"
+            android:exported="true"
+            android:label="@string/activity_style_crossfade">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_lab" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".ExampleOverviewActivity" />
+        </activity>
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -992,7 +992,7 @@
             android:label="@string/activity_style_crossfade">
             <meta-data
                 android:name="@string/category"
-                android:value="@string/category_lab" />
+                android:value="@string/category_styles" />
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ExampleOverviewActivity" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -992,7 +992,7 @@
             android:label="@string/activity_style_crossfade">
             <meta-data
                 android:name="@string/category"
-                android:value="@string/category_styles" />
+                android:value="@string/category_lab" />
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ExampleOverviewActivity" />

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/StyleCrossFadeAnimationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/StyleCrossFadeAnimationActivity.kt
@@ -28,8 +28,8 @@ class StyleCrossFadeAnimationActivity : AppCompatActivity() {
         .pitch(PITCH)
         .build()
     )
+    styleSwitcher = StyleSwitcher(mapView.getMapboxMap())
     mapView.getMapboxMap().loadStyleUri(currentStyleURI) {
-      styleSwitcher = StyleSwitcher(mapView.getMapboxMap(), it)
       switchStyleButton.visibility = View.VISIBLE
       switchStyleButton.setOnClickListener {
         crossFadeSwitchStyle()
@@ -81,6 +81,6 @@ class StyleCrossFadeAnimationActivity : AppCompatActivity() {
     private const val LONGITUDE = 11.582
     private const val ZOOM = 13.0
     private const val PITCH = 60.0
-    private const val STYLE_TRANSITION_DELAY_MS = 300L
+    private const val STYLE_TRANSITION_DELAY_MS = 400L
   }
 }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/StyleCrossFadeAnimationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/StyleCrossFadeAnimationActivity.kt
@@ -1,0 +1,173 @@
+package com.mapbox.maps.testapp.examples
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.bindgen.Value
+import com.mapbox.geojson.Point
+import com.mapbox.maps.*
+import com.mapbox.maps.testapp.R
+import kotlinx.android.synthetic.main.activity_style_cross_fade.*
+
+/**
+ * Example of cross fading animation when changing between styles.
+ */
+class StyleCrossFadeAnimationActivity : AppCompatActivity() {
+
+  private lateinit var currentStyle: Style
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val originalProperties = mutableMapOf<Pair<String, String>, Value>()
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_style_cross_fade)
+    switchStyleButton.visibility = View.GONE
+    mapView.getMapboxMap().setCamera(
+      CameraOptions.Builder()
+        .center(Point.fromLngLat(LONGITUDE, LATITUDE))
+        .zoom(ZOOM)
+        .pitch(PITCH)
+        .build()
+    )
+    mapView.getMapboxMap().loadStyleUri(Style.MAPBOX_STREETS) {
+      currentStyle = it
+      switchStyleButton.visibility = View.VISIBLE
+      mapView.getMapboxMap().subscribe(
+        object : Observer() {
+          override fun notify(event: Event) {
+            when (event.type) {
+              // make newly loaded layers 'invisible' when new style is loaded
+              MapEvents.STYLE_LOADED -> {
+                for (layer in currentStyle.styleLayers) {
+                  if (layer.id.contains("road-") ||
+                    layer.id.contains("landuse") ||
+                    layer.id.contains("bridge-")
+                  ) {
+                    val property =
+                      currentStyle.getStyleLayerProperty(layer.id, layer.type + "-color")
+                    if (property.value != Value.nullValue()) {
+                      originalProperties[Pair(layer.id, layer.type)] = property.value
+                      currentStyle.setStyleLayerProperty(
+                        layer.id,
+                        layer.type + "-color-transition",
+                        Value(hashMapOf("duration" to Value(0), "delay" to Value(0)))
+                      )
+                      currentStyle.setStyleLayerProperty(
+                        layer.id,
+                        layer.type + "-color",
+                        Value(
+                          arrayListOf(
+                            Value("rgba"),
+                            Value(0.0), Value(0.0), Value(0.0), Value(0.0)
+                          )
+                        )
+                      )
+                    }
+                  }
+                }
+              }
+              // when map loaded, fade-in layers using original values
+              MapEvents.MAP_LOADED -> {
+                for (originalProperty in originalProperties) {
+                  currentStyle.setStyleLayerProperty(
+                    originalProperty.key.first,
+                    originalProperty.key.second + "-color-transition",
+                    Value(
+                      hashMapOf(
+                        "duration" to Value(STYLE_TRANSITION_DELAY_MS),
+                        "delay" to Value(0)
+                      )
+                    )
+                  )
+                  currentStyle.setStyleLayerProperty(
+                    originalProperty.key.first,
+                    originalProperty.key.second + "-color",
+                    originalProperty.value
+                  )
+                }
+                originalProperties.clear()
+              }
+            }
+          }
+        },
+        listOf(MapEvents.STYLE_LOADED, MapEvents.MAP_LOADED)
+      )
+      switchStyleButton.setOnClickListener {
+        crossFadeSwitchStyle()
+      }
+    }
+  }
+
+  private fun crossFadeSwitchStyle() {
+    switchStyleButton.isEnabled = false
+    val newStyleUri = if (currentStyle.styleURI == Style.MAPBOX_STREETS) {
+      Style.DARK
+    } else {
+      Style.MAPBOX_STREETS
+    }
+    // fade-out flickering layers while new style is loaded
+    for (layer in currentStyle.styleLayers) {
+      if (layer.id.contains("road-") ||
+        layer.id.contains("landuse") ||
+        layer.id.contains("bridge-")
+      ) {
+        currentStyle.setStyleLayerProperty(
+          layer.id,
+          layer.type + "-color-transition",
+          Value(hashMapOf("duration" to Value(STYLE_FADE_OUT_DURATION_MS), "delay" to Value(0)))
+        )
+        currentStyle.setStyleLayerProperty(
+          layer.id,
+          layer.type + "-color",
+          Value(
+            arrayListOf(
+              Value("rgba"),
+              Value(0.0), Value(0.0), Value(0.0), Value(0.0)
+            )
+          )
+        )
+      }
+    }
+    mainHandler.postDelayed(
+      {
+        mapView.getMapboxMap().loadStyleUri(newStyleUri) {
+          currentStyle = it
+          switchStyleButton.isEnabled = true
+        }
+      },
+      STYLE_TRANSITION_DELAY_MS
+    )
+  }
+
+  override fun onStart() {
+    super.onStart()
+    mapView.onStart()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView.onStop()
+  }
+
+  override fun onLowMemory() {
+    super.onLowMemory()
+    mapView.onLowMemory()
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    mapView.onDestroy()
+  }
+
+  companion object {
+    private const val LATITUDE = 55.7558
+    private const val LONGITUDE = 37.6173
+    private const val ZOOM = 14.0
+    private const val PITCH = 60.0
+
+    private const val STYLE_TRANSITION_DELAY_MS = 300L
+    private const val STYLE_FADE_OUT_DURATION_MS = (STYLE_TRANSITION_DELAY_MS / 1.5).toLong()
+  }
+}

--- a/app/src/main/java/com/mapbox/maps/testapp/utils/StyleSwitcher.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/utils/StyleSwitcher.kt
@@ -1,0 +1,119 @@
+package com.mapbox.maps.testapp.utils
+
+import android.os.Handler
+import android.os.Looper
+import com.mapbox.bindgen.Value
+import com.mapbox.maps.*
+
+class StyleSwitcher(
+  val mapboxMap: MapboxMap,
+  initialStyle: Style
+) {
+  private lateinit var currentStyle: Style
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val originalProperties = mutableMapOf<Pair<String, String>, Value>()
+  private var styleTransitionDelayMs: Long = 0
+  private var onStyleSwitched: ((Style) -> Unit)? = null
+
+  init {
+    mapboxMap.subscribe(
+      object : Observer() {
+        override fun notify(event: Event) {
+          when (event.type) {
+            // when map loaded, fade-in layers using original values
+            MapEvents.MAP_LOADED -> {
+              for (originalProperty in originalProperties) {
+                currentStyle.setStyleLayerProperty(
+                  originalProperty.key.first,
+                  originalProperty.key.second + "-color-transition",
+                  Value(
+                    hashMapOf(
+                      "duration" to Value(styleTransitionDelayMs),
+                      "delay" to Value(0)
+                    )
+                  )
+                )
+                currentStyle.setStyleLayerProperty(
+                  originalProperty.key.first,
+                  originalProperty.key.second + "-color",
+                  originalProperty.value
+                )
+              }
+              originalProperties.clear()
+              onStyleSwitched?.invoke(currentStyle)
+            }
+          }
+        }
+      },
+      listOf(MapEvents.MAP_LOADED)
+    )
+    currentStyle = initialStyle
+  }
+
+  fun switchStyle(
+    newStyleUri: String,
+    styleTransitionDelayMs: Long,
+    flickeringLayers: List<String> = listOf(),
+    onStyleSwitched: ((Style) -> Unit)? = null
+  ) {
+    this.onStyleSwitched = onStyleSwitched
+    this.styleTransitionDelayMs = styleTransitionDelayMs
+    // fade-out flickering layers while new style is loaded
+    for (layer in currentStyle.styleLayers) {
+      for (flickeringLayer in flickeringLayers) {
+        if (layer.id.contains(flickeringLayer)) {
+          currentStyle.setStyleLayerProperty(
+            layer.id,
+            layer.type + "-color-transition",
+            Value(hashMapOf("duration" to Value(0), "delay" to Value(0)))
+          )
+          currentStyle.setStyleLayerProperty(
+            layer.id,
+            layer.type + "-color",
+            Value(
+              arrayListOf(
+                Value("rgba"),
+                Value(0.0), Value(0.0), Value(0.0), Value(0.0)
+              )
+            )
+          )
+        }
+      }
+    }
+    mainHandler.postDelayed(
+      {
+        mapboxMap.loadStyleUri(newStyleUri) {
+          currentStyle = it
+          // make newly loaded layers 'invisible' when new style is loaded
+          for (layer in currentStyle.styleLayers) {
+            for (flickeringLayer in flickeringLayers) {
+              if (layer.id.contains(flickeringLayer)) {
+                val property =
+                  currentStyle.getStyleLayerProperty(layer.id, layer.type + "-color")
+                if (property.value != Value.nullValue()) {
+                  originalProperties[Pair(layer.id, layer.type)] = property.value
+                  currentStyle.setStyleLayerProperty(
+                    layer.id,
+                    layer.type + "-color-transition",
+                    Value(hashMapOf("duration" to Value(0), "delay" to Value(0)))
+                  )
+                  currentStyle.setStyleLayerProperty(
+                    layer.id,
+                    layer.type + "-color",
+                    Value(
+                      arrayListOf(
+                        Value("rgba"),
+                        Value(0.0), Value(0.0), Value(0.0), Value(0.0)
+                      )
+                    )
+                  )
+                }
+              }
+            }
+          }
+        }
+      },
+      styleTransitionDelayMs
+    )
+  }
+}

--- a/app/src/main/res/layout/activity_style_cross_fade.xml
+++ b/app/src/main/res/layout/activity_style_cross_fade.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/switchStyleButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:gravity="center"
+        android:padding="15dp"
+        android:text="@string/switch_style_button"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/example_descriptions.xml
+++ b/app/src/main/res/values/example_descriptions.xml
@@ -77,4 +77,5 @@
     <string name="description_map_view_customization">Customize your map view</string>
     <string name="description_ornaments_margin">Update margins of ornaments when the map rotates</string>
     <string name="description_large_geojson">Display long route as large geojson</string>
+    <string name="description_style_cross_fade">Smooth animation when switching style</string>
 </resources>

--- a/app/src/main/res/values/example_titles.xml
+++ b/app/src/main/res/values/example_titles.xml
@@ -77,4 +77,5 @@
     <string name="activity_map_view_customization">Creating a map view</string>
     <string name="activity_ornaments">Ornaments</string>
     <string name="activity_large_geojson">Geojson performance</string>
+    <string name="activity_style_crossfade">Cross fade style switch</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,4 +111,6 @@
     <string name="toggle_stencil_clip">Stencil Clip</string>
     <string name="toggle_depth_buffer">Depth Buffer</string>
 
+    <string name="switch_style_button">Switch style</string>
+
 </resources>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Add activity showcasing style cross fading.</changelog>`.

### Summary of changes

Add activity showcasing style cross fading. 
For easier use added utility class of `StyleSwitcher` to `:app` module (not part of SDK itself).

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

Before:

https://user-images.githubusercontent.com/15800566/122414411-cce89680-cf8f-11eb-8a30-92e934b135b8.mp4

After:

https://user-images.githubusercontent.com/15800566/122414084-8c891880-cf8f-11eb-9cc4-332d1ff9101e.mp4



<!--
If this PR introduces user-facing changes, please note them here.
-->