### PR TITLE
[style] Optimise the style#getLayer and style#getSource APIs.

### DIFF
--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/Layer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/Layer.kt
@@ -10,6 +10,7 @@ import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.layers.generated.*
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.extension.style.utils.unwrap
 
 /**
@@ -182,14 +183,15 @@ abstract class Layer : StyleContract.StyleLayerExtension {
  * @return StyleLayerPlugin
  */
 fun StyleManagerInterface.getLayer(layerId: String): Layer? {
-  val expected = this.getStyleLayerProperties(layerId)
-  expected.value?.let { value ->
-    @Suppress("UNCHECKED_CAST")
-    val map = value.contents as HashMap<String, Value>
-    val source = map["source"]?.contents?.let { it as String }
-    val type = map["type"]?.contents?.let { it as String }
-    return when (type) {
+  val source =
+    if (layerId != "background" && layerId != "location-indicator" && layerId != "sky") {
+      this.getStyleLayerProperty(layerId, "source").silentUnwrap<String>()
+    } else null
+  return this.getStyleLayerProperty(layerId, "type").silentUnwrap<String>()?.let { type ->
+    when (type) {
       "background" -> BackgroundLayer(layerId).also { it.delegate = this }
+      "location-indicator" -> LocationIndicatorLayer(layerId).also { it.delegate = this }
+      "sky" -> SkyLayer(layerId).also { it.delegate = this }
       "circle" -> CircleLayer(layerId, source!!).also { it.delegate = this }
       "fill-extrusion" -> FillExtrusionLayer(layerId, source!!).also { it.delegate = this }
       "fill" -> FillLayer(layerId, source!!).also { it.delegate = this }
@@ -198,18 +200,12 @@ fun StyleManagerInterface.getLayer(layerId: String): Layer? {
       "line" -> LineLayer(layerId, source!!).also { it.delegate = this }
       "raster" -> RasterLayer(layerId, source!!).also { it.delegate = this }
       "symbol" -> SymbolLayer(layerId, source!!).also { it.delegate = this }
-      "location-indicator" -> LocationIndicatorLayer(layerId).also { it.delegate = this }
-      "sky" -> SkyLayer(layerId).also { it.delegate = this }
       else -> {
         Logger.e("StyleLayerPlugin", "Layer type: $type unknown.")
         null
       }
     }
   }
-  expected.error?.let {
-    Logger.e("StyleLayerPlugin", "Get layer $layerId failed: $it")
-  }
-  return null
 }
 
 /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/Layer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/Layer.kt
@@ -183,23 +183,19 @@ abstract class Layer : StyleContract.StyleLayerExtension {
  * @return StyleLayerPlugin
  */
 fun StyleManagerInterface.getLayer(layerId: String): Layer? {
-  val source =
-    if (layerId != "background" && layerId != "location-indicator" && layerId != "sky") {
-      this.getStyleLayerProperty(layerId, "source").silentUnwrap<String>()
-    } else null
   return this.getStyleLayerProperty(layerId, "type").silentUnwrap<String>()?.let { type ->
     when (type) {
       "background" -> BackgroundLayer(layerId).also { it.delegate = this }
       "location-indicator" -> LocationIndicatorLayer(layerId).also { it.delegate = this }
       "sky" -> SkyLayer(layerId).also { it.delegate = this }
-      "circle" -> CircleLayer(layerId, source!!).also { it.delegate = this }
-      "fill-extrusion" -> FillExtrusionLayer(layerId, source!!).also { it.delegate = this }
-      "fill" -> FillLayer(layerId, source!!).also { it.delegate = this }
-      "heatmap" -> HeatmapLayer(layerId, source!!).also { it.delegate = this }
-      "hillshade" -> HillshadeLayer(layerId, source!!).also { it.delegate = this }
-      "line" -> LineLayer(layerId, source!!).also { it.delegate = this }
-      "raster" -> RasterLayer(layerId, source!!).also { it.delegate = this }
-      "symbol" -> SymbolLayer(layerId, source!!).also { it.delegate = this }
+      "circle" -> CircleLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
+      "fill-extrusion" -> FillExtrusionLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
+      "fill" -> FillLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
+      "heatmap" -> HeatmapLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
+      "hillshade" -> HillshadeLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
+      "line" -> LineLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
+      "raster" -> RasterLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
+      "symbol" -> SymbolLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
       else -> {
         Logger.e("StyleLayerPlugin", "Layer type: $type unknown.")
         null

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/Source.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/Source.kt
@@ -8,6 +8,7 @@ import com.mapbox.maps.extension.style.StyleContract
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.sources.generated.*
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.extension.style.utils.unwrap
 
 /**
@@ -146,11 +147,8 @@ abstract class Source(
  * @return StyleSourcePlugin
  */
 fun StyleManagerInterface.getSource(sourceId: String): Source? {
-  val expected = this.getStyleSourceProperties(sourceId)
-  expected.value?.let { value ->
-    @Suppress("UNCHECKED_CAST")
-    val map = value.contents as HashMap<String, Value>
-    return when (val type = map["type"]?.contents?.let { it as String }) {
+  return this.getStyleSourceProperty(sourceId, "type").silentUnwrap<String>()?.let { type ->
+    when (type) {
       "vector" -> VectorSource.Builder(sourceId).build().also { it.delegate = this }
       "geojson" -> GeoJsonSource.Builder(sourceId) {}.build().also { it.delegate = this }
       "image" -> ImageSource.Builder(sourceId).build().also { it.delegate = this }
@@ -162,10 +160,6 @@ fun StyleManagerInterface.getSource(sourceId: String): Source? {
       }
     }
   }
-  expected.error?.let {
-    Logger.e("StyleSourcePlugin", "Get source $sourceId failed: $it")
-  }
-  return null
 }
 
 /**

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayerTest.kt
@@ -443,12 +443,10 @@ class BackgroundLayerTest {
 
   @Test
   fun getBackgroundLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("background")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("background"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as BackgroundLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/CircleLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/CircleLayerTest.kt
@@ -1393,13 +1393,14 @@ class CircleLayerTest {
 
   @Test
   fun getCircleLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("circle")
-    value["source"] = Value("source")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "source") } returns StylePropertyValue(
+      Value("source"),
+      StylePropertyValueKind.CONSTANT
+    )
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("circle"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as CircleLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayerTest.kt
@@ -1001,13 +1001,14 @@ class FillExtrusionLayerTest {
 
   @Test
   fun getFillExtrusionLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("fill-extrusion")
-    value["source"] = Value("source")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "source") } returns StylePropertyValue(
+      Value("source"),
+      StylePropertyValueKind.CONSTANT
+    )
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("fill-extrusion"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as FillExtrusionLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillLayerTest.kt
@@ -1003,13 +1003,14 @@ class FillLayerTest {
 
   @Test
   fun getFillLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("fill")
-    value["source"] = Value("source")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "source") } returns StylePropertyValue(
+      Value("source"),
+      StylePropertyValueKind.CONSTANT
+    )
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("fill"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as FillLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/HeatmapLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/HeatmapLayerTest.kt
@@ -655,13 +655,14 @@ class HeatmapLayerTest {
 
   @Test
   fun getHeatmapLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("heatmap")
-    value["source"] = Value("source")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "source") } returns StylePropertyValue(
+      Value("source"),
+      StylePropertyValueKind.CONSTANT
+    )
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("heatmap"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as HeatmapLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/HillshadeLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/HillshadeLayerTest.kt
@@ -839,13 +839,14 @@ class HillshadeLayerTest {
 
   @Test
   fun getHillshadeLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("hillshade")
-    value["source"] = Value("source")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "source") } returns StylePropertyValue(
+      Value("source"),
+      StylePropertyValueKind.CONSTANT
+    )
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("hillshade"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as HillshadeLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LineLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LineLayerTest.kt
@@ -1677,13 +1677,14 @@ class LineLayerTest {
 
   @Test
   fun getLineLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("line")
-    value["source"] = Value("source")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "source") } returns StylePropertyValue(
+      Value("source"),
+      StylePropertyValueKind.CONSTANT
+    )
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("line"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as LineLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayerTest.kt
@@ -1569,12 +1569,10 @@ class LocationIndicatorLayerTest {
 
   @Test
   fun getLocationIndicatorLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("location-indicator")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("location-indicator"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as LocationIndicatorLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/RasterLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/RasterLayerTest.kt
@@ -926,13 +926,14 @@ class RasterLayerTest {
 
   @Test
   fun getRasterLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("raster")
-    value["source"] = Value("source")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "source") } returns StylePropertyValue(
+      Value("source"),
+      StylePropertyValueKind.CONSTANT
+    )
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("raster"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as RasterLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/SkyLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/SkyLayerTest.kt
@@ -860,12 +860,10 @@ class SkyLayerTest {
 
   @Test
   fun getSkyLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("sky")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("sky"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as SkyLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/SymbolLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/SymbolLayerTest.kt
@@ -4681,13 +4681,14 @@ class SymbolLayerTest {
 
   @Test
   fun getSymbolLayerTest() {
-    val value = HashMap<String, Value>()
-    value["id"] = Value("id")
-    value["type"] = Value("symbol")
-    value["source"] = Value("source")
-    every { style.getStyleLayerProperties("id") } returns valueExpected
-    every { valueExpected.error } returns null
-    every { valueExpected.value } returns Value(value)
+    every { style.getStyleLayerProperty("id", "source") } returns StylePropertyValue(
+      Value("source"),
+      StylePropertyValueKind.CONSTANT
+    )
+    every { style.getStyleLayerProperty("id", "type") } returns StylePropertyValue(
+      Value("symbol"),
+      StylePropertyValueKind.CONSTANT
+    )
     val layer = style.getLayer("id") as SymbolLayer
     assertNotNull(layer)
     assertNotNull(layer.delegate)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Refs: #364 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Optimise the style#getLayer and style#getSource APIs' performance.</changelog>`.

### Summary of changes

Optimise the `style#getLayer` and `style#getSource` APIs' performance by avoid using the heavy `style#getStyleLayerProperties` and `style#getStyleSourceProperties` API.

### User impact (optional)

The initial benchmarking showed the CPU utilisation improvement as follows when the getLayer is used frequently, for example, inside the camera animator:

Before(`getLayer` takes 12.1% CPU time, `getStyleLayerProperties` takes 8.7% CPU time):
<img width="1242" alt="Screenshot 2021-06-24 at 19 10 25" src="https://user-images.githubusercontent.com/2764714/123297110-f1101e80-d51f-11eb-9907-fcdf562590d3.png">

After(`getLayer` takes 5.47% cpu time, `getStyleLayerProperty` takes 2.14% CPU time):
<img width="1242" alt="Screenshot 2021-06-24 at 18 55 52" src="https://user-images.githubusercontent.com/2764714/123297117-f3727880-d51f-11eb-825b-2b06bf8c4c7f.png">
