### PR TITLE
Fix flyTo crash when using single-pixel paddings

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
@@ -280,12 +280,13 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
 
     val size = mapTransformDelegate.getSize()
     val pixelRatio = mapTransformDelegate.getMapOptions().pixelRatio
-    val w0 = if (size.width.toDouble() != endPadding.left + endPadding.right
-      && size.height.toDouble() != endPadding.bottom + endPadding.top) {
-        max(
-          (size.width - endPadding.left - endPadding.right) / pixelRatio,
-          (size.height - endPadding.top - endPadding.bottom) / pixelRatio
-        )
+    val w0 = if (size.width.toDouble() != endPadding.left + endPadding.right &&
+      size.height.toDouble() != endPadding.bottom + endPadding.top
+    ) {
+      max(
+        (size.width - endPadding.left - endPadding.right) / pixelRatio,
+        (size.height - endPadding.top - endPadding.bottom) / pixelRatio
+      )
     } else {
       max(
         size.width.toDouble() / pixelRatio,

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
@@ -280,10 +280,18 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
 
     val size = mapTransformDelegate.getSize()
     val pixelRatio = mapTransformDelegate.getMapOptions().pixelRatio
-    val w0 = max(
-      (size.width - endPadding.left - endPadding.right) / pixelRatio,
-      (size.height - endPadding.top - endPadding.bottom) / pixelRatio
-    )
+    val w0 = if (size.width.toDouble() != endPadding.left + endPadding.right
+      && size.height.toDouble() != endPadding.bottom + endPadding.top) {
+        max(
+          (size.width - endPadding.left - endPadding.right) / pixelRatio,
+          (size.height - endPadding.top - endPadding.bottom) / pixelRatio
+        )
+    } else {
+      max(
+        size.width.toDouble() / pixelRatio,
+        size.height.toDouble() / pixelRatio
+      )
+    }
     // w₁: Final visible span, measured in pixels with respect to the initial
     // scale.
     val w1 = w0 / (endZoom - startZoom).zoomScale()

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactoryTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactoryTest.kt
@@ -14,6 +14,7 @@ import com.mapbox.maps.plugin.delegates.MapCameraManagerDelegate
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.delegates.MapProjectionDelegate
 import com.mapbox.maps.plugin.delegates.MapTransformDelegate
+import com.mapbox.maps.toCameraOptions
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert
@@ -110,6 +111,21 @@ class CameraAnimatorsFactoryTest {
     every { mapTransformDelegate.getMapOptions() } returns MapOptions.Builder().size(Size(1078.875f, 1698.375f)).build()
     val target = CameraOptions.Builder().bearing(-25.981604850040434).build()
     val animators = cameraAnimatorsFactory.getRotateBy(ScreenCoordinate(0.0, 0.0), ScreenCoordinate(500.0, 500.0))
+    testAnimators(animators, target)
+  }
+
+  @Test
+  fun testFlyToAnimatorsWithSinglePixelPadding() {
+    val size = Size(800.0f, 600.0f)
+    every { mapCameraManagerDelegate.cameraState } returns initialCameraPosition
+    every { mapTransformDelegate.getMapOptions() } returns MapOptions.Builder().size(size).build()
+    every { mapTransformDelegate.getSize() } returns size
+
+    val target = initialCameraPosition.toCameraOptions().toBuilder()
+      .bearing(90.0)
+      .padding(EdgeInsets(300.0, 400.0, 300.0, 400.0))
+      .build()
+    val animators = cameraAnimatorsFactory.getFlyTo(target)
     testAnimators(animators, target)
   }
 


### PR DESCRIPTION
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #475 
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/177

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix flyTo crash when using single-pixel paddings.</changelog>`.

### Summary of changes

Fix a crash (if changing center as well) or zoom reporting NaN (if changing zoom) when using `mapView.camera.flyTo` with 1-pixel padding or `mapView.width == padding.left + padding.right && mapView.height == padding.bottom + padding.top`
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->