### PR TITLE
Coalesce to the default language if not supported

### DIFF
--- a/extension-localization/src/main/java/com/mapbox/maps/extension/localization/Localization.kt
+++ b/extension-localization/src/main/java/com/mapbox/maps/extension/localization/Localization.kt
@@ -78,5 +78,5 @@ private const val LAYER_TYPE_SYMBOL = "symbol"
 private const val STREET_V7 = "mapbox.mapbox-streets-v7"
 private const val STREET_V8 = "mapbox.mapbox-streets-v8"
 private val SUPPORTED_SOURCES = listOf(STREET_V7, STREET_V8)
-private val EXPRESSION_REGEX = Regex("\\[\"get\",\\s*\"(name|name_.{2,7})\"\\]")
+private val EXPRESSION_REGEX = Regex("\\[\"get\",\\s*\"(name_.{2,7})\"\\]")
 private val EXPRESSION_ABBR_REGEX = Regex("\\[\"get\",\\s*\"abbr\"\\]")

--- a/extension-localization/src/main/java/com/mapbox/maps/extension/localization/SupportedLanguages.kt
+++ b/extension-localization/src/main/java/com/mapbox/maps/extension/localization/SupportedLanguages.kt
@@ -125,7 +125,7 @@ internal fun getLanguageNameV7(locale: Locale): String {
     return if (locale == Locale.SIMPLIFIED_CHINESE || locale.script == "Hans") NAME_ZH_HANS
     else NAME_ZH
   }
-  "name_${locale.language}".apply { return if (supportedV7.contains(this)) this else NAME }
+  return "name_${locale.language}"
 }
 
 /**
@@ -136,5 +136,5 @@ internal fun getLanguageNameV8(locale: Locale): String {
     return if (locale == Locale.TAIWAN || locale.script == "Hant") NAME_ZH_HANT
     else NAME_ZH_HANS
   }
-  "name_${locale.language}".apply { return if (supportedV8.contains(this)) this else NAME }
+  return "name_${locale.language}"
 }

--- a/extension-localization/src/main/java/com/mapbox/maps/extension/localization/SupportedLanguages.kt
+++ b/extension-localization/src/main/java/com/mapbox/maps/extension/localization/SupportedLanguages.kt
@@ -1,5 +1,6 @@
 package com.mapbox.maps.extension.localization
 
+import com.mapbox.common.Logger
 import java.util.*
 
 /**
@@ -117,6 +118,8 @@ private val supportedV8 =
     NAME_VI
   )
 
+private const val TAG = "Localization"
+
 /**
  * Get the language name for v7, fallback to [NAME] if not supported.
  */
@@ -125,7 +128,11 @@ internal fun getLanguageNameV7(locale: Locale): String {
     return if (locale == Locale.SIMPLIFIED_CHINESE || locale.script == "Hans") NAME_ZH_HANS
     else NAME_ZH
   }
-  return "name_${locale.language}"
+  return "name_${locale.language}".apply {
+    if (!supportedV7.contains(this)) {
+      Logger.w(TAG, "Language ${locale.displayLanguage} is not supported in the current style")
+    }
+  }
 }
 
 /**
@@ -136,5 +143,9 @@ internal fun getLanguageNameV8(locale: Locale): String {
     return if (locale == Locale.TAIWAN || locale.script == "Hant") NAME_ZH_HANT
     else NAME_ZH_HANS
   }
-  return "name_${locale.language}"
+  return "name_${locale.language}".apply {
+    if (!supportedV8.contains(this)) {
+      Logger.w(TAG, "Language ${locale.displayLanguage} is not supported in the current style")
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes
We replaced all the `get` expression with selected language and for those with expression `coalesce` and only have a default language it will not show the default language.
This pr will make the replacement not applied on such expression like `get("name")` to show the default language. 
However, users might pass in a not supported language, then we will output a warning logcat.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->