### PR TITLE
Introduce option to use continuous rendering for scale bar

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/scalebar/generated/ScaleBarAttributeParserDefaultValueTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/scalebar/generated/ScaleBarAttributeParserDefaultValueTest.kt
@@ -113,6 +113,11 @@ class ScaleBarAttributeParserDefaultValueTest : BaseMapTest() {
       0.5f,
       mapView.scalebar.getSettings().ratio
     )
+    assertEquals(
+      "useContinuousRendering test failed..",
+      false,
+      mapView.scalebar.getSettings().useContinuousRendering
+    )
   }
 }
 

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/scalebar/generated/ScaleBarAttributeParserTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/scalebar/generated/ScaleBarAttributeParserTest.kt
@@ -122,6 +122,11 @@ class ScaleBarAttributeParserTest : BaseMapTest() {
       0.9f,
       mapView.scalebar.getSettings().ratio
     )
+    assertEquals(
+      "useContinuousRendering test failed..",
+      false,
+      mapView.scalebar.getSettings().useContinuousRendering
+    )
   }
 }
 

--- a/app/src/main/res/layout/generated_test_scalebar.xml
+++ b/app/src/main/res/layout/generated_test_scalebar.xml
@@ -21,6 +21,7 @@
     mapbox:mapbox_scaleBarRefreshInterval = "1000000"
     mapbox:mapbox_scaleBarShowTextBorder = "false"
     mapbox:mapbox_scaleBarRatio = "0.9"
+    mapbox:mapbox_scaleBarUseContinuousRendering = "false"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />
 <!-- End of generated file. -->

--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarImpl.kt
@@ -66,6 +66,7 @@ class ScaleBarImpl : ScaleBar, View {
 
   private val refreshHandler: RefreshHandler
   private val decimalFormat = DecimalFormat("0.#")
+  private var isScaleBarVisible = false
 
   /**
    * Current settings will be used to draw ScaleBar
@@ -102,9 +103,9 @@ class ScaleBarImpl : ScaleBar, View {
    * Whether ScaleBar is enabled or not
    */
   override var enable: Boolean
-    get() = visibility == View.VISIBLE
+    get() = isScaleBarVisible
     set(value) {
-      visibility = if (value) View.VISIBLE else View.GONE
+      isScaleBarVisible = value
     }
 
   /**
@@ -153,6 +154,10 @@ class ScaleBarImpl : ScaleBar, View {
    * Draw ScaleBar with current settings
    */
   override fun onDraw(canvas: Canvas) {
+    if (!isScaleBarVisible) {
+      canvas.drawARGB(0, 0, 0, 0)
+      return
+    }
     if (distancePerPixel <= 0 || mapViewWidth <= 0 || maxBarWidth <= 0) {
       return
     }

--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
@@ -131,6 +131,19 @@ open class ScaleBarPluginImpl(
     set(value) {
       scaleBar.distancePerPixel = value
     }
+
+  /**
+   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
+   * even if actual data did not change. If set to False scale bar will redraw only on demand.
+   *
+   * Defaults to False and should not be changed explicitly in most cases.
+   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
+   */
+  override var useContinuousRendering: Boolean
+    get() = scaleBar.useContinuousRendering
+    set(value) {
+      scaleBar.useContinuousRendering = value
+    }
 }
 
 /**

--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
@@ -114,7 +114,10 @@ open class ScaleBarPluginImpl(
     get() = internalSettings.enabled
     set(value) {
       if (value) {
+        mapListenerDelegate.addOnCameraChangeListener(cameraChangeListener)
         invalidateScaleBar()
+      } else {
+        mapListenerDelegate.removeOnCameraChangeListener(cameraChangeListener)
       }
       internalSettings.enabled = value
       scaleBar.enable = value

--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
@@ -114,10 +114,7 @@ open class ScaleBarPluginImpl(
     get() = internalSettings.enabled
     set(value) {
       if (value) {
-        mapListenerDelegate.addOnCameraChangeListener(cameraChangeListener)
         invalidateScaleBar()
-      } else {
-        mapListenerDelegate.removeOnCameraChangeListener(cameraChangeListener)
       }
       internalSettings.enabled = value
       scaleBar.enable = value
@@ -136,5 +133,5 @@ open class ScaleBarPluginImpl(
 /**
  * Extension val for MapView to get the ScaleBar plugin instance.
  */
-val MapPluginProviderDelegate.scalebar: ScaleBarPluginImpl
+val MapPluginProviderDelegate.scalebar: ScaleBarPlugin
   get() = this.getPlugin(ScaleBarPluginImpl::class.java)!!

--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarAttributeParser.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarAttributeParser.kt
@@ -41,6 +41,7 @@ internal object ScaleBarAttributeParser {
         refreshInterval = typedArray.getInt(R.styleable.mapbox_MapView_mapbox_scaleBarRefreshInterval, 15).toLong(),
         showTextBorder = typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_scaleBarShowTextBorder, true),
         ratio = typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_scaleBarRatio, 0.5f),
+        useContinuousRendering = typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_scaleBarUseContinuousRendering, false),
       )
     } finally {
       typedArray.recycle()

--- a/plugin-scalebar/src/main/res-public/values/public.xml
+++ b/plugin-scalebar/src/main/res-public/values/public.xml
@@ -55,5 +55,12 @@
 
     <!-- configures ratio of scale bar max width compared with MapView width, default is 0.5. -->
     <public name="mapbox_scaleBarRatio" type="attr" />
+
+    <!-- If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
+   * even if actual data did not change. If set to False scale bar will redraw only on demand.
+
+   * Defaults to False and should not be changed explicitly in most cases.
+   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command. -->
+    <public name="mapbox_scaleBarUseContinuousRendering" type="attr" />
 </resources>
 <!-- End of generated file. -->

--- a/plugin-scalebar/src/main/res-public/values/public.xml
+++ b/plugin-scalebar/src/main/res-public/values/public.xml
@@ -56,11 +56,7 @@
     <!-- configures ratio of scale bar max width compared with MapView width, default is 0.5. -->
     <public name="mapbox_scaleBarRatio" type="attr" />
 
-    <!-- If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
-   * even if actual data did not change. If set to False scale bar will redraw only on demand.
-
-   * Defaults to False and should not be changed explicitly in most cases.
-   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command. -->
+    <!-- If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval] even if actual data did not change. If set to False scale bar will redraw only on demand. Defaults to False and should not be changed explicitly in most cases. Could be set to True to produce correct GPU frame metrics when running gfxinfo command. -->
     <public name="mapbox_scaleBarUseContinuousRendering" type="attr" />
 </resources>
 <!-- End of generated file. -->

--- a/plugin-scalebar/src/main/res/values/attrs.xml
+++ b/plugin-scalebar/src/main/res/values/attrs.xml
@@ -74,6 +74,12 @@
         <attr name="mapbox_scaleBarShowTextBorder" format="boolean"/>
         <!-- configures ratio of scale bar max width compared with MapView width, default is 0.5. -->
         <attr name="mapbox_scaleBarRatio" format="float"/>
+        <!-- If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
+   * even if actual data did not change. If set to False scale bar will redraw only on demand.
+
+   * Defaults to False and should not be changed explicitly in most cases.
+   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command. -->
+        <attr name="mapbox_scaleBarUseContinuousRendering" format="boolean"/>
     </declare-styleable>
 </resources>
 <!-- End of generated file. -->

--- a/plugin-scalebar/src/main/res/values/attrs.xml
+++ b/plugin-scalebar/src/main/res/values/attrs.xml
@@ -74,11 +74,7 @@
         <attr name="mapbox_scaleBarShowTextBorder" format="boolean"/>
         <!-- configures ratio of scale bar max width compared with MapView width, default is 0.5. -->
         <attr name="mapbox_scaleBarRatio" format="float"/>
-        <!-- If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
-   * even if actual data did not change. If set to False scale bar will redraw only on demand.
-
-   * Defaults to False and should not be changed explicitly in most cases.
-   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command. -->
+        <!-- If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval] even if actual data did not change. If set to False scale bar will redraw only on demand. Defaults to False and should not be changed explicitly in most cases. Could be set to True to produce correct GPU frame metrics when running gfxinfo command. -->
         <attr name="mapbox_scaleBarUseContinuousRendering" format="boolean"/>
     </declare-styleable>
 </resources>

--- a/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarImplTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarImplTest.kt
@@ -2,16 +2,20 @@ package com.mapbox.maps.plugin.scalebar
 
 import android.content.Context
 import android.graphics.Color
+import android.os.Looper
 import android.view.Gravity
+import com.mapbox.maps.plugin.scalebar.ScaleBarImpl.Companion.MSG_RENDER_CONTINUOUS
+import com.mapbox.maps.plugin.scalebar.ScaleBarImpl.Companion.MSG_RENDER_ON_DEMAND
 import com.mapbox.maps.plugin.scalebar.generated.ScaleBarSettings
 import io.mockk.mockk
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
 
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowProjection::class])
@@ -105,5 +109,27 @@ class ScaleBarImplTest {
     assertEquals("1.9 mi", scaleBarView.getDistanceText(10000))
     assertEquals("2 mi", scaleBarView.getDistanceText(10560))
     assertEquals("10 mi", scaleBarView.getDistanceText(52800))
+  }
+
+  @Test
+  @LooperMode(LooperMode.Mode.PAUSED)
+  fun renderingOnDemandTest() {
+    scaleBarView.useContinuousRendering = false
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    scaleBarView.distancePerPixel = 1.0f
+    assertTrue(scaleBarView.refreshHandler.hasMessages(MSG_RENDER_ON_DEMAND))
+    assertFalse(scaleBarView.refreshHandler.hasMessages(MSG_RENDER_CONTINUOUS))
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  @LooperMode(LooperMode.Mode.PAUSED)
+  fun renderingContinuousTest() {
+    scaleBarView.useContinuousRendering = true
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    scaleBarView.distancePerPixel = 1.0f
+    assertFalse(scaleBarView.refreshHandler.hasMessages(MSG_RENDER_ON_DEMAND))
+    assertTrue(scaleBarView.refreshHandler.hasMessages(MSG_RENDER_CONTINUOUS))
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
   }
 }

--- a/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginTest.kt
@@ -101,4 +101,11 @@ class ScaleBarPluginTest {
     verify { scaleBarPlugin.distancePerPixel = 100F }
     verify { scaleBarView.distancePerPixel = 100F }
   }
+
+  @Test
+  fun set_useContinuousRendering() {
+    scaleBarPlugin.useContinuousRendering = true
+    verify { scaleBarPlugin.useContinuousRendering = true }
+    verify { scaleBarView.useContinuousRendering = true }
+  }
 }

--- a/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarAttributeParserTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarAttributeParserTest.kt
@@ -193,6 +193,20 @@ class ScaleBarAttributeParserTest {
     val settings = ScaleBarAttributeParser.parseScaleBarSettings(context, attrs, 1.2f)
     assertEquals(0.5f, settings.ratio)
   }
+
+  @Test
+  fun useContinuousRenderingTestTrue() {
+    every { typedArray.getBoolean(any(), any()) } returns true
+    val settings = ScaleBarAttributeParser.parseScaleBarSettings(context, attrs, 1.2f)
+    assertEquals(true, settings.useContinuousRendering)
+  }
+
+  @Test
+  fun useContinuousRenderingTestFalse() {
+    every { typedArray.getBoolean(any(), any()) } returns false
+    val settings = ScaleBarAttributeParser.parseScaleBarSettings(context, attrs, 1.2f)
+    assertEquals(false, settings.useContinuousRendering)
+  }
 }
 
 // End of generated file.

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBar.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBar.kt
@@ -25,4 +25,13 @@ interface ScaleBar {
    * Defines the width of mapView
    */
   var mapViewWidth: Float
+
+  /**
+   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
+   * even if actual data did not change. If set to False scale bar will redraw only on demand.
+   *
+   * Defaults to False and should not be changed explicitly in most cases.
+   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
+   */
+  var useContinuousRendering: Boolean
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPlugin.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps.plugin.scalebar
 
 import com.mapbox.maps.plugin.MapSizePlugin
 import com.mapbox.maps.plugin.ViewPlugin
+import com.mapbox.maps.plugin.scalebar.generated.ScaleBarSettings
 import com.mapbox.maps.plugin.scalebar.generated.ScaleBarSettingsInterface
 
 /**
@@ -12,4 +13,13 @@ interface ScaleBarPlugin : ViewPlugin, MapSizePlugin, ScaleBarSettingsInterface 
    * How many meters in each pixel.
    */
   var distancePerPixel: Float
+
+  /**
+   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
+   * even if actual data did not change. If set to False scale bar will redraw only on demand.
+   *
+   * Defaults to False and should not be changed explicitly in most cases.
+   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
+   */
+  var useContinuousRendering: Boolean
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPlugin.kt
@@ -2,7 +2,6 @@ package com.mapbox.maps.plugin.scalebar
 
 import com.mapbox.maps.plugin.MapSizePlugin
 import com.mapbox.maps.plugin.ViewPlugin
-import com.mapbox.maps.plugin.scalebar.generated.ScaleBarSettings
 import com.mapbox.maps.plugin.scalebar.generated.ScaleBarSettingsInterface
 
 /**
@@ -13,13 +12,4 @@ interface ScaleBarPlugin : ViewPlugin, MapSizePlugin, ScaleBarSettingsInterface 
    * How many meters in each pixel.
    */
   var distancePerPixel: Float
-
-  /**
-   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
-   * even if actual data did not change. If set to False scale bar will redraw only on demand.
-   *
-   * Defaults to False and should not be changed explicitly in most cases.
-   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
-   */
-  var useContinuousRendering: Boolean
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettings.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettings.kt
@@ -100,11 +100,7 @@ data class ScaleBarSettings(
   var ratio: Float = 0.5f,
 
   /**
-   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
-   * even if actual data did not change. If set to False scale bar will redraw only on demand.
-
-   * Defaults to False and should not be changed explicitly in most cases.
-   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
+   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval] even if actual data did not change. If set to False scale bar will redraw only on demand. Defaults to False and should not be changed explicitly in most cases. Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
    */
   var useContinuousRendering: Boolean = false,
 )

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettings.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettings.kt
@@ -98,6 +98,15 @@ data class ScaleBarSettings(
    * configures ratio of scale bar max width compared with MapView width, default is 0.5.
    */
   var ratio: Float = 0.5f,
+
+  /**
+   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
+   * even if actual data did not change. If set to False scale bar will redraw only on demand.
+
+   * Defaults to False and should not be changed explicitly in most cases.
+   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
+   */
+  var useContinuousRendering: Boolean = false,
 )
 
 // End of generated file.

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettingsBase.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettingsBase.kt
@@ -254,11 +254,7 @@ abstract class ScaleBarSettingsBase : ScaleBarSettingsInterface {
     }
 
   /**
-   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
-   * even if actual data did not change. If set to False scale bar will redraw only on demand.
-
-   * Defaults to False and should not be changed explicitly in most cases.
-   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
+   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval] even if actual data did not change. If set to False scale bar will redraw only on demand. Defaults to False and should not be changed explicitly in most cases. Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
    */
   override var useContinuousRendering: Boolean
     get() {

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettingsBase.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettingsBase.kt
@@ -252,6 +252,22 @@ abstract class ScaleBarSettingsBase : ScaleBarSettingsInterface {
       this.internalSettings.ratio = value
       applySettings()
     }
+
+  /**
+   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
+   * even if actual data did not change. If set to False scale bar will redraw only on demand.
+
+   * Defaults to False and should not be changed explicitly in most cases.
+   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
+   */
+  override var useContinuousRendering: Boolean
+    get() {
+      return this.internalSettings.useContinuousRendering
+    }
+    set(value) {
+      this.internalSettings.useContinuousRendering = value
+      applySettings()
+    }
 }
 
 // End of generated file.

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettingsInterface.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettingsInterface.kt
@@ -109,6 +109,15 @@ interface ScaleBarSettingsInterface {
    * configures ratio of scale bar max width compared with MapView width, default is 0.5.
    */
   var ratio: Float
+
+  /**
+   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
+   * even if actual data did not change. If set to False scale bar will redraw only on demand.
+
+   * Defaults to False and should not be changed explicitly in most cases.
+   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
+   */
+  var useContinuousRendering: Boolean
 }
 
 // End of generated file.

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettingsInterface.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/generated/ScaleBarSettingsInterface.kt
@@ -111,11 +111,7 @@ interface ScaleBarSettingsInterface {
   var ratio: Float
 
   /**
-   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
-   * even if actual data did not change. If set to False scale bar will redraw only on demand.
-
-   * Defaults to False and should not be changed explicitly in most cases.
-   * Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
+   * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval] even if actual data did not change. If set to False scale bar will redraw only on demand. Defaults to False and should not be changed explicitly in most cases. Could be set to True to produce correct GPU frame metrics when running gfxinfo command.
    */
   var useContinuousRendering: Boolean
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Introduce option to use continuous rendering for scale bar. Continuous render mode will fix gfxinfo profiling.</changelog>`.

### Summary of changes

Scale bar custom view was previously rendering on demand. Drawing was happening when camera was moving. However when scalebar is disabled it actually means that no more draw calls would happen. That actually leads to incorrect data from `gfxinfo` in terms of `Total frames rendered` as number of such frames would we always 3 or 4 despite map itself is rendering OK. This is actually not visible if scalebar is visible and map is moving but results are totally incorrect if we do `mapView.scalebar.enabled = false`.

In order to fix that we introduce and option to perform drawing for scalebar continuously now. This option should not be used by users in regular cases but might be useful to get correct rendered frames count info during let's say benchmarking.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

Default rendering way for scale bar will remain the same (rendering on demand). To change rendering mode to continuous `mapView.scalebar.useContinuousRendering = true` should be called. 

<!--
If this PR introduces user-facing changes, please note them here.
-->