### PR TITLE
Fixes string interpolation in font utils log message

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/FontUtils.kt
+++ b/sdk/src/main/java/com/mapbox/maps/FontUtils.kt
@@ -39,7 +39,7 @@ internal object FontUtils {
       }
     }
     Log.i(
-      TAG, "Couldn't map font family for local ideograph, using %s instead $DEFAULT_FONT"
+      TAG, "Couldn't map font family for local ideograph, using ${DEFAULT_FONT} instead"
     )
     return DEFAULT_FONT
   }


### PR DESCRIPTION
Hey folks, quick fix. I'm playing around on Android a bit and noticed my log :cat2: showing me this all day

```
I/Mbgl-FontUtils: Couldn't map font family for local ideograph, using %s instead sans-serif
```

instead of the properly interpolated string.

That's it :v: