### PR TITLE
[build] Publish snapshot when the commit message contains publish_android_snapshot keyword.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,23 @@ commands:
                     make sdkRegistryUpload
                   fi
 
+  publish-sdk-registry-named-snapshot:
+    steps:
+      - unless:
+          condition: << pipeline.parameters.mapbox_upstream >>
+          steps:
+            - run:
+                name: Publish the SDK snapshot based on the keyword in commit message
+                command: |
+                  COMMIT_SHA=$(git rev-parse --short HEAD)
+                  LAST_RELEASE=$(git describe --tags --abbrev=0)
+                  if [[ -n ${CIRCLE_BRANCH+x} ]] && [[ $CIRCLE_BRANCH != "main" ]] && [[ "$(git log -1)" = *"publish_android_snapshot"* ]]; then
+                    sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${LAST_RELEASE:9}-${CIRCLE_BRANCH}-SNAPSHOT/" gradle.properties
+                    curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci
+                    ./mbx-ci aws setup
+                    make sdkRegistryUpload
+                  fi
+
   login-google-cloud-platform:
     steps:
       - run:
@@ -419,4 +436,5 @@ jobs:
       - update-version-name
       - track-metrics
       - publish-sdk-registry
+      - publish-sdk-registry-named-snapshot
       - generate-docs


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

If a last commit in a branch has `publish_android_snapshot` in a title or description, `build-sdk-release` bot will create a snapshot release. The name of the snapshot release would be:

${LAST_RELEASE_VERSION_BEFORE_THIS_COMMIT}-${BRANCH_NAME}-SNAPSHOT for example:

10.0.0-rc.1-peng-commit-message-based-snapshot-SNAPSHOT

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->