### PR TITLE
Fix memory leaks in SDK

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/DataDrivenMapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/DataDrivenMapSnapshotterActivity.kt
@@ -134,7 +134,7 @@ class DataDrivenMapSnapshotterActivity : AppCompatActivity() {
 
   override fun onDestroy() {
     super.onDestroy()
-    snapshotter.cancel()
+    snapshotter.destroy()
   }
 
   companion object {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/LocalStyleMapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/LocalStyleMapSnapshotterActivity.kt
@@ -64,7 +64,7 @@ class LocalStyleMapSnapshotterActivity : AppCompatActivity() {
 
   override fun onDestroy() {
     super.onDestroy()
-    mapSnapshotter.cancel()
+    mapSnapshotter.destroy()
   }
 
   companion object {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapSnapshotterActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/snapshotter/MapSnapshotterActivity.kt
@@ -55,7 +55,7 @@ class MapSnapshotterActivity : AppCompatActivity(), SnapshotStyleListener {
 
   override fun onDestroy() {
     super.onDestroy()
-    mapSnapshotter.cancel()
+    mapSnapshotter.destroy()
   }
 
   companion object {

--- a/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Snapshotter.kt
@@ -33,8 +33,8 @@ open class Snapshotter {
   private val mapSnapshotOptions: MapSnapshotOptions
   private val snapshotOverlayOptions: SnapshotOverlayOptions
 
-  private var snapshotCreatedCallback: SnapshotCreatedListener? = null
-  private var snapshotStyleCallback: SnapshotStyleListener? = null
+  internal var snapshotCreatedCallback: SnapshotCreatedListener? = null
+  internal var snapshotStyleCallback: SnapshotStyleListener? = null
 
   private val observer: Observer
 
@@ -132,6 +132,15 @@ open class Snapshotter {
   fun cancel() {
     coreSnapshotter.cancel()
     snapshotCreatedCallback = null
+  }
+
+  /**
+   * Destroy snapshotter.
+   */
+  fun destroy() {
+    cancel()
+    unsubscribeEvents()
+    snapshotStyleCallback = null
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -51,6 +51,7 @@ internal abstract class MapboxRenderer : MapClient() {
   fun onDestroy() {
     // we destroy and stop thread after surface or texture is destroyed
     needDestroy = true
+    renderThread.fpsChangedListener = null
   }
 
   @AnyThread

--- a/sdk/src/test/java/com/mapbox/maps/SnapshotterDelegateTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/SnapshotterDelegateTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.maps
 import com.mapbox.common.ShadowLogger
 import com.mapbox.geojson.Point
 import io.mockk.*
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -141,6 +142,14 @@ class SnapshotterDelegateTest {
   fun cancel() {
     snapshotter.cancel()
     verify { coreSnapshotter.cancel() }
+  }
+
+  @Test
+  fun destroy() {
+    snapshotter.destroy()
+    verify { coreSnapshotter.cancel() }
+    Assert.assertNull(snapshotter.snapshotCreatedCallback)
+    Assert.assertNull(snapshotter.snapshotStyleCallback)
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/SnapshotterTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/SnapshotterTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps
 
 import com.mapbox.common.ShadowLogger
 import io.mockk.*
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -137,6 +138,14 @@ class SnapshotterTest {
   fun cancel() {
     snapshotter.cancel()
     verify { coreSnapshotter.cancel() }
+  }
+
+  @Test
+  fun destroy() {
+    snapshotter.destroy()
+    verify { coreSnapshotter.cancel() }
+    Assert.assertNull(snapshotter.snapshotStyleCallback)
+    Assert.assertNull(snapshotter.snapshotCreatedCallback)
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -229,7 +229,11 @@ internal abstract class MapboxRendererTest {
 
   @Test
   fun onDestroyTest() {
+    val listener = OnFpsChangedListener { }
+    every { renderThread.fpsChangedListener } returns listener
+    mapboxRenderer.setOnFpsChangedListener(listener)
     mapboxRenderer.onDestroy()
     Assert.assertEquals(true, mapboxRenderer.needDestroy)
+    verify { renderThread.fpsChangedListener = null }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #448 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix several memory leaks: clean up OnFpsChangeListener on render thread destroy / introduce Snapshotter#destroy method that must be called in Activity#onDestroy</changelog>`.

### Summary of changes

Fix memory leaks that were caught during going thru our example activities.

- Clean up `OnFpsChangeListener` on render thread destroy.
- Introduce `Snapshotter#destroy` method that must be called in `Activity#onDestroy`

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->