### PR TITLE
Add check for layer and source while creating annotations and init them if not initiated before

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/CircleAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/CircleAnnotationActivity.kt
@@ -32,17 +32,16 @@ class CircleAnnotationActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_annotation)
-    mapView.getMapboxMap().loadStyleUri(nextStyle) {
-      annotationPlugin = mapView.annotations
-      circleAnnotationManager = annotationPlugin.createCircleAnnotationManager(mapView).apply {
-        addClickListener(
-          OnCircleAnnotationClickListener {
-            Toast.makeText(this@CircleAnnotationActivity, "click: ${it.id}", Toast.LENGTH_SHORT)
-              .show()
-            false
-          }
-        )
-
+    annotationPlugin = mapView.annotations
+    circleAnnotationManager = annotationPlugin.createCircleAnnotationManager(mapView).apply {
+      addClickListener(
+        OnCircleAnnotationClickListener {
+          Toast.makeText(this@CircleAnnotationActivity, "click: ${it.id}", Toast.LENGTH_SHORT)
+            .show()
+          false
+        }
+      )
+      mapView.getMapboxMap().loadStyleUri(nextStyle) {
         addInteractionListener(
           object : OnCircleAnnotationInteractionListener {
             override fun onSelectAnnotation(annotation: CircleAnnotation) {

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -333,6 +333,9 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
       Logger.e(TAG, "Can't update source: style is not fully loaded.")
       return
     }
+    if (source == null || layer == null) {
+      initLayerAndSource(style)
+    }
     source?.let { geoJsonSource ->
       if (!style.styleSourceExists(geoJsonSource.sourceId)) {
         Logger.e(TAG, "Can't update source: source has not been added to style.")

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -29,7 +29,6 @@ import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.getSource
-import com.mapbox.maps.plugin.Plugin
 import com.mapbox.maps.plugin.annotation.*
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
@@ -101,7 +100,7 @@ class PointAnnotationManagerTest {
     every { gesturesPlugin.removeOnMoveListener(any()) } just Runs
     every { gesturesPlugin.removeOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.removeOnMapLongClickListener(any()) } just Runs
-    every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(Plugin.MAPBOX_GESTURES_PLUGIN_ID) } returns gesturesPlugin
+    every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
@@ -191,6 +190,25 @@ class PointAnnotationManagerTest {
     assertTrue(manager.dragListeners.isEmpty())
     assertTrue(manager.clickListeners.isEmpty())
     assertTrue(manager.longClickListeners.isEmpty())
+  }
+
+  @Test
+  fun initializeBeforeStyleLoad() {
+    every { style.styleLayerExists("test_layer") } returns true
+    val captureCallback = slot<(StyleInterface) -> Unit>()
+    every { delegateProvider.getStyle(capture(captureCallback)) } just Runs
+    manager = PointAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
+    // Style is not loaded, can't create and add layer to style
+    verify(exactly = 0) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
+    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+      captureCallback.captured.invoke(style)
+    }
+    manager.create(
+      PointAnnotationOptions()
+        .withPoint(Point.fromLngLat(0.0, 0.0))
+    )
+    // Style is loaded, will create and add layer to style while creating annotations
+    verify(exactly = 1) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -27,7 +27,6 @@ import com.mapbox.maps.extension.style.layers.generated.FillLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.getSource
-import com.mapbox.maps.plugin.Plugin
 import com.mapbox.maps.plugin.annotation.*
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
@@ -98,7 +97,7 @@ class PolygonAnnotationManagerTest {
     every { gesturesPlugin.removeOnMoveListener(any()) } just Runs
     every { gesturesPlugin.removeOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.removeOnMapLongClickListener(any()) } just Runs
-    every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(Plugin.MAPBOX_GESTURES_PLUGIN_ID) } returns gesturesPlugin
+    every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
@@ -164,6 +163,25 @@ class PolygonAnnotationManagerTest {
     assertTrue(manager.dragListeners.isEmpty())
     assertTrue(manager.clickListeners.isEmpty())
     assertTrue(manager.longClickListeners.isEmpty())
+  }
+
+  @Test
+  fun initializeBeforeStyleLoad() {
+    every { style.styleLayerExists("test_layer") } returns true
+    val captureCallback = slot<(StyleInterface) -> Unit>()
+    every { delegateProvider.getStyle(capture(captureCallback)) } just Runs
+    manager = PolygonAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
+    // Style is not loaded, can't create and add layer to style
+    verify(exactly = 0) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
+    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+      captureCallback.captured.invoke(style)
+    }
+    manager.create(
+      PolygonAnnotationOptions()
+        .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
+    )
+    // Style is loaded, will create and add layer to style while creating annotations
+    verify(exactly = 1) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -28,7 +28,6 @@ import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.getSource
-import com.mapbox.maps.plugin.Plugin
 import com.mapbox.maps.plugin.annotation.*
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
@@ -99,7 +98,7 @@ class PolylineAnnotationManagerTest {
     every { gesturesPlugin.removeOnMoveListener(any()) } just Runs
     every { gesturesPlugin.removeOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.removeOnMapLongClickListener(any()) } just Runs
-    every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(Plugin.MAPBOX_GESTURES_PLUGIN_ID) } returns gesturesPlugin
+    every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
@@ -169,6 +168,25 @@ class PolylineAnnotationManagerTest {
     assertTrue(manager.dragListeners.isEmpty())
     assertTrue(manager.clickListeners.isEmpty())
     assertTrue(manager.longClickListeners.isEmpty())
+  }
+
+  @Test
+  fun initializeBeforeStyleLoad() {
+    every { style.styleLayerExists("test_layer") } returns true
+    val captureCallback = slot<(StyleInterface) -> Unit>()
+    every { delegateProvider.getStyle(capture(captureCallback)) } just Runs
+    manager = PolylineAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
+    // Style is not loaded, can't create and add layer to style
+    verify(exactly = 0) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
+    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+      captureCallback.captured.invoke(style)
+    }
+    manager.create(
+      PolylineAnnotationOptions()
+        .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
+    )
+    // Style is loaded, will create and add layer to style while creating annotations
+    verify(exactly = 1) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #378 
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Add check for layer and source while creating annotations and init them if not initiated before. So that enable create the AnnotationManager before loading style.</changelog>`.

### Summary of changes
If create an AnnotationManager before loading a style, the layer and source will not be initiated because while loading a style, the previously added styleload listener will be removed. To fix this, this pr add a check in `updateSource` method and init layer and source if they are not initiated before
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->