### PR TITLE
Enable render cache by default

### DIFF
--- a/sdk/src/androidTest/java/com/mapbox/maps/RenderCacheTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/RenderCacheTest.kt
@@ -8,7 +8,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
-@MapboxExperimental
 class RenderCacheTest {
 
   @get:Rule
@@ -104,6 +103,19 @@ class RenderCacheTest {
         mapView.getMapboxMap().setRenderCacheOptions(RenderCacheOptions.Builder().build())
         Assert.assertEquals(
           RENDER_CACHE_DISABLED,
+          mapView.getMapboxMap().getRenderCacheOptions().size
+        )
+      }
+    }
+  }
+
+  @Test
+  fun defaultRenderCache() {
+    // should be large by default
+    rule.scenario.onActivity {
+      it.runOnUiThread {
+        Assert.assertEquals(
+          RENDER_CACHE_SIZE_LARGE_MB,
           mapView.getMapboxMap().getRenderCacheOptions().size
         )
       }

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -62,9 +62,14 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       renderer,
     )
     this.nativeObserver = NativeObserver(WeakReference(nativeMap))
-    this.mapboxMap =
-      MapProvider.getMapboxMap(nativeMap, nativeObserver, mapInitOptions.mapOptions.pixelRatio)
-    this.mapboxMap.renderHandler = renderer.renderThread.handlerThread.handler
+    this.mapboxMap = MapProvider.getMapboxMap(
+      nativeMap,
+      nativeObserver,
+      mapInitOptions.mapOptions.pixelRatio
+    ).apply {
+      renderHandler = renderer.renderThread.handlerThread.handler
+      setRenderCacheOptions(RenderCacheOptions.Builder().setLargeSize().build())
+    }
     this.pluginRegistry = MapProvider.getMapPluginRegistry(
       mapboxMap,
       this,

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -1166,9 +1166,9 @@ class MapboxMap internal constructor(
   fun getElevation(coordinate: Point) = nativeMapWeakRef.call { this.getElevation(coordinate) }
 
   /**
-   * Enables or disables the experimental render cache feature.
+   * Enables or disables the render cache feature.
    *
-   * Render cache is an experimental feature aiming to reduce resource usage of map rendering
+   * Render cache is the feature aiming to reduce resource usage of map rendering
    * by caching intermediate rendering results of tiles into specific cache textures for reuse between frames.
    * Performance benefit of the cache depends on the style as not all layers are cacheable due to e.g.
    * viewport aligned features. Render cache always prefers quality over performance.
@@ -1178,7 +1178,6 @@ class MapboxMap internal constructor(
    *
    * @param options Options defining the render cache behavior
    */
-  @MapboxExperimental
   fun setRenderCacheOptions(options: RenderCacheOptions) {
     options.size?.let { size ->
       nativeMapWeakRef.call {
@@ -1197,7 +1196,6 @@ class MapboxMap internal constructor(
    *
    * The size of the render cache is in megabytes. Returned value is zero if the feature is disabled.
    */
-  @MapboxExperimental
   fun getRenderCacheOptions(): RenderCacheOptions {
     return nativeMapWeakRef.call { this.renderCacheOptions }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Enable render cache by default when creating a map view.</changelog>`.

### Summary of changes

Render cache is enabled by default when creating a map view. More information and visuals about render cache may be found [here](https://www.mapbox.com/blog/maps-sdk-v10-release-candidate) or API docs.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

Render cache can be easily turned off for any `MapView`:
```
mapView.getMapboxMap().setRenderCacheOptions(RenderCacheOptions.Builder().setDisabled().build())
```