### PR TITLE
[ci] Fix the snapshot circle CI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,7 @@ commands:
           command: |
             if [[ $CIRCLE_TAG == android-v* ]]; then
               sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${CIRCLE_TAG:9}/" gradle.properties
-            fi
-            if [[ $CIRCLE_TAG == main ]]; then
+            elif [[ $CIRCLE_BRANCH == main ]]; then
               COMMIT_SHA=$(git rev-parse --short HEAD)
               sed -i -e "s/-SNAPSHOT.*/-${COMMIT_SHA}-SNAPSHOT/" gradle.properties
             fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

This PR fixes the snapshot circle CI config, to use CIRCLE_BRANCH instead of CIRCLE_TAG to check for main branch. And also fixed the logic to only change the snapshot version name if it is not a release tag.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->