### PR TITLE
[sdk-base] add default parameters to coordinate conversion functions

### DIFF
--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapCameraManagerDelegate.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapCameraManagerDelegate.kt
@@ -28,9 +28,9 @@ interface MapCameraManagerDelegate {
    */
   fun cameraForCoordinateBounds(
     bounds: CoordinateBounds,
-    padding: EdgeInsets,
-    bearing: Double?,
-    pitch: Double?
+    padding: EdgeInsets = EdgeInsets(0.0, 0.0, 0.0, 0.0),
+    bearing: Double? = null,
+    pitch: Double? = null
   ): CameraOptions
 
   /**
@@ -45,9 +45,9 @@ interface MapCameraManagerDelegate {
    */
   fun cameraForCoordinates(
     coordinates: List<Point>,
-    padding: EdgeInsets,
-    bearing: Double?,
-    pitch: Double?
+    padding: EdgeInsets = EdgeInsets(0.0, 0.0, 0.0, 0.0),
+    bearing: Double? = null,
+    pitch: Double? = null
   ): CameraOptions
 
   /**
@@ -83,9 +83,9 @@ interface MapCameraManagerDelegate {
    */
   fun cameraForGeometry(
     geometry: Geometry,
-    padding: EdgeInsets,
-    bearing: Double?,
-    pitch: Double?
+    padding: EdgeInsets = EdgeInsets(0.0, 0.0, 0.0, 0.0),
+    bearing: Double? = null,
+    pitch: Double? = null
   ): CameraOptions
 
   /**

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -458,6 +458,56 @@ class MapboxMapTest {
   }
 
   @Test
+  fun cameraForCoordinateBoundsOverload() {
+    val bounds = mockk<CoordinateBounds>()
+    mapboxMap.cameraForCoordinateBounds(bounds)
+    verify {
+      nativeMap.cameraForCoordinateBounds(
+        bounds,
+        EdgeInsets(0.0, 0.0, 0.0, 0.0),
+        null,
+        null
+      )
+    }
+  }
+
+  @Test
+  fun cameraForCoordinateBoundsOverloadPadding() {
+    val bounds = mockk<CoordinateBounds>()
+    val padding = EdgeInsets(1.1, 1.3, 1.4, 1.2)
+    mapboxMap.cameraForCoordinateBounds(bounds, padding)
+    verify { nativeMap.cameraForCoordinateBounds(bounds, padding, null, null) }
+  }
+
+  @Test
+  fun cameraForCoordinateBoundsOverloadBearing() {
+    val bounds = mockk<CoordinateBounds>()
+    mapboxMap.cameraForCoordinateBounds(bounds, bearing = 2.0)
+    verify {
+      nativeMap.cameraForCoordinateBounds(
+        bounds,
+        EdgeInsets(0.0, 0.0, 0.0, 0.0),
+        2.0,
+        null
+      )
+    }
+  }
+
+  @Test
+  fun cameraForCoordinateBoundsOverloadPitch() {
+    val bounds = mockk<CoordinateBounds>()
+    mapboxMap.cameraForCoordinateBounds(bounds, pitch = 2.0)
+    verify {
+      nativeMap.cameraForCoordinateBounds(
+        bounds,
+        EdgeInsets(0.0, 0.0, 0.0, 0.0),
+        null,
+        2.0
+      )
+    }
+  }
+
+  @Test
   fun coordinateBoundsForCamera() {
     val cameraOptions = mockk<CameraOptions>()
     mapboxMap.coordinateBoundsForCamera(cameraOptions)
@@ -496,11 +546,53 @@ class MapboxMapTest {
   }
 
   @Test
+  fun cameraForCoordinatesOverload() {
+    val points = mockk<List<Point>>()
+    mapboxMap.cameraForCoordinates(points)
+    verify { nativeMap.cameraForCoordinates(points, EdgeInsets(0.0, 0.0, 0.0, 0.0), null, null) }
+  }
+
+  @Test
+  fun cameraForCoordinatesOverloadBearing() {
+    val points = mockk<List<Point>>()
+    mapboxMap.cameraForCoordinates(points, bearing = 2.0)
+    verify { nativeMap.cameraForCoordinates(points, EdgeInsets(0.0, 0.0, 0.0, 0.0), 2.0, null) }
+  }
+
+  @Test
+  fun cameraForCoordinatesOverloadPitch() {
+    val points = mockk<List<Point>>()
+    mapboxMap.cameraForCoordinates(points, pitch = 2.0)
+    verify { nativeMap.cameraForCoordinates(points, EdgeInsets(0.0, 0.0, 0.0, 0.0), null, 2.0) }
+  }
+
+  @Test
   fun cameraForGeometry() {
     val point = mockk<Point>()
     val edgeInsets = mockk<EdgeInsets>()
     mapboxMap.cameraForGeometry(point, edgeInsets, 0.0, 1.0)
     verify { nativeMap.cameraForGeometry(point, edgeInsets, 0.0, 1.0) }
+  }
+
+  @Test
+  fun cameraForGeometryOverload() {
+    val point = mockk<Point>()
+    mapboxMap.cameraForGeometry(point)
+    verify { nativeMap.cameraForGeometry(point, EdgeInsets(0.0, 0.0, 0.0, 0.0), null, null) }
+  }
+
+  @Test
+  fun cameraForGeometryOverloadBearing() {
+    val point = mockk<Point>()
+    mapboxMap.cameraForGeometry(point, bearing = 2.0)
+    verify { nativeMap.cameraForGeometry(point, EdgeInsets(0.0, 0.0, 0.0, 0.0), 2.0, null) }
+  }
+
+  @Test
+  fun cameraForGeometryOverloadPitch() {
+    val point = mockk<Point>()
+    mapboxMap.cameraForGeometry(point, pitch = 2.0)
+    verify { nativeMap.cameraForGeometry(point, EdgeInsets(0.0, 0.0, 0.0, 0.0), null, 2.0) }
   }
 
   @Test


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Add default parameters to coordinate conversion functions of MapCameraManagerDelegate#cameraForCoordinates, MapCameraManagerDelegate#cameraForCoordinateBounds and MapCameraManagerDelegate#cameraForGeometry. This overloads the functions to have a more simple API surface for developers to hook into.</changelog>`.

### Summary of changes

Add default values to parameters of `MapCameraManagerDelegate#cameraForCoordinates`, `MapCameraManagerDelegate#cameraForCoordinateBounds` and `MapCameraManagerDelegate#cameraForGeometry`.


### User impact (optional)

Allows user to hook into these functions more easily, not needing them to provide null values.  

![image](https://user-images.githubusercontent.com/2151639/125265659-5710ea00-e305-11eb-8c51-58337fa3216c.png)