### PR TITLE
[ci] Increase robo test and build sdk release CI bot's resources to fix flaky tests due to OOM.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,6 +354,10 @@ jobs:
   run-robo-test:
     docker:
       - image: mbgl/android-ndk-r21e:latest
+    resource_class: xlarge
+    environment:
+      JVM_OPTS: -Xmx3200m
+      GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
 
     steps:
       - checkout
@@ -436,6 +440,10 @@ jobs:
   build-sdk-release:
     docker:
       - image: mbgl/android-ndk-r21e:latest
+    resource_class: xlarge
+    environment:
+      JVM_OPTS: -Xmx3200m
+      GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
 
     steps:
       - checkout


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

This PR increases robo test and build sdk release CI bot's resources to fix flaky tests due to OOM.
The recent flaky tests are build-sdk-release and robo tests(building release version of the SDK), so this PR only covers these two bots.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->