### PR TITLE
Add API to control logs for animators

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -57,6 +57,8 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
 
   private val lifecycleListeners = CopyOnWriteArraySet<CameraAnimationsLifecycleListener>()
 
+  override var debugMode: Boolean = true
+
   private var center by Delegates.observable<Point?>(null) { _, old, new ->
     new?.let {
       if (old != it) {
@@ -171,10 +173,12 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
       CameraAnimatorType.BEARING -> mapCameraManagerDelegate.cameraState.bearing
       CameraAnimatorType.PITCH -> mapCameraManagerDelegate.cameraState.pitch
     }.also {
-      Logger.i(
-        TAG,
-        "Animation ${cameraAnimator.type.name}(${cameraAnimator.hashCode()}): automatically setting start value $it."
-      )
+      if (debugMode) {
+        Logger.d(
+          TAG,
+          "Animation ${cameraAnimator.type.name}(${cameraAnimator.hashCode()}): automatically setting start value $it."
+        )
+      }
     }
 
     val targets = cameraAnimator.targets
@@ -262,7 +266,9 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
           if (isUpdated) {
             // finally register update listener in order to update map properly
             registerInternalUpdateListener(this)
-            Logger.i(TAG, "Animation ${type.name}(${hashCode()}) started.")
+            if (debugMode) {
+              Logger.d(TAG, "Animation ${type.name}(${hashCode()}) started.")
+            }
           }
         } ?: throw RuntimeException(
           "Could not start animation in CameraManager! " +
@@ -283,13 +289,17 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
       private fun finishAnimation(animation: Animator?, finishStatus: AnimationFinishStatus) {
         (animation as? CameraAnimator<*>)?.apply {
           runningAnimatorsQueue.remove(animation)
-          val logText = when (finishStatus) {
-            AnimationFinishStatus.CANCELED -> "was canceled."
-            AnimationFinishStatus.ENDED -> "ended."
+          if (debugMode) {
+            val logText = when (finishStatus) {
+              AnimationFinishStatus.CANCELED -> "was canceled."
+              AnimationFinishStatus.ENDED -> "ended."
+            }
+            Logger.d(TAG, "Animation ${type.name}(${hashCode()}) $logText")
           }
-          Logger.i(TAG, "Animation ${type.name}(${hashCode()}) $logText")
           if (isInternal) {
-            Logger.i(TAG, "Internal Animator ${type.name} was unregistered")
+            if (debugMode) {
+              Logger.d(TAG, "Internal Animator ${type.name} was unregistered")
+            }
             unregisterAnimators(this, cancelAnimators = false)
           }
           if (runningAnimatorsQueue.isEmpty()) {

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -57,7 +57,7 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
 
   private val lifecycleListeners = CopyOnWriteArraySet<CameraAnimationsLifecycleListener>()
 
-  override var debugMode: Boolean = true
+  override var debugMode: Boolean = false
 
   private var center by Delegates.observable<Point?>(null) { _, old, new ->
     new?.let {
@@ -809,7 +809,7 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
    * Static variables and methods.
    */
   companion object {
-    private const val TAG = "Mbgl-CameraManager"
+    internal const val TAG = "Mbgl-CameraManager"
   }
 }
 

--- a/plugin-animation/src/test/java/com/mapbox/common/ShadowLogger.java
+++ b/plugin-animation/src/test/java/com/mapbox/common/ShadowLogger.java
@@ -11,6 +11,8 @@ import org.robolectric.annotation.Implements;
 @Implements(Logger.class)
 public class ShadowLogger {
 
+    public static int logCount = 0;
+
     @Implementation
     public static void e(@Nullable String tag, @NonNull String message) {
         Log.e(message, tag);
@@ -18,6 +20,7 @@ public class ShadowLogger {
 
     @Implementation
     public static void d(@Nullable String tag, @NonNull String message) {
+        logCount++;
         Log.d(message, tag);
     }
 

--- a/plugin-animation/src/test/java/com/mapbox/common/ShadowLogger.java
+++ b/plugin-animation/src/test/java/com/mapbox/common/ShadowLogger.java
@@ -11,8 +11,6 @@ import org.robolectric.annotation.Implements;
 @Implements(Logger.class)
 public class ShadowLogger {
 
-    public static int logCount = 0;
-
     @Implementation
     public static void e(@Nullable String tag, @NonNull String message) {
         Log.e(message, tag);
@@ -20,7 +18,6 @@ public class ShadowLogger {
 
     @Implementation
     public static void d(@Nullable String tag, @NonNull String message) {
-        logCount++;
         Log.d(message, tag);
     }
 

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -13,6 +13,7 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.CameraState
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.ScreenCoordinate
+import com.mapbox.maps.plugin.animation.CameraAnimationsPluginImpl.Companion.TAG
 import com.mapbox.maps.plugin.animation.CameraAnimatorOptions.Companion.cameraAnimatorOptions
 import com.mapbox.maps.plugin.animation.MapAnimationOptions.Companion.mapAnimationOptions
 import com.mapbox.maps.plugin.animation.animator.CameraBearingAnimator
@@ -49,7 +50,6 @@ class CameraAnimationsPluginImplTest {
   @Before
   fun setUp() {
     ShadowLog.stream = System.out
-    ShadowLogger.logCount = 0
     cameraAnimatorsFactory = mockk(relaxed = true)
     bearingAnimator = mockk(relaxed = true)
     centerAnimator = mockk(relaxed = true)
@@ -964,18 +964,25 @@ class CameraAnimationsPluginImplTest {
   }
 
   @Test
-  fun debugModeTest() {
-    // debug mode is enabled by default for backward compatibility
+  fun debugModeTrueTest() {
+    mockkStatic(ShadowLogger::class)
+    cameraAnimationsPluginImpl.debugMode = true
     shadowOf(getMainLooper()).pause()
     cameraAnimationsPluginImpl.easeTo(cameraOptions, mapAnimationOptions { duration(DURATION) })
     shadowOf(getMainLooper()).idle()
-    assertNotEquals(0, ShadowLogger.logCount)
-    ShadowLogger.logCount = 0
+    verify { ShadowLogger.d(TAG, any()) }
+    unmockkStatic(ShadowLogger::class)
+  }
+
+  @Test
+  fun debugModeFalseTest() {
+    mockkStatic(ShadowLogger::class)
     cameraAnimationsPluginImpl.debugMode = false
     shadowOf(getMainLooper()).pause()
     cameraAnimationsPluginImpl.easeTo(cameraOptions, mapAnimationOptions { duration(DURATION) })
     shadowOf(getMainLooper()).idle()
-    assertEquals(0, ShadowLogger.logCount)
+    verify(exactly = 0) { ShadowLogger.d(TAG, any()) }
+    unmockkStatic(ShadowLogger::class)
   }
 
   class LifecycleListener : CameraAnimationsLifecycleListener {

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -49,6 +49,7 @@ class CameraAnimationsPluginImplTest {
   @Before
   fun setUp() {
     ShadowLog.stream = System.out
+    ShadowLogger.logCount = 0
     cameraAnimatorsFactory = mockk(relaxed = true)
     bearingAnimator = mockk(relaxed = true)
     centerAnimator = mockk(relaxed = true)
@@ -960,6 +961,21 @@ class CameraAnimationsPluginImplTest {
     // second bearing tick as first animation -
     // pitch is updated to start value
     assertEquals(10.0, updateList[1].pitch!!, EPS)
+  }
+
+  @Test
+  fun debugModeTest() {
+    // debug mode is enabled by default for backward compatibility
+    shadowOf(getMainLooper()).pause()
+    cameraAnimationsPluginImpl.easeTo(cameraOptions, mapAnimationOptions { duration(DURATION) })
+    shadowOf(getMainLooper()).idle()
+    assertNotEquals(0, ShadowLogger.logCount)
+    ShadowLogger.logCount = 0
+    cameraAnimationsPluginImpl.debugMode = false
+    shadowOf(getMainLooper()).pause()
+    cameraAnimationsPluginImpl.easeTo(cameraOptions, mapAnimationOptions { duration(DURATION) })
+    shadowOf(getMainLooper()).idle()
+    assertEquals(0, ShadowLogger.logCount)
   }
 
   class LifecycleListener : CameraAnimationsLifecycleListener {

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
@@ -13,6 +13,12 @@ import com.mapbox.maps.plugin.MapPlugin
 interface CameraAnimationsPlugin : MapPlugin {
 
   /**
+   * If debug mode is enabled extra logs will be written about animation lifecycle and
+   * some other events that may be useful for debugging.
+   */
+  var debugMode: Boolean
+
+  /**
    * Map camera anchor value.
    * Default value is NULL meaning center of given map view.
    * Left-top corner is represented as [ScreenCoordinate] (0.0, 0.0).


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #243 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Add API to control logging for animation plugin and disable debug logs by default.</changelog>`.

### Summary of changes

Add API to disable not critical logs for camera plugin. `debugMode` is set to false by default. Logs could be enabled with:

```
mapView.camera.debugMode = true
```

Additionally even if logs are enabled non-critical logs are downgraded to use `Logger.d` instead of `Logger.i`.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->