### PR TITLE
Fix overwriting sync geojson data with getSourceAs by async

### DIFF
--- a/sdk/src/androidTest/java/com/mapbox/maps/MapIntegrationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/MapIntegrationTest.kt
@@ -10,7 +10,9 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.generated.circleLayer
 import com.mapbox.maps.extension.style.sources.addSource
+import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
+import com.mapbox.maps.extension.style.sources.getSourceAs
 import com.mapbox.maps.extension.style.style
 import org.junit.After
 import org.junit.Before
@@ -399,6 +401,76 @@ class MapIntegrationTest {
               1_000L
             )
           }
+        }
+        mapView.onStart()
+      }
+    }
+    if (!countDownLatch.await(5, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun testApplySyncDataToGeoJsonUsingGetSourceAs() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      it.runOnUiThread {
+        mapView = MapView(it)
+        mapboxMap = mapView.getMapboxMap()
+        it.frameLayout.addView(mapView)
+        mapboxMap.setCamera(
+          CameraOptions.Builder()
+            .center(Point.fromLngLat(0.0, 0.0))
+            .zoom(9.0)
+            .build()
+        )
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) { style ->
+          val source = geoJsonSource("source") {
+            featureCollection(FeatureCollection.fromFeatures(emptyList()))
+          }
+          style.addSource(source)
+          val layer = circleLayer("layer", "source") {
+            circleColor("red")
+            circleRadius(10.0)
+          }
+          style.addLayer(layer)
+          val feature = Feature.fromJson(
+            """
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [0.0, 0.0]
+                    },
+                    "properties": {
+                        "fillOpacity": 0.5,
+                        "fillColor": "rgba(255, 0, 255, 1.0)",
+                        "fillPattern": "",
+                        "type": "circle",
+                        "radius": 1.0
+                    }
+                }
+            """.trimIndent()
+          )
+          style.getSourceAs<GeoJsonSource>("source")!!
+            .featureCollection(
+              FeatureCollection.fromFeatures(
+                listOf(feature)
+              )
+            )
+          mapView.postDelayed(
+            {
+              mapboxMap.queryRenderedFeatures(
+                ScreenCoordinate(mapView.width / 2.0, mapView.height / 2.0),
+                RenderedQueryOptions(listOf("layer"), null)
+              ) { result ->
+                if (result.value?.size == 1) {
+                  countDownLatch.countDown()
+                }
+              }
+            },
+            1_000L
+          )
         }
         mapView.onStart()
       }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/481

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix overwriting sync geojson data with getSourceAs by async.</changelog>`.

### Summary of changes

If sync method is called using `getSourceAs` while some parsing is already happening e.g.:
```
style.getSourceAs<GeoJsonSource>("source")!!
.featureCollection(
  FeatureCollection.fromFeatures(
    listOf(feature)
  )
)
```
async task will __not__ overwrite data now.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->