### PR TITLE
[ci] Add commit hash to the snapshots' name built on main branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,10 @@ commands:
             if [[ $CIRCLE_TAG == android-v* ]]; then
               sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${CIRCLE_TAG:9}/" gradle.properties
             fi
+            if [[ $CIRCLE_TAG == main ]]; then
+              COMMIT_SHA=$(git rev-parse --short HEAD)
+              sed -i -e "s/-SNAPSHOT.*/-${COMMIT_SHA}-SNAPSHOT/" gradle.properties
+            fi
 
   generate-docs:
     steps:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

This PR adds commit hash to the built snapshot releases.

Before:

Snapshots on main branch are overwritten every time there's a new commit, and the version name is:

`com.mapbox.maps:android:10.0.0-SNAPSHOT`

After:

Snapshots on the main branch will have unique version name for each commit, the proposed version name is:

Appending the commit hash before the -SNAPSHOT defined in the gradle.properties file, so it would become:

`com.mapbox.maps:android:10.0.0-a1d95e7a-SNAPSHOT`

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->