### PR TITLE
Remove generate-docs step in release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,4 +447,3 @@ jobs:
       - track-metrics
       - publish-sdk-registry
       - publish-sdk-registry-named-snapshot
-      - generate-docs


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes
This pr contains the following changes:
- Output the snapshot name if a snapshot is uploaded to registry to enable us to use the snapshot easily.
- As we now generate and create the pr for docs locally,  the `generate-docs` step is not needed, so delete this stop from release steps
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->