### PR TITLE
Add showLogo and showAttributes config for snapshotter

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapSnapshotterActivity.kt
@@ -26,7 +26,10 @@ class MapSnapshotterActivity : AppCompatActivity(), SnapshotStyleListener {
       .pixelRatio(1.0f)
       .build()
 
-    mapSnapshotter = Snapshotter(this, snapshotterOptions).apply {
+    mapSnapshotter = Snapshotter(
+      this, snapshotterOptions,
+      SnapshotOverlayOptions(showLogo = false, showAttributes = false)
+    ).apply {
       setStyleListener(this@MapSnapshotterActivity)
       setStyleUri(Style.MAPBOX_STREETS)
       setCamera(

--- a/sdk/src/main/java/com/mapbox/maps/SnapshotOverlayOptions.kt
+++ b/sdk/src/main/java/com/mapbox/maps/SnapshotOverlayOptions.kt
@@ -1,0 +1,12 @@
+package com.mapbox.maps
+
+/**
+ * Data class to config the overlays on the snapshotter
+ *
+ * @param showLogo whether show Mapbox logo on the taken snapshot
+ * @param showAttributes whether show attribution on the taken snapshot
+ */
+data class SnapshotOverlayOptions(
+  val showLogo: Boolean = true,
+  val showAttributes: Boolean = true
+)

--- a/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
@@ -31,6 +31,7 @@ open class Snapshotter {
   private val coreSnapshotter: MapSnapshotterInterface
   private val pixelRatio: Float
   private val mapSnapshotOptions: MapSnapshotOptions
+  private val snapshotOverlayOptions: SnapshotOverlayOptions
 
   private var snapshotCreatedCallback: SnapshotCreatedListener? = null
   private var snapshotStyleCallback: SnapshotStyleListener? = null
@@ -39,9 +40,10 @@ open class Snapshotter {
 
   private val mainHandler: Handler
 
-  constructor(context: Context, options: MapSnapshotOptions) {
+  constructor(context: Context, options: MapSnapshotOptions, snapshotOverlayOptions: SnapshotOverlayOptions = SnapshotOverlayOptions()) {
     this.context = WeakReference(context)
     this.mapSnapshotOptions = options
+    this.snapshotOverlayOptions = snapshotOverlayOptions
     coreSnapshotter = MapSnapshotter(options)
     pixelRatio = context.resources.displayMetrics.density
     mainHandler = Handler(context.mainLooper)
@@ -72,9 +74,10 @@ open class Snapshotter {
   }
 
   @VisibleForTesting
-  internal constructor(context: Context, options: MapSnapshotOptions, snapshotter: MapSnapshotterInterface, mainHandler: Handler, observer: Observer) {
+  internal constructor(context: Context, options: MapSnapshotOptions, snapshotter: MapSnapshotterInterface, mainHandler: Handler, observer: Observer, snapshotOverlayOptions: SnapshotOverlayOptions = SnapshotOverlayOptions()) {
     this.context = WeakReference(context)
     this.mapSnapshotOptions = options
+    this.snapshotOverlayOptions = snapshotOverlayOptions
     coreSnapshotter = snapshotter
     pixelRatio = context.resources.displayMetrics.density
     this.observer = observer
@@ -342,8 +345,12 @@ open class Snapshotter {
       val measure: AttributionMeasure = getAttributionMeasure(it, mapSnapshot, snapshot, margin)
       val layout = measure.measure()
       layout?.let {
-        drawLogo(mapSnapshot, canvas, margin, layout)
-        drawAttribution(mapSnapshot, canvas, measure, layout)
+        if (snapshotOverlayOptions.showLogo) {
+          drawLogo(mapSnapshot, canvas, margin, layout)
+        }
+        if (snapshotOverlayOptions.showAttributes) {
+          drawAttribution(mapSnapshot, canvas, measure, layout)
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Add showLogo and showAttributes config for snapshotter. User can then hide logo and attributions in a snapshotter</changelog>`.

### Summary of changes
Created a new data class `SnapshotOptions` which wrap `MapSnapshotOptions` and `showLogo`/`showAttribution`. 
`Snapshotter` now take a `SnapshotOptions` as construct param.
![image](https://user-images.githubusercontent.com/8577318/125442233-af5fcac2-dc43-43d0-be56-ace625817fe0.png)
![image](https://user-images.githubusercontent.com/8577318/125442301-6f368e36-2d8c-48f8-8a3f-1a5f18614adf.png)
![image](https://user-images.githubusercontent.com/8577318/125442378-4db03e6d-5ffc-4200-b702-8b85adc9bedd.png)

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->