### PR TITLE
[CameraAnimationsPluginImpl] Fix camera animations on Android 6

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -310,6 +310,14 @@ internal class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
             unregisterAnimators(this, cancelAnimators = false)
           }
           if (runningAnimatorsQueue.isEmpty()) {
+            cameraOptionsBuilder.build().let { options ->
+              if (options.hasChanges) {
+                // cameraOptionsBuilder might have some accumulated, but not applied changes.
+                performMapJump(options)
+                cameraOptionsBuilder = CameraOptions.Builder()
+              }
+            }
+
             mapTransformDelegate.setUserAnimationInProgress(false)
           }
           lifecycleListeners.forEach {

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraOptionsUtils.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraOptionsUtils.kt
@@ -1,0 +1,18 @@
+package com.mapbox.maps.plugin.animation
+
+import com.mapbox.maps.CameraOptions
+
+internal val CameraOptions.isEmpty: Boolean
+  get() {
+    if (center != null) return false
+    if (padding != null) return false
+    if (anchor != null) return false
+    if (zoom != null) return false
+    if (bearing != null) return false
+    if (pitch != null) return false
+
+    return true
+  }
+
+internal val CameraOptions.hasChanges: Boolean
+  get() = !isEmpty


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/483

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fixed regression in map gestures on devices with Android 6 and lower.</changelog>`.

### Summary of changes

Try to apply camera changes accumulated in `cameraOptionsBuilder` when all animators finish. This is relevant for Android SDK <= 23 versions and has visual effect for gestures because they use `easeTo` with zero-duration. In general last animator is skipped for low-end devices without this fix which leads to incorrect behaviour.