### PR TITLE
Fix camera deadlock use-case

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/HighLevelAnimatorSet.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/HighLevelAnimatorSet.kt
@@ -7,6 +7,8 @@ internal data class HighLevelAnimatorSet(
   val animatorSet: AnimatorSet
 ) : Cancelable {
 
+  var started = false
+
   override fun cancel() {
     animatorSet.cancel()
   }

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
@@ -42,6 +42,7 @@ abstract class CameraAnimator<out T> (
   private val userUpdateListeners = mutableListOf<AnimatorUpdateListener?>()
   private val userListeners = mutableListOf<AnimatorListener?>()
 
+  internal var canceled = false
   internal var isInternal = false
 
   init {
@@ -158,6 +159,18 @@ abstract class CameraAnimator<out T> (
       super.addListener(internalListener)
     }
     userListeners.clear()
+  }
+
+  /**
+   * Cancels the animation. Unlike end(), cancel() causes the animation to stop in its tracks,
+   * sending an Animator.AnimatorListener.onAnimationCancel(Animator) to its listeners,
+   * followed by an Animator.AnimatorListener.onAnimationEnd(Animator) message.
+   *
+   * This method must be called on the thread that is running the animation.
+   */
+  final override fun cancel() {
+    canceled = true
+    super.cancel()
   }
 
   internal fun addInternalUpdateListener(listener: AnimatorUpdateListener) {

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
@@ -78,6 +78,7 @@ abstract class CameraAnimator<out T> (
    */
   final override fun start() {
     if (registered) {
+      canceled = false
       super.start()
     } else {
       Logger.w(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #164 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix camera deadlock use-case.</changelog>`.

### Summary of changes

When canceling animators manually inside `CameraAnimationsLifecycleListener.onAnimatorStarting` (typical Nav SDK use-case) before starting high-level animation (e.g. `easeTo`) - callbacks for high-level animation listener would be called incorrectly while camera itself would be completely stuck. That happens in concrete scenario when animator with delay was not started before canceling it.

This PR fixes it.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->