### PR TITLE
[style-extension] Remove the expression getter/setters for source properties

### DIFF
--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/GeoJsonSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/GeoJsonSourceTest.kt
@@ -45,18 +45,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun dataAsExpressionTest() {
-    val expression = literal(TEST_URI)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      data(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.dataAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun urlTest() {
     val testSource = geoJsonSource("testId") {
       url(TEST_URI)
@@ -78,17 +66,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun urlAsExpressionTest() {
-    val expression = literal(TEST_URI)
-    val testSource = geoJsonSource("testId") {
-      url(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.dataAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun maxzoomTest() {
     val testSource = geoJsonSource("testId") {
       url(TEST_URI)
@@ -96,18 +73,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(1L, testSource.maxzoom)
-  }
-
-  @Test
-  @UiThreadTest
-  fun maxzoomAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      maxzoom(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.maxzoomAsExpression?.toString())
   }
 
   @Test
@@ -123,18 +88,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun attributionAsExpressionTest() {
-    val expression = literal("abc")
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      attribution(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.attributionAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun bufferTest() {
     val testSource = geoJsonSource("testId") {
       url(TEST_URI)
@@ -142,18 +95,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(1L, testSource.buffer)
-  }
-
-  @Test
-  @UiThreadTest
-  fun bufferAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      buffer(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.bufferAsExpression?.toString())
   }
 
   @Test
@@ -169,18 +110,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun toleranceAsExpressionTest() {
-    val expression = literal(1.0)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      tolerance(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.toleranceAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun clusterTest() {
     val testSource = geoJsonSource("testId") {
       url(TEST_URI)
@@ -188,18 +117,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(true, testSource.cluster)
-  }
-
-  @Test
-  @UiThreadTest
-  fun clusterAsExpressionTest() {
-    val expression = literal(true)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      cluster(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.clusterAsExpression?.toString())
   }
 
   @Test
@@ -215,18 +132,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun clusterRadiusAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      clusterRadius(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.clusterRadiusAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun clusterMaxZoomTest() {
     val testSource = geoJsonSource("testId") {
       url(TEST_URI)
@@ -234,18 +139,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(1L, testSource.clusterMaxZoom)
-  }
-
-  @Test
-  @UiThreadTest
-  fun clusterMaxZoomAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      clusterMaxZoom(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.clusterMaxZoomAsExpression?.toString())
   }
 
   @Test
@@ -258,19 +151,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals((hashMapOf("key1" to "x", "key2" to "y") as HashMap<String, Any>), testSource.clusterProperties)
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun clusterPropertiesAsExpressionTest() {
-    val expression = literal(hashMapOf("key1" to "x", "key2" to "y") as HashMap<String, Any>)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      clusterProperties(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.clusterPropertiesAsExpression?.toString())
   }
 
   @Test
@@ -348,18 +228,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun lineMetricsAsExpressionTest() {
-    val expression = literal(true)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      lineMetrics(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.lineMetricsAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun generateIdTest() {
     val testSource = geoJsonSource("testId") {
       url(TEST_URI)
@@ -367,18 +235,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(true, testSource.generateId)
-  }
-
-  @Test
-  @UiThreadTest
-  fun generateIdAsExpressionTest() {
-    val expression = literal(true)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      generateId(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.generateIdAsExpression?.toString())
   }
 
   @Test
@@ -401,18 +257,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
     setupSource(testSource)
     testSource.prefetchZoomDelta(1L)
     assertEquals(1L, testSource.prefetchZoomDelta)
-  }
-
-  @Test
-  @UiThreadTest
-  fun prefetchZoomDeltaAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = geoJsonSource("testId") {
-      url(TEST_URI)
-      prefetchZoomDelta(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
   }
 
   @Test
@@ -596,23 +440,14 @@ class GeoJsonSourceTest : BaseStyleTest() {
   @UiThreadTest
   fun defaultSourcePropertiesTest() {
     assertNotNull("defaultMaxzoom should not be null", GeoJsonSource.defaultMaxzoom)
-    assertNotNull("defaultMaxzoomAsExpression should not be null", GeoJsonSource.defaultMaxzoomAsExpression)
     assertNotNull("defaultBuffer should not be null", GeoJsonSource.defaultBuffer)
-    assertNotNull("defaultBufferAsExpression should not be null", GeoJsonSource.defaultBufferAsExpression)
     assertNotNull("defaultTolerance should not be null", GeoJsonSource.defaultTolerance)
-    assertNotNull("defaultToleranceAsExpression should not be null", GeoJsonSource.defaultToleranceAsExpression)
     assertNotNull("defaultCluster should not be null", GeoJsonSource.defaultCluster)
-    assertNotNull("defaultClusterAsExpression should not be null", GeoJsonSource.defaultClusterAsExpression)
     assertNotNull("defaultClusterRadius should not be null", GeoJsonSource.defaultClusterRadius)
-    assertNotNull("defaultClusterRadiusAsExpression should not be null", GeoJsonSource.defaultClusterRadiusAsExpression)
     assertNotNull("defaultClusterMaxZoom should not be null", GeoJsonSource.defaultClusterMaxZoom)
-    assertNotNull("defaultClusterMaxZoomAsExpression should not be null", GeoJsonSource.defaultClusterMaxZoomAsExpression)
     assertNotNull("defaultLineMetrics should not be null", GeoJsonSource.defaultLineMetrics)
-    assertNotNull("defaultLineMetricsAsExpression should not be null", GeoJsonSource.defaultLineMetricsAsExpression)
     assertNotNull("defaultGenerateId should not be null", GeoJsonSource.defaultGenerateId)
-    assertNotNull("defaultGenerateIdAsExpression should not be null", GeoJsonSource.defaultGenerateIdAsExpression)
     assertNotNull("defaultPrefetchZoomDelta should not be null", GeoJsonSource.defaultPrefetchZoomDelta)
-    assertNotNull("defaultPrefetchZoomDeltaAsExpression should not be null", GeoJsonSource.defaultPrefetchZoomDeltaAsExpression)
   }
 
   companion object {

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/ImageSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/ImageSourceTest.kt
@@ -4,12 +4,10 @@ package com.mapbox.maps.testapp.style.sources.generated
 
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.sources.generated.*
 import com.mapbox.maps.testapp.style.BaseStyleTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -45,19 +43,6 @@ class ImageSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun urlAsExpressionTest() {
-    val expression = literal("abc")
-    val testSource = imageSource("testId") {
-      url(TEST_URI)
-      coordinates(TEST_COORDINATES)
-      url(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.urlAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun coordinatesTest() {
     val testSource = imageSource("testId") {
       url(TEST_URI)
@@ -78,20 +63,6 @@ class ImageSourceTest : BaseStyleTest() {
     setupSource(testSource)
     testSource.coordinates(listOf(listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0)))
     assertEquals(listOf(listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0)), testSource.coordinates)
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/500")
-  fun coordinatesAsExpressionTest() {
-    val expression = literal(listOf(listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0)))
-    val testSource = imageSource("testId") {
-      url(TEST_URI)
-      coordinates(TEST_COORDINATES)
-      coordinates(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.coordinatesAsExpression?.toString())
   }
 
   @Test
@@ -118,26 +89,12 @@ class ImageSourceTest : BaseStyleTest() {
     assertEquals(1L, testSource.prefetchZoomDelta)
   }
 
-  @Test
-  @UiThreadTest
-  fun prefetchZoomDeltaAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = imageSource("testId") {
-      url(TEST_URI)
-      coordinates(TEST_COORDINATES)
-      prefetchZoomDelta(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
-  }
-
   // Default source properties getter tests
 
   @Test
   @UiThreadTest
   fun defaultSourcePropertiesTest() {
     assertNotNull("defaultPrefetchZoomDelta should not be null", ImageSource.defaultPrefetchZoomDelta)
-    assertNotNull("defaultPrefetchZoomDeltaAsExpression should not be null", ImageSource.defaultPrefetchZoomDeltaAsExpression)
   }
 
   companion object {

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/RasterDemSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/RasterDemSourceTest.kt
@@ -4,7 +4,6 @@ package com.mapbox.maps.testapp.style.sources.generated
 
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.sources.generated.*
 import com.mapbox.maps.testapp.style.BaseStyleTest
@@ -44,18 +43,6 @@ class RasterDemSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun urlAsExpressionTest() {
-    val expression = literal("abc")
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      url(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.urlAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun tilesTest() {
     val testSource = rasterDemSource("testId") {
@@ -80,19 +67,6 @@ class RasterDemSourceTest : BaseStyleTest() {
   @Test
   @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun tilesAsExpressionTest() {
-    val expression = literal(listOf("a", "b", "c"))
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      tiles(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.tilesAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun boundsTest() {
     val testSource = rasterDemSource("testId") {
       url(TEST_URI)
@@ -100,19 +74,6 @@ class RasterDemSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(listOf(0.0, 1.0, 2.0, 3.0), testSource.bounds)
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun boundsAsExpressionTest() {
-    val expression = literal(listOf(0.0, 1.0, 2.0, 3.0))
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      bounds(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.boundsAsExpression?.toString())
   }
 
   @Test
@@ -139,18 +100,6 @@ class RasterDemSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun minzoomAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      minzoom(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.minzoomAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun maxzoomTest() {
     val testSource = rasterDemSource("testId") {
       url(TEST_URI)
@@ -173,18 +122,6 @@ class RasterDemSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun maxzoomAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      maxzoom(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.maxzoomAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun tileSizeTest() {
     val testSource = rasterDemSource("testId") {
       url(TEST_URI)
@@ -192,18 +129,6 @@ class RasterDemSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(1L, testSource.tileSize)
-  }
-
-  @Test
-  @UiThreadTest
-  fun tileSizeAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      tileSize(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.tileSizeAsExpression?.toString())
   }
 
   @Test
@@ -221,19 +146,6 @@ class RasterDemSourceTest : BaseStyleTest() {
   @Test
   @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun attributionAsExpressionTest() {
-    val expression = literal("abc")
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      attribution(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.attributionAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun encodingTest() {
     val testSource = rasterDemSource("testId") {
       url(TEST_URI)
@@ -241,19 +153,6 @@ class RasterDemSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(Encoding.TERRARIUM, testSource.encoding)
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun encodingAsExpressionTest() {
-    val expression = literal("terrarium")
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      encoding(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.encodingAsExpression?.toString())
   }
 
   @Test
@@ -280,18 +179,6 @@ class RasterDemSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun volatileAsExpressionTest() {
-    val expression = literal(true)
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      volatile(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.volatileAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun prefetchZoomDeltaTest() {
     val testSource = rasterDemSource("testId") {
       url(TEST_URI)
@@ -310,18 +197,6 @@ class RasterDemSourceTest : BaseStyleTest() {
     setupSource(testSource)
     testSource.prefetchZoomDelta(1L)
     assertEquals(1L, testSource.prefetchZoomDelta)
-  }
-
-  @Test
-  @UiThreadTest
-  fun prefetchZoomDeltaAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      prefetchZoomDelta(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
   }
 
   @Test
@@ -348,18 +223,6 @@ class RasterDemSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun minimumTileUpdateIntervalAsExpressionTest() {
-    val expression = literal(1.0)
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      minimumTileUpdateInterval(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.minimumTileUpdateIntervalAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun maxOverscaleFactorForParentTilesTest() {
     val testSource = rasterDemSource("testId") {
       url(TEST_URI)
@@ -378,18 +241,6 @@ class RasterDemSourceTest : BaseStyleTest() {
     setupSource(testSource)
     testSource.maxOverscaleFactorForParentTiles(1L)
     assertEquals(1L, testSource.maxOverscaleFactorForParentTiles)
-  }
-
-  @Test
-  @UiThreadTest
-  fun maxOverscaleFactorForParentTilesAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterDemSource("testId") {
-      url(TEST_URI)
-      maxOverscaleFactorForParentTiles(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.maxOverscaleFactorForParentTilesAsExpression?.toString())
   }
 
   @Test
@@ -420,17 +271,11 @@ class RasterDemSourceTest : BaseStyleTest() {
   @UiThreadTest
   fun defaultSourcePropertiesTest() {
     assertNotNull("defaultMinzoom should not be null", RasterDemSource.defaultMinzoom)
-    assertNotNull("defaultMinzoomAsExpression should not be null", RasterDemSource.defaultMinzoomAsExpression)
     assertNotNull("defaultMaxzoom should not be null", RasterDemSource.defaultMaxzoom)
-    assertNotNull("defaultMaxzoomAsExpression should not be null", RasterDemSource.defaultMaxzoomAsExpression)
     assertNotNull("defaultEncoding should not be null", RasterDemSource.defaultEncoding)
-    assertNotNull("defaultEncodingAsExpression should not be null", RasterDemSource.defaultEncodingAsExpression)
     assertNotNull("defaultVolatile should not be null", RasterDemSource.defaultVolatile)
-    assertNotNull("defaultVolatileAsExpression should not be null", RasterDemSource.defaultVolatileAsExpression)
     assertNotNull("defaultPrefetchZoomDelta should not be null", RasterDemSource.defaultPrefetchZoomDelta)
-    assertNotNull("defaultPrefetchZoomDeltaAsExpression should not be null", RasterDemSource.defaultPrefetchZoomDeltaAsExpression)
     assertNotNull("defaultMinimumTileUpdateInterval should not be null", RasterDemSource.defaultMinimumTileUpdateInterval)
-    assertNotNull("defaultMinimumTileUpdateIntervalAsExpression should not be null", RasterDemSource.defaultMinimumTileUpdateIntervalAsExpression)
   }
 
   companion object {

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/RasterSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/RasterSourceTest.kt
@@ -4,7 +4,6 @@ package com.mapbox.maps.testapp.style.sources.generated
 
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.sources.generated.*
 import com.mapbox.maps.testapp.style.BaseStyleTest
@@ -44,18 +43,6 @@ class RasterSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun urlAsExpressionTest() {
-    val expression = literal("abc")
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      url(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.urlAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun tilesTest() {
     val testSource = rasterSource("testId") {
@@ -80,19 +67,6 @@ class RasterSourceTest : BaseStyleTest() {
   @Test
   @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun tilesAsExpressionTest() {
-    val expression = literal(listOf("a", "b", "c"))
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      tiles(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.tilesAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun boundsTest() {
     val testSource = rasterSource("testId") {
       url(TEST_URI)
@@ -100,19 +74,6 @@ class RasterSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(listOf(0.0, 1.0, 2.0, 3.0), testSource.bounds)
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun boundsAsExpressionTest() {
-    val expression = literal(listOf(0.0, 1.0, 2.0, 3.0))
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      bounds(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.boundsAsExpression?.toString())
   }
 
   @Test
@@ -139,18 +100,6 @@ class RasterSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun minzoomAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      minzoom(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.minzoomAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun maxzoomTest() {
     val testSource = rasterSource("testId") {
       url(TEST_URI)
@@ -173,18 +122,6 @@ class RasterSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun maxzoomAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      maxzoom(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.maxzoomAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun tileSizeTest() {
     val testSource = rasterSource("testId") {
       url(TEST_URI)
@@ -192,18 +129,6 @@ class RasterSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(1L, testSource.tileSize)
-  }
-
-  @Test
-  @UiThreadTest
-  fun tileSizeAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      tileSize(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.tileSizeAsExpression?.toString())
   }
 
   @Test
@@ -221,19 +146,6 @@ class RasterSourceTest : BaseStyleTest() {
   @Test
   @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun schemeAsExpressionTest() {
-    val expression = literal("xyz")
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      scheme(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.schemeAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun attributionTest() {
     val testSource = rasterSource("testId") {
       url(TEST_URI)
@@ -241,19 +153,6 @@ class RasterSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals("abc", testSource.attribution)
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun attributionAsExpressionTest() {
-    val expression = literal("abc")
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      attribution(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.attributionAsExpression?.toString())
   }
 
   @Test
@@ -280,18 +179,6 @@ class RasterSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun volatileAsExpressionTest() {
-    val expression = literal(true)
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      volatile(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.volatileAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun prefetchZoomDeltaTest() {
     val testSource = rasterSource("testId") {
       url(TEST_URI)
@@ -310,18 +197,6 @@ class RasterSourceTest : BaseStyleTest() {
     setupSource(testSource)
     testSource.prefetchZoomDelta(1L)
     assertEquals(1L, testSource.prefetchZoomDelta)
-  }
-
-  @Test
-  @UiThreadTest
-  fun prefetchZoomDeltaAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      prefetchZoomDelta(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
   }
 
   @Test
@@ -348,18 +223,6 @@ class RasterSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun minimumTileUpdateIntervalAsExpressionTest() {
-    val expression = literal(1.0)
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      minimumTileUpdateInterval(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.minimumTileUpdateIntervalAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun maxOverscaleFactorForParentTilesTest() {
     val testSource = rasterSource("testId") {
       url(TEST_URI)
@@ -378,18 +241,6 @@ class RasterSourceTest : BaseStyleTest() {
     setupSource(testSource)
     testSource.maxOverscaleFactorForParentTiles(1L)
     assertEquals(1L, testSource.maxOverscaleFactorForParentTiles)
-  }
-
-  @Test
-  @UiThreadTest
-  fun maxOverscaleFactorForParentTilesAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = rasterSource("testId") {
-      url(TEST_URI)
-      maxOverscaleFactorForParentTiles(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.maxOverscaleFactorForParentTilesAsExpression?.toString())
   }
 
   @Test
@@ -420,17 +271,11 @@ class RasterSourceTest : BaseStyleTest() {
   @UiThreadTest
   fun defaultSourcePropertiesTest() {
     assertNotNull("defaultMinzoom should not be null", RasterSource.defaultMinzoom)
-    assertNotNull("defaultMinzoomAsExpression should not be null", RasterSource.defaultMinzoomAsExpression)
     assertNotNull("defaultMaxzoom should not be null", RasterSource.defaultMaxzoom)
-    assertNotNull("defaultMaxzoomAsExpression should not be null", RasterSource.defaultMaxzoomAsExpression)
     assertNotNull("defaultScheme should not be null", RasterSource.defaultScheme)
-    assertNotNull("defaultSchemeAsExpression should not be null", RasterSource.defaultSchemeAsExpression)
     assertNotNull("defaultVolatile should not be null", RasterSource.defaultVolatile)
-    assertNotNull("defaultVolatileAsExpression should not be null", RasterSource.defaultVolatileAsExpression)
     assertNotNull("defaultPrefetchZoomDelta should not be null", RasterSource.defaultPrefetchZoomDelta)
-    assertNotNull("defaultPrefetchZoomDeltaAsExpression should not be null", RasterSource.defaultPrefetchZoomDeltaAsExpression)
     assertNotNull("defaultMinimumTileUpdateInterval should not be null", RasterSource.defaultMinimumTileUpdateInterval)
-    assertNotNull("defaultMinimumTileUpdateIntervalAsExpression should not be null", RasterSource.defaultMinimumTileUpdateIntervalAsExpression)
   }
 
   companion object {

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/VectorSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/VectorSourceTest.kt
@@ -4,7 +4,6 @@ package com.mapbox.maps.testapp.style.sources.generated
 
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.sources.generated.*
 import com.mapbox.maps.testapp.style.BaseStyleTest
@@ -44,18 +43,6 @@ class VectorSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun urlAsExpressionTest() {
-    val expression = literal("abc")
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      url(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.urlAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun tilesTest() {
     val testSource = vectorSource("testId") {
@@ -80,19 +67,6 @@ class VectorSourceTest : BaseStyleTest() {
   @Test
   @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun tilesAsExpressionTest() {
-    val expression = literal(listOf("a", "b", "c"))
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      tiles(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.tilesAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun boundsTest() {
     val testSource = vectorSource("testId") {
       url(TEST_URI)
@@ -105,19 +79,6 @@ class VectorSourceTest : BaseStyleTest() {
   @Test
   @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun boundsAsExpressionTest() {
-    val expression = literal(listOf(0.0, 1.0, 2.0, 3.0))
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      bounds(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.boundsAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun schemeTest() {
     val testSource = vectorSource("testId") {
       url(TEST_URI)
@@ -125,19 +86,6 @@ class VectorSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals(Scheme.XYZ, testSource.scheme)
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun schemeAsExpressionTest() {
-    val expression = literal("xyz")
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      scheme(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.schemeAsExpression?.toString())
   }
 
   @Test
@@ -164,18 +112,6 @@ class VectorSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun minzoomAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      minzoom(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.minzoomAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun maxzoomTest() {
     val testSource = vectorSource("testId") {
       url(TEST_URI)
@@ -198,18 +134,6 @@ class VectorSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun maxzoomAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      maxzoom(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.maxzoomAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
   fun attributionTest() {
     val testSource = vectorSource("testId") {
@@ -218,19 +142,6 @@ class VectorSourceTest : BaseStyleTest() {
     }
     setupSource(testSource)
     assertEquals("abc", testSource.attribution)
-  }
-
-  @Test
-  @UiThreadTest
-  @Ignore("https://github.com/mapbox/mapbox-maps-android/issues/499")
-  fun attributionAsExpressionTest() {
-    val expression = literal("abc")
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      attribution(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.attributionAsExpression?.toString())
   }
 
   @Test
@@ -257,18 +168,6 @@ class VectorSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun volatileAsExpressionTest() {
-    val expression = literal(true)
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      volatile(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.volatileAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun prefetchZoomDeltaTest() {
     val testSource = vectorSource("testId") {
       url(TEST_URI)
@@ -287,18 +186,6 @@ class VectorSourceTest : BaseStyleTest() {
     setupSource(testSource)
     testSource.prefetchZoomDelta(1L)
     assertEquals(1L, testSource.prefetchZoomDelta)
-  }
-
-  @Test
-  @UiThreadTest
-  fun prefetchZoomDeltaAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      prefetchZoomDelta(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
   }
 
   @Test
@@ -325,18 +212,6 @@ class VectorSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun minimumTileUpdateIntervalAsExpressionTest() {
-    val expression = literal(1.0)
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      minimumTileUpdateInterval(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.minimumTileUpdateIntervalAsExpression?.toString())
-  }
-
-  @Test
-  @UiThreadTest
   fun maxOverscaleFactorForParentTilesTest() {
     val testSource = vectorSource("testId") {
       url(TEST_URI)
@@ -355,18 +230,6 @@ class VectorSourceTest : BaseStyleTest() {
     setupSource(testSource)
     testSource.maxOverscaleFactorForParentTiles(1L)
     assertEquals(1L, testSource.maxOverscaleFactorForParentTiles)
-  }
-
-  @Test
-  @UiThreadTest
-  fun maxOverscaleFactorForParentTilesAsExpressionTest() {
-    val expression = literal(1L)
-    val testSource = vectorSource("testId") {
-      url(TEST_URI)
-      maxOverscaleFactorForParentTiles(expression)
-    }
-    setupSource(testSource)
-    assertEquals(expression.toString(), testSource.maxOverscaleFactorForParentTilesAsExpression?.toString())
   }
 
   @Test
@@ -397,17 +260,11 @@ class VectorSourceTest : BaseStyleTest() {
   @UiThreadTest
   fun defaultSourcePropertiesTest() {
     assertNotNull("defaultScheme should not be null", VectorSource.defaultScheme)
-    assertNotNull("defaultSchemeAsExpression should not be null", VectorSource.defaultSchemeAsExpression)
     assertNotNull("defaultMinzoom should not be null", VectorSource.defaultMinzoom)
-    assertNotNull("defaultMinzoomAsExpression should not be null", VectorSource.defaultMinzoomAsExpression)
     assertNotNull("defaultMaxzoom should not be null", VectorSource.defaultMaxzoom)
-    assertNotNull("defaultMaxzoomAsExpression should not be null", VectorSource.defaultMaxzoomAsExpression)
     assertNotNull("defaultVolatile should not be null", VectorSource.defaultVolatile)
-    assertNotNull("defaultVolatileAsExpression should not be null", VectorSource.defaultVolatileAsExpression)
     assertNotNull("defaultPrefetchZoomDelta should not be null", VectorSource.defaultPrefetchZoomDelta)
-    assertNotNull("defaultPrefetchZoomDeltaAsExpression should not be null", VectorSource.defaultPrefetchZoomDeltaAsExpression)
     assertNotNull("defaultMinimumTileUpdateInterval should not be null", VectorSource.defaultMinimumTileUpdateInterval)
-    assertNotNull("defaultMinimumTileUpdateIntervalAsExpression should not be null", VectorSource.defaultMinimumTileUpdateIntervalAsExpression)
   }
 
   companion object {

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -105,18 +105,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
   /**
    * A URL to a GeoJSON file, or inline GeoJSON.
    *
-   * If method is called while another asynchronous method is parsing data - asynchronous method will not
-   * apply when data is parsed.
-   */
-  fun data(value: Expression) = apply {
-    ignoreParsedGeoJsonRegistry[sourceId] = true
-    workerHandler.removeCallbacksAndMessages(null)
-    setProperty(PropertyValue("data", value))
-  }
-
-  /**
-   * A URL to a GeoJSON file, or inline GeoJSON.
-   *
    * Note: Getter for plain Geojson string data is not supported due to performance consideration.
    */
   val data: String?
@@ -129,36 +117,8 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
 
   /**
    * A URL to a GeoJSON file, or inline GeoJSON.
-   *
-   * Note: Getter for plain Geojson string data is not supported due to performance consideration.
-   */
-  val dataAsExpression: Expression?
-    /**
-     * Get the Data property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("data")?.let {
-        return it
-      }
-      data?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
-   * A URL to a GeoJSON file, or inline GeoJSON.
    */
   fun url(value: String) = apply {
-    data(value)
-  }
-
-  /**
-   * A URL to a GeoJSON file, or inline GeoJSON.
-   */
-  fun url(value: Expression) = apply {
     data(value)
   }
 
@@ -175,26 +135,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("maxzoom")
 
   /**
-   * Maximum zoom level at which to create vector tiles (higher means greater detail at high zoom
-   * levels).
-   */
-  val maxzoomAsExpression: Expression?
-    /**
-     * Get the Maxzoom property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("maxzoom")?.let {
-        return it
-      }
-      maxzoom?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Contains an attribution to be displayed when the map is shown to a user.
    */
   val attribution: String?
@@ -204,25 +144,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return String
      */
     get() = getPropertyValue("attribution")
-
-  /**
-   * Contains an attribution to be displayed when the map is shown to a user.
-   */
-  val attributionAsExpression: Expression?
-    /**
-     * Get the Attribution property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("attribution")?.let {
-        return it
-      }
-      attribution?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Size of the tile buffer on each side. A value of 0 produces no buffer. A
@@ -238,27 +159,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("buffer")
 
   /**
-   * Size of the tile buffer on each side. A value of 0 produces no buffer. A
-   * value of 512 produces a buffer as wide as the tile itself. Larger values produce fewer
-   * rendering artifacts near tile edges and slower performance.
-   */
-  val bufferAsExpression: Expression?
-    /**
-     * Get the Buffer property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("buffer")?.let {
-        return it
-      }
-      buffer?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Douglas-Peucker simplification tolerance (higher means simpler geometries and faster performance).
    */
   val tolerance: Double?
@@ -268,25 +168,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return Double
      */
     get() = getPropertyValue("tolerance")
-
-  /**
-   * Douglas-Peucker simplification tolerance (higher means simpler geometries and faster performance).
-   */
-  val toleranceAsExpression: Expression?
-    /**
-     * Get the Tolerance property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("tolerance")?.let {
-        return it
-      }
-      tolerance?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * If the data is a collection of point features, setting this to true clusters the points
@@ -306,31 +187,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("cluster")
 
   /**
-   * If the data is a collection of point features, setting this to true clusters the points
-   * by radius into groups. Cluster groups become new `Point` features in the source with additional properties:
-   * - `cluster` Is `true` if the point is a cluster
-   * - `cluster_id` A unqiue id for the cluster to be used in conjunction with the
-   * [cluster inspection methods](https://www.mapbox.com/mapbox-gl-js/api/#geojsonsource#getclusterexpansionzoom)
-   * - `point_count` Number of original points grouped into this cluster
-   * - `point_count_abbreviated` An abbreviated point count
-   */
-  val clusterAsExpression: Expression?
-    /**
-     * Get the Cluster property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("cluster")?.let {
-        return it
-      }
-      cluster?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Radius of each cluster if clustering is enabled. A value of 512 indicates a radius equal
    * to the width of a tile.
    */
@@ -341,26 +197,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return Long
      */
     get() = getPropertyValue("clusterRadius")
-
-  /**
-   * Radius of each cluster if clustering is enabled. A value of 512 indicates a radius equal
-   * to the width of a tile.
-   */
-  val clusterRadiusAsExpression: Expression?
-    /**
-     * Get the ClusterRadius property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("clusterRadius")?.let {
-        return it
-      }
-      clusterRadius?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less
@@ -374,27 +210,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return Long
      */
     get() = getPropertyValue("clusterMaxZoom")
-
-  /**
-   * Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less
-   * than maxzoom (so that last zoom features are not clustered). Clusters are re-evaluated at integer zoom
-   * levels so setting clusterMaxZoom to 14 means the clusters will be displayed until z15.
-   */
-  val clusterMaxZoomAsExpression: Expression?
-    /**
-     * Get the ClusterMaxZoom property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("clusterMaxZoom")?.let {
-        return it
-      }
-      clusterMaxZoom?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * An object defining custom properties on the generated clusters if clustering is enabled, aggregating values from
@@ -417,34 +232,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("clusterProperties")
 
   /**
-   * An object defining custom properties on the generated clusters if clustering is enabled, aggregating values from
-   * clustered points. Has the form `{"property_name": [operator, map_expression]}`. `operator` is any expression function that accepts at
-   * least 2 operands (e.g. `"+"` or `"max"`) — it accumulates the property value from clusters/points the
-   * cluster contains; `map_expression` produces the value of a single point.
-   *
-   * Example: `{"sum": ["+", ["get", "scalerank"]]}`.
-   *
-   * For more advanced use cases, in place of `operator`, you can use a custom reduce expression
-   * that references a special `["accumulated"]` value, e.g.:
-   * `{"sum": [["+", ["accumulated"], ["get", "sum"]], ["get", "scalerank"]]}`
-   */
-  val clusterPropertiesAsExpression: Expression?
-    /**
-     * Get the ClusterProperties property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("clusterProperties")?.let {
-        return it
-      }
-      clusterProperties?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Whether to calculate line distance metrics. This is required for line layers that specify `line-gradient` values.
    */
   val lineMetrics: Boolean?
@@ -454,25 +241,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return Boolean
      */
     get() = getPropertyValue("lineMetrics")
-
-  /**
-   * Whether to calculate line distance metrics. This is required for line layers that specify `line-gradient` values.
-   */
-  val lineMetricsAsExpression: Expression?
-    /**
-     * Get the LineMetrics property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("lineMetrics")?.let {
-        return it
-      }
-      lineMetrics?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
@@ -485,26 +253,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return Boolean
      */
     get() = getPropertyValue("generateId")
-
-  /**
-   * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
-   * assigned based on its index in the `features` array, over-writing any previous values.
-   */
-  val generateIdAsExpression: Expression?
-    /**
-     * Get the GenerateId property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("generateId")?.let {
-        return it
-      }
-      generateId?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
@@ -522,16 +270,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
    * map at lower resolution as quick as possible. It will get clamped at the tile source
    * minimum zoom. The default `delta` is 4.
    */
-  fun prefetchZoomDelta(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("prefetch-zoom-delta", value))
-  }
-
-  /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
   val prefetchZoomDelta: Long?
     /**
      * Get the PrefetchZoomDelta property
@@ -539,28 +277,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return Long
      */
     get() = getPropertyValue("prefetch-zoom-delta")
-
-  /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
-  val prefetchZoomDeltaAsExpression: Expression?
-    /**
-     * Get the PrefetchZoomDelta property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("prefetch-zoom-delta")?.let {
-        return it
-      }
-      prefetchZoomDelta?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Add a Feature to the GeojsonSource.
@@ -676,23 +392,7 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     /**
      * A URL to a GeoJSON file, or inline GeoJSON.
      */
-    fun data(value: Expression) = apply {
-      rawGeoJson = null
-      val propertyValue = PropertyValue("data", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * A URL to a GeoJSON file, or inline GeoJSON.
-     */
     fun url(value: String) = apply {
-      data(value)
-    }
-
-    /**
-     * A URL to a GeoJSON file, or inline GeoJSON.
-     */
-    fun url(value: Expression) = apply {
       data(value)
     }
 
@@ -706,27 +406,10 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Maximum zoom level at which to create vector tiles (higher means greater detail at high zoom
-     * levels).
-     */
-    fun maxzoom(value: Expression) = apply {
-      val propertyValue = PropertyValue("maxzoom", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
     fun attribution(value: String) = apply {
       val propertyValue = PropertyValue("attribution", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Contains an attribution to be displayed when the map is shown to a user.
-     */
-    fun attribution(value: Expression) = apply {
-      val propertyValue = PropertyValue("attribution", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -741,28 +424,10 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Size of the tile buffer on each side. A value of 0 produces no buffer. A
-     * value of 512 produces a buffer as wide as the tile itself. Larger values produce fewer
-     * rendering artifacts near tile edges and slower performance.
-     */
-    fun buffer(value: Expression) = apply {
-      val propertyValue = PropertyValue("buffer", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Douglas-Peucker simplification tolerance (higher means simpler geometries and faster performance).
      */
     fun tolerance(value: Double = 0.375) = apply {
       val propertyValue = PropertyValue("tolerance", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Douglas-Peucker simplification tolerance (higher means simpler geometries and faster performance).
-     */
-    fun tolerance(value: Expression) = apply {
-      val propertyValue = PropertyValue("tolerance", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -781,34 +446,11 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * If the data is a collection of point features, setting this to true clusters the points
-     * by radius into groups. Cluster groups become new `Point` features in the source with additional properties:
-     * - `cluster` Is `true` if the point is a cluster
-     * - `cluster_id` A unqiue id for the cluster to be used in conjunction with the
-     * [cluster inspection methods](https://www.mapbox.com/mapbox-gl-js/api/#geojsonsource#getclusterexpansionzoom)
-     * - `point_count` Number of original points grouped into this cluster
-     * - `point_count_abbreviated` An abbreviated point count
-     */
-    fun cluster(value: Expression) = apply {
-      val propertyValue = PropertyValue("cluster", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Radius of each cluster if clustering is enabled. A value of 512 indicates a radius equal
      * to the width of a tile.
      */
     fun clusterRadius(value: Long = 50L) = apply {
       val propertyValue = PropertyValue("clusterRadius", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Radius of each cluster if clustering is enabled. A value of 512 indicates a radius equal
-     * to the width of a tile.
-     */
-    fun clusterRadius(value: Expression) = apply {
-      val propertyValue = PropertyValue("clusterRadius", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -819,16 +461,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      */
     fun clusterMaxZoom(value: Long) = apply {
       val propertyValue = PropertyValue("clusterMaxZoom", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less
-     * than maxzoom (so that last zoom features are not clustered). Clusters are re-evaluated at integer zoom
-     * levels so setting clusterMaxZoom to 14 means the clusters will be displayed until z15.
-     */
-    fun clusterMaxZoom(value: Expression) = apply {
-      val propertyValue = PropertyValue("clusterMaxZoom", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -846,23 +478,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      */
     fun clusterProperties(value: HashMap<String, Any>) = apply {
       val propertyValue = PropertyValue("clusterProperties", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * An object defining custom properties on the generated clusters if clustering is enabled, aggregating values from
-     * clustered points. Has the form `{"property_name": [operator, map_expression]}`. `operator` is any expression function that accepts at
-     * least 2 operands (e.g. `"+"` or `"max"`) — it accumulates the property value from clusters/points the
-     * cluster contains; `map_expression` produces the value of a single point.
-     *
-     * Example: `{"sum": ["+", ["get", "scalerank"]]}`.
-     *
-     * For more advanced use cases, in place of `operator`, you can use a custom reduce expression
-     * that references a special `["accumulated"]` value, e.g.:
-     * `{"sum": [["+", ["accumulated"], ["get", "sum"]], ["get", "scalerank"]]}`
-     */
-    fun clusterProperties(value: Expression) = apply {
-      val propertyValue = PropertyValue("clusterProperties", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -935,28 +550,11 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Whether to calculate line distance metrics. This is required for line layers that specify `line-gradient` values.
-     */
-    fun lineMetrics(value: Expression) = apply {
-      val propertyValue = PropertyValue("lineMetrics", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
      * assigned based on its index in the `features` array, over-writing any previous values.
      */
     fun generateId(value: Boolean = false) = apply {
       val propertyValue = PropertyValue("generateId", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
-     * assigned based on its index in the `features` array, over-writing any previous values.
-     */
-    fun generateId(value: Expression) = apply {
-      val propertyValue = PropertyValue("generateId", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -968,17 +566,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      */
     fun prefetchZoomDelta(value: Long = 4L) = apply {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    fun prefetchZoomDelta(value: Expression) = apply {
-      val propertyValue = PropertyValue("prefetch-zoom-delta", value)
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
 
@@ -1051,26 +638,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "maxzoom").silentUnwrap()
 
     /**
-     * Maximum zoom level at which to create vector tiles (higher means greater detail at high zoom
-     * levels).
-     */
-    val defaultMaxzoomAsExpression: Expression?
-      /**
-       * Get the Maxzoom property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("geojson", "maxzoom").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMaxzoom?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * Size of the tile buffer on each side. A value of 0 produces no buffer. A
      * value of 512 produces a buffer as wide as the tile itself. Larger values produce fewer
      * rendering artifacts near tile edges and slower performance.
@@ -1084,27 +651,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "buffer").silentUnwrap()
 
     /**
-     * Size of the tile buffer on each side. A value of 0 produces no buffer. A
-     * value of 512 produces a buffer as wide as the tile itself. Larger values produce fewer
-     * rendering artifacts near tile edges and slower performance.
-     */
-    val defaultBufferAsExpression: Expression?
-      /**
-       * Get the Buffer property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("geojson", "buffer").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultBuffer?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * Douglas-Peucker simplification tolerance (higher means simpler geometries and faster performance).
      */
     val defaultTolerance: Double?
@@ -1114,25 +660,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        * @return Double
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "tolerance").silentUnwrap()
-
-    /**
-     * Douglas-Peucker simplification tolerance (higher means simpler geometries and faster performance).
-     */
-    val defaultToleranceAsExpression: Expression?
-      /**
-       * Get the Tolerance property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("geojson", "tolerance").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultTolerance?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
 
     /**
      * If the data is a collection of point features, setting this to true clusters the points
@@ -1152,31 +679,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "cluster").silentUnwrap()
 
     /**
-     * If the data is a collection of point features, setting this to true clusters the points
-     * by radius into groups. Cluster groups become new `Point` features in the source with additional properties:
-     * - `cluster` Is `true` if the point is a cluster
-     * - `cluster_id` A unqiue id for the cluster to be used in conjunction with the
-     * [cluster inspection methods](https://www.mapbox.com/mapbox-gl-js/api/#geojsonsource#getclusterexpansionzoom)
-     * - `point_count` Number of original points grouped into this cluster
-     * - `point_count_abbreviated` An abbreviated point count
-     */
-    val defaultClusterAsExpression: Expression?
-      /**
-       * Get the Cluster property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("geojson", "cluster").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultCluster?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * Radius of each cluster if clustering is enabled. A value of 512 indicates a radius equal
      * to the width of a tile.
      */
@@ -1187,26 +689,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        * @return Long
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterRadius").silentUnwrap()
-
-    /**
-     * Radius of each cluster if clustering is enabled. A value of 512 indicates a radius equal
-     * to the width of a tile.
-     */
-    val defaultClusterRadiusAsExpression: Expression?
-      /**
-       * Get the ClusterRadius property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterRadius").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultClusterRadius?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
 
     /**
      * Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less
@@ -1222,27 +704,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterMaxZoom").silentUnwrap()
 
     /**
-     * Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less
-     * than maxzoom (so that last zoom features are not clustered). Clusters are re-evaluated at integer zoom
-     * levels so setting clusterMaxZoom to 14 means the clusters will be displayed until z15.
-     */
-    val defaultClusterMaxZoomAsExpression: Expression?
-      /**
-       * Get the ClusterMaxZoom property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterMaxZoom").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultClusterMaxZoom?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * Whether to calculate line distance metrics. This is required for line layers that specify `line-gradient` values.
      */
     val defaultLineMetrics: Boolean?
@@ -1252,25 +713,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        * @return Boolean
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "lineMetrics").silentUnwrap()
-
-    /**
-     * Whether to calculate line distance metrics. This is required for line layers that specify `line-gradient` values.
-     */
-    val defaultLineMetricsAsExpression: Expression?
-      /**
-       * Get the LineMetrics property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("geojson", "lineMetrics").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultLineMetrics?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
 
     /**
      * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
@@ -1285,26 +727,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId").silentUnwrap()
 
     /**
-     * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
-     * assigned based on its index in the `features` array, over-writing any previous values.
-     */
-    val defaultGenerateIdAsExpression: Expression?
-      /**
-       * Get the GenerateId property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultGenerateId?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
      * will first request a tile for `zoom - delta` in a attempt to display a full
      * map at lower resolution as quick as possible. It will get clamped at the tile source
@@ -1317,28 +739,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        * @return Long
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "prefetch-zoom-delta").silentUnwrap()
-
-    /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    val defaultPrefetchZoomDeltaAsExpression: Expression?
-      /**
-       * Get the PrefetchZoomDelta property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("geojson", "prefetch-zoom-delta").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultPrefetchZoomDelta?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
   }
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -3,7 +3,6 @@
 package com.mapbox.maps.extension.style.sources.generated
 
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.sources.Source
 import com.mapbox.maps.extension.style.types.SourceDsl
@@ -41,13 +40,6 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
   /**
    * URL that points to an image.
    */
-  fun url(value: Expression) = apply {
-    setProperty(PropertyValue("url", value))
-  }
-
-  /**
-   * URL that points to an image.
-   */
   val url: String?
     /**
      * Get the Url property
@@ -57,36 +49,10 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("url")
 
   /**
-   * URL that points to an image.
-   */
-  val urlAsExpression: Expression?
-    /**
-     * Get the Url property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("url")?.let {
-        return it
-      }
-      url?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Corners of image specified in longitude, latitude pairs.
    */
   fun coordinates(value: List<List<Double>>) = apply {
     setProperty(PropertyValue("coordinates", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Corners of image specified in longitude, latitude pairs.
-   */
-  fun coordinates(value: Expression) = apply {
-    setProperty(PropertyValue("coordinates", value))
   }
 
   /**
@@ -99,25 +65,6 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
      * @return List<List<Double>>
      */
     get() = getPropertyValue("coordinates")
-
-  /**
-   * Corners of image specified in longitude, latitude pairs.
-   */
-  val coordinatesAsExpression: Expression?
-    /**
-     * Get the Coordinates property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("coordinates")?.let {
-        return it
-      }
-      coordinates?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
@@ -135,16 +82,6 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
    * map at lower resolution as quick as possible. It will get clamped at the tile source
    * minimum zoom. The default `delta` is 4.
    */
-  fun prefetchZoomDelta(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("prefetch-zoom-delta", value))
-  }
-
-  /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
   val prefetchZoomDelta: Long?
     /**
      * Get the PrefetchZoomDelta property
@@ -152,28 +89,6 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
      * @return Long
      */
     get() = getPropertyValue("prefetch-zoom-delta")
-
-  /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
-  val prefetchZoomDeltaAsExpression: Expression?
-    /**
-     * Get the PrefetchZoomDelta property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("prefetch-zoom-delta")?.let {
-        return it
-      }
-      prefetchZoomDelta?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Builder for ImageSource.
@@ -195,26 +110,10 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * URL that points to an image.
-     */
-    fun url(value: Expression) = apply {
-      val propertyValue = PropertyValue("url", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Corners of image specified in longitude, latitude pairs.
      */
     fun coordinates(value: List<List<Double>>) = apply {
       val propertyValue = PropertyValue("coordinates", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Corners of image specified in longitude, latitude pairs.
-     */
-    fun coordinates(value: Expression) = apply {
-      val propertyValue = PropertyValue("coordinates", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -226,17 +125,6 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
      */
     fun prefetchZoomDelta(value: Long = 4L) = apply {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    fun prefetchZoomDelta(value: Expression) = apply {
-      val propertyValue = PropertyValue("prefetch-zoom-delta", value)
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
     /**
@@ -265,28 +153,6 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
        * @return Long
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("image", "prefetch-zoom-delta").silentUnwrap()
-
-    /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    val defaultPrefetchZoomDeltaAsExpression: Expression?
-      /**
-       * Get the PrefetchZoomDelta property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("image", "prefetch-zoom-delta").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultPrefetchZoomDelta?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
   }
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -3,7 +3,6 @@
 package com.mapbox.maps.extension.style.sources.generated
 
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.sources.Source
 import com.mapbox.maps.extension.style.sources.TileSet
@@ -42,13 +41,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
   /**
    * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
    */
-  fun url(value: Expression) = apply {
-    setProperty(PropertyValue("url", value))
-  }
-
-  /**
-   * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-   */
   val url: String?
     /**
      * Get the Url property
@@ -58,36 +50,10 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("url")
 
   /**
-   * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-   */
-  val urlAsExpression: Expression?
-    /**
-     * Get the Url property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("url")?.let {
-        return it
-      }
-      url?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * An array of one or more tile source URLs, as in the TileJSON spec.
    */
   fun tiles(value: List<String>) = apply {
     setProperty(PropertyValue("tiles", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * An array of one or more tile source URLs, as in the TileJSON spec.
-   */
-  fun tiles(value: Expression) = apply {
-    setProperty(PropertyValue("tiles", value))
   }
 
   /**
@@ -100,25 +66,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
      * @return List<String>
      */
     get() = getPropertyValue("tiles")
-
-  /**
-   * An array of one or more tile source URLs, as in the TileJSON spec.
-   */
-  val tilesAsExpression: Expression?
-    /**
-     * Get the Tiles property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("tiles")?.let {
-        return it
-      }
-      tiles?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * An array containing the longitude and latitude of the southwest and northeast corners of the source's
@@ -134,38 +81,10 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("bounds")
 
   /**
-   * An array containing the longitude and latitude of the southwest and northeast corners of the source's
-   * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
-   * a source, no tiles outside of the given bounds are requested by Mapbox GL.
-   */
-  val boundsAsExpression: Expression?
-    /**
-     * Get the Bounds property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("bounds")?.let {
-        return it
-      }
-      bounds?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Minimum zoom level for which tiles are available, as in the TileJSON spec.
    */
   fun minzoom(value: Long = 0L) = apply {
     setProperty(PropertyValue("minzoom", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-   */
-  fun minzoom(value: Expression) = apply {
-    setProperty(PropertyValue("minzoom", value))
   }
 
   /**
@@ -180,38 +99,11 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("minzoom")
 
   /**
-   * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-   */
-  val minzoomAsExpression: Expression?
-    /**
-     * Get the Minzoom property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("minzoom")?.let {
-        return it
-      }
-      minzoom?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
    * at the maxzoom are used when displaying the map at higher zoom levels.
    */
   fun maxzoom(value: Long = 22L) = apply {
     setProperty(PropertyValue("maxzoom", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-   * at the maxzoom are used when displaying the map at higher zoom levels.
-   */
-  fun maxzoom(value: Expression) = apply {
-    setProperty(PropertyValue("maxzoom", value))
   }
 
   /**
@@ -227,26 +119,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("maxzoom")
 
   /**
-   * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-   * at the maxzoom are used when displaying the map at higher zoom levels.
-   */
-  val maxzoomAsExpression: Expression?
-    /**
-     * Get the Maxzoom property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("maxzoom")?.let {
-        return it
-      }
-      maxzoom?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
    */
   val tileSize: Long?
@@ -258,25 +130,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("tileSize")
 
   /**
-   * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
-   */
-  val tileSizeAsExpression: Expression?
-    /**
-     * Get the TileSize property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("tileSize")?.let {
-        return it
-      }
-      tileSize?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Contains an attribution to be displayed when the map is shown to a user.
    */
   val attribution: String?
@@ -286,25 +139,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
      * @return String
      */
     get() = getPropertyValue("attribution")
-
-  /**
-   * Contains an attribution to be displayed when the map is shown to a user.
-   */
-  val attributionAsExpression: Expression?
-    /**
-     * Get the Attribution property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("attribution")?.let {
-        return it
-      }
-      attribution?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * The encoding used by this source. Mapbox Terrain RGB is used by default
@@ -323,38 +157,10 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     }
 
   /**
-   * The encoding used by this source. Mapbox Terrain RGB is used by default
-   * This is an Expression representation of this Property.
-   *
-   */
-  val encodingAsExpression: Expression?
-    /**
-     * Get the Encoding property as an Expression
-     *
-     * @return expression
-     */
-    get() {
-      getPropertyValue<Expression>("encoding")?.let {
-        return it
-      }
-      encoding?.let {
-        return Expression.literal(it.value)
-      }
-      return null
-    }
-
-  /**
    * A setting to determine whether a source's tiles are cached locally.
    */
   fun volatile(value: Boolean = false) = apply {
     setProperty(PropertyValue("volatile", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * A setting to determine whether a source's tiles are cached locally.
-   */
-  fun volatile(value: Expression) = apply {
-    setProperty(PropertyValue("volatile", value))
   }
 
   /**
@@ -367,25 +173,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
      * @return Boolean
      */
     get() = getPropertyValue("volatile")
-
-  /**
-   * A setting to determine whether a source's tiles are cached locally.
-   */
-  val volatileAsExpression: Expression?
-    /**
-     * Get the Volatile property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("volatile")?.let {
-        return it
-      }
-      volatile?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
@@ -403,16 +190,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
    * map at lower resolution as quick as possible. It will get clamped at the tile source
    * minimum zoom. The default `delta` is 4.
    */
-  fun prefetchZoomDelta(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("prefetch-zoom-delta", value))
-  }
-
-  /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
   val prefetchZoomDelta: Long?
     /**
      * Get the PrefetchZoomDelta property
@@ -422,39 +199,10 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("prefetch-zoom-delta")
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
-  val prefetchZoomDeltaAsExpression: Expression?
-    /**
-     * Get the PrefetchZoomDelta property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("prefetch-zoom-delta")?.let {
-        return it
-      }
-      prefetchZoomDelta?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
    */
   fun minimumTileUpdateInterval(value: Double = 0.0) = apply {
     setVolatileProperty(PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-   */
-  fun minimumTileUpdateInterval(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("minimum-tile-update-interval", value))
   }
 
   /**
@@ -467,25 +215,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
      * @return Double
      */
     get() = getPropertyValue("minimum-tile-update-interval")
-
-  /**
-   * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-   */
-  val minimumTileUpdateIntervalAsExpression: Expression?
-    /**
-     * Get the MinimumTileUpdateInterval property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("minimum-tile-update-interval")?.let {
-        return it
-      }
-      minimumTileUpdateInterval?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * When a set of tiles for a current zoom level is being rendered and some of
@@ -503,16 +232,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
    * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
    * This property sets the maximum limit for how much a parent tile can be overscaled.
    */
-  fun maxOverscaleFactorForParentTiles(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("max-overscale-factor-for-parent-tiles", value))
-  }
-
-  /**
-   * When a set of tiles for a current zoom level is being rendered and some of
-   * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
-   * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
-   * This property sets the maximum limit for how much a parent tile can be overscaled.
-   */
   val maxOverscaleFactorForParentTiles: Long?
     /**
      * Get the MaxOverscaleFactorForParentTiles property
@@ -520,28 +239,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
      * @return Long
      */
     get() = getPropertyValue("max-overscale-factor-for-parent-tiles")
-
-  /**
-   * When a set of tiles for a current zoom level is being rendered and some of
-   * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
-   * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
-   * This property sets the maximum limit for how much a parent tile can be overscaled.
-   */
-  val maxOverscaleFactorForParentTilesAsExpression: Expression?
-    /**
-     * Get the MaxOverscaleFactorForParentTiles property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("max-overscale-factor-for-parent-tiles")?.let {
-        return it
-      }
-      maxOverscaleFactorForParentTiles?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Builder for RasterDemSource.
@@ -563,26 +260,10 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-     */
-    fun url(value: Expression) = apply {
-      val propertyValue = PropertyValue("url", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * An array of one or more tile source URLs, as in the TileJSON spec.
      */
     fun tiles(value: List<String>) = apply {
       val propertyValue = PropertyValue("tiles", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * An array of one or more tile source URLs, as in the TileJSON spec.
-     */
-    fun tiles(value: Expression) = apply {
-      val propertyValue = PropertyValue("tiles", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -597,28 +278,10 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * An array containing the longitude and latitude of the southwest and northeast corners of the source's
-     * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
-     * a source, no tiles outside of the given bounds are requested by Mapbox GL.
-     */
-    fun bounds(value: Expression) = apply {
-      val propertyValue = PropertyValue("bounds", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
     fun minzoom(value: Long = 0L) = apply {
       val propertyValue = PropertyValue("minzoom", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-     */
-    fun minzoom(value: Expression) = apply {
-      val propertyValue = PropertyValue("minzoom", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -632,27 +295,10 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-     * at the maxzoom are used when displaying the map at higher zoom levels.
-     */
-    fun maxzoom(value: Expression) = apply {
-      val propertyValue = PropertyValue("maxzoom", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
      */
     fun tileSize(value: Long = 512L) = apply {
       val propertyValue = PropertyValue("tileSize", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
-     */
-    fun tileSize(value: Expression) = apply {
-      val propertyValue = PropertyValue("tileSize", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -665,14 +311,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Contains an attribution to be displayed when the map is shown to a user.
-     */
-    fun attribution(value: Expression) = apply {
-      val propertyValue = PropertyValue("attribution", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * The encoding used by this source. Mapbox Terrain RGB is used by default
      */
     fun encoding(value: Encoding = Encoding.MAPBOX) = apply {
@@ -681,26 +319,10 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * The encoding used by this source. Mapbox Terrain RGB is used by default
-     */
-    fun encoding(value: Expression) = apply {
-      val propertyValue = PropertyValue("encoding", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * A setting to determine whether a source's tiles are cached locally.
      */
     fun volatile(value: Boolean = false) = apply {
       val propertyValue = PropertyValue("volatile", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * A setting to determine whether a source's tiles are cached locally.
-     */
-    fun volatile(value: Expression) = apply {
-      val propertyValue = PropertyValue("volatile", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -716,29 +338,10 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    fun prefetchZoomDelta(value: Expression) = apply {
-      val propertyValue = PropertyValue("prefetch-zoom-delta", value)
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
      */
     fun minimumTileUpdateInterval(value: Double = 0.0) = apply {
       val propertyValue = PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value))
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-     */
-    fun minimumTileUpdateInterval(value: Expression) = apply {
-      val propertyValue = PropertyValue("minimum-tile-update-interval", value)
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
 
@@ -750,17 +353,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
      */
     fun maxOverscaleFactorForParentTiles(value: Long) = apply {
       val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", TypeUtils.wrapToValue(value))
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * When a set of tiles for a current zoom level is being rendered and some of
-     * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
-     * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
-     * This property sets the maximum limit for how much a parent tile can be overscaled.
-     */
-    fun maxOverscaleFactorForParentTiles(value: Expression) = apply {
-      val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", value)
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
 
@@ -815,25 +407,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "minzoom").silentUnwrap()
 
     /**
-     * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-     */
-    val defaultMinzoomAsExpression: Expression?
-      /**
-       * Get the Minzoom property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "minzoom").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMinzoom?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
      * at the maxzoom are used when displaying the map at higher zoom levels.
      */
@@ -844,26 +417,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
        * @return Long
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "maxzoom").silentUnwrap()
-
-    /**
-     * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-     * at the maxzoom are used when displaying the map at higher zoom levels.
-     */
-    val defaultMaxzoomAsExpression: Expression?
-      /**
-       * Get the Maxzoom property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "maxzoom").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMaxzoom?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
 
     /**
      * The encoding used by this source. Mapbox Terrain RGB is used by default
@@ -882,27 +435,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       }
 
     /**
-     * The encoding used by this source. Mapbox Terrain RGB is used by default
-     * This is an Expression representation of this Property.
-     *
-     */
-    val defaultEncodingAsExpression: Expression?
-      /**
-       * Get the Encoding property as an Expression
-       *
-       * @return expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "encoding").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultEncoding?.let {
-          return Expression.literal(it.value)
-        }
-        return null
-      }
-
-    /**
      * A setting to determine whether a source's tiles are cached locally.
      */
     val defaultVolatile: Boolean?
@@ -912,25 +444,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
        * @return Boolean
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "volatile").silentUnwrap()
-
-    /**
-     * A setting to determine whether a source's tiles are cached locally.
-     */
-    val defaultVolatileAsExpression: Expression?
-      /**
-       * Get the Volatile property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "volatile").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultVolatile?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
 
     /**
      * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
@@ -947,28 +460,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "prefetch-zoom-delta").silentUnwrap()
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    val defaultPrefetchZoomDeltaAsExpression: Expression?
-      /**
-       * Get the PrefetchZoomDelta property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "prefetch-zoom-delta").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultPrefetchZoomDelta?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
      */
     val defaultMinimumTileUpdateInterval: Double?
@@ -978,25 +469,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
        * @return Double
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "minimum-tile-update-interval").silentUnwrap()
-
-    /**
-     * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-     */
-    val defaultMinimumTileUpdateIntervalAsExpression: Expression?
-      /**
-       * Get the MinimumTileUpdateInterval property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "minimum-tile-update-interval").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMinimumTileUpdateInterval?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
   }
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -3,7 +3,6 @@
 package com.mapbox.maps.extension.style.sources.generated
 
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.sources.Source
 import com.mapbox.maps.extension.style.sources.TileSet
@@ -42,13 +41,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
   /**
    * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
    */
-  fun url(value: Expression) = apply {
-    setProperty(PropertyValue("url", value))
-  }
-
-  /**
-   * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-   */
   val url: String?
     /**
      * Get the Url property
@@ -58,36 +50,10 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("url")
 
   /**
-   * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-   */
-  val urlAsExpression: Expression?
-    /**
-     * Get the Url property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("url")?.let {
-        return it
-      }
-      url?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * An array of one or more tile source URLs, as in the TileJSON spec.
    */
   fun tiles(value: List<String>) = apply {
     setProperty(PropertyValue("tiles", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * An array of one or more tile source URLs, as in the TileJSON spec.
-   */
-  fun tiles(value: Expression) = apply {
-    setProperty(PropertyValue("tiles", value))
   }
 
   /**
@@ -100,25 +66,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
      * @return List<String>
      */
     get() = getPropertyValue("tiles")
-
-  /**
-   * An array of one or more tile source URLs, as in the TileJSON spec.
-   */
-  val tilesAsExpression: Expression?
-    /**
-     * Get the Tiles property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("tiles")?.let {
-        return it
-      }
-      tiles?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * An array containing the longitude and latitude of the southwest and northeast corners of the source's
@@ -134,38 +81,10 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("bounds")
 
   /**
-   * An array containing the longitude and latitude of the southwest and northeast corners of the source's
-   * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
-   * a source, no tiles outside of the given bounds are requested by Mapbox GL.
-   */
-  val boundsAsExpression: Expression?
-    /**
-     * Get the Bounds property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("bounds")?.let {
-        return it
-      }
-      bounds?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Minimum zoom level for which tiles are available, as in the TileJSON spec.
    */
   fun minzoom(value: Long = 0L) = apply {
     setProperty(PropertyValue("minzoom", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-   */
-  fun minzoom(value: Expression) = apply {
-    setProperty(PropertyValue("minzoom", value))
   }
 
   /**
@@ -180,38 +99,11 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("minzoom")
 
   /**
-   * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-   */
-  val minzoomAsExpression: Expression?
-    /**
-     * Get the Minzoom property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("minzoom")?.let {
-        return it
-      }
-      minzoom?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
    * at the maxzoom are used when displaying the map at higher zoom levels.
    */
   fun maxzoom(value: Long = 22L) = apply {
     setProperty(PropertyValue("maxzoom", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-   * at the maxzoom are used when displaying the map at higher zoom levels.
-   */
-  fun maxzoom(value: Expression) = apply {
-    setProperty(PropertyValue("maxzoom", value))
   }
 
   /**
@@ -227,26 +119,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("maxzoom")
 
   /**
-   * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-   * at the maxzoom are used when displaying the map at higher zoom levels.
-   */
-  val maxzoomAsExpression: Expression?
-    /**
-     * Get the Maxzoom property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("maxzoom")?.let {
-        return it
-      }
-      maxzoom?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
    */
   val tileSize: Long?
@@ -256,25 +128,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
      * @return Long
      */
     get() = getPropertyValue("tileSize")
-
-  /**
-   * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
-   */
-  val tileSizeAsExpression: Expression?
-    /**
-     * Get the TileSize property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("tileSize")?.let {
-        return it
-      }
-      tileSize?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
@@ -293,27 +146,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     }
 
   /**
-   * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
-   * This is an Expression representation of this Property.
-   *
-   */
-  val schemeAsExpression: Expression?
-    /**
-     * Get the Scheme property as an Expression
-     *
-     * @return expression
-     */
-    get() {
-      getPropertyValue<Expression>("scheme")?.let {
-        return it
-      }
-      scheme?.let {
-        return Expression.literal(it.value)
-      }
-      return null
-    }
-
-  /**
    * Contains an attribution to be displayed when the map is shown to a user.
    */
   val attribution: String?
@@ -325,36 +157,10 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("attribution")
 
   /**
-   * Contains an attribution to be displayed when the map is shown to a user.
-   */
-  val attributionAsExpression: Expression?
-    /**
-     * Get the Attribution property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("attribution")?.let {
-        return it
-      }
-      attribution?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * A setting to determine whether a source's tiles are cached locally.
    */
   fun volatile(value: Boolean = false) = apply {
     setProperty(PropertyValue("volatile", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * A setting to determine whether a source's tiles are cached locally.
-   */
-  fun volatile(value: Expression) = apply {
-    setProperty(PropertyValue("volatile", value))
   }
 
   /**
@@ -367,25 +173,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
      * @return Boolean
      */
     get() = getPropertyValue("volatile")
-
-  /**
-   * A setting to determine whether a source's tiles are cached locally.
-   */
-  val volatileAsExpression: Expression?
-    /**
-     * Get the Volatile property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("volatile")?.let {
-        return it
-      }
-      volatile?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
@@ -403,16 +190,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
    * map at lower resolution as quick as possible. It will get clamped at the tile source
    * minimum zoom. The default `delta` is 4.
    */
-  fun prefetchZoomDelta(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("prefetch-zoom-delta", value))
-  }
-
-  /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
   val prefetchZoomDelta: Long?
     /**
      * Get the PrefetchZoomDelta property
@@ -422,39 +199,10 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("prefetch-zoom-delta")
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
-  val prefetchZoomDeltaAsExpression: Expression?
-    /**
-     * Get the PrefetchZoomDelta property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("prefetch-zoom-delta")?.let {
-        return it
-      }
-      prefetchZoomDelta?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
    */
   fun minimumTileUpdateInterval(value: Double = 0.0) = apply {
     setVolatileProperty(PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-   */
-  fun minimumTileUpdateInterval(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("minimum-tile-update-interval", value))
   }
 
   /**
@@ -467,25 +215,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
      * @return Double
      */
     get() = getPropertyValue("minimum-tile-update-interval")
-
-  /**
-   * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-   */
-  val minimumTileUpdateIntervalAsExpression: Expression?
-    /**
-     * Get the MinimumTileUpdateInterval property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("minimum-tile-update-interval")?.let {
-        return it
-      }
-      minimumTileUpdateInterval?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * When a set of tiles for a current zoom level is being rendered and some of
@@ -503,16 +232,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
    * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
    * This property sets the maximum limit for how much a parent tile can be overscaled.
    */
-  fun maxOverscaleFactorForParentTiles(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("max-overscale-factor-for-parent-tiles", value))
-  }
-
-  /**
-   * When a set of tiles for a current zoom level is being rendered and some of
-   * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
-   * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
-   * This property sets the maximum limit for how much a parent tile can be overscaled.
-   */
   val maxOverscaleFactorForParentTiles: Long?
     /**
      * Get the MaxOverscaleFactorForParentTiles property
@@ -520,28 +239,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
      * @return Long
      */
     get() = getPropertyValue("max-overscale-factor-for-parent-tiles")
-
-  /**
-   * When a set of tiles for a current zoom level is being rendered and some of
-   * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
-   * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
-   * This property sets the maximum limit for how much a parent tile can be overscaled.
-   */
-  val maxOverscaleFactorForParentTilesAsExpression: Expression?
-    /**
-     * Get the MaxOverscaleFactorForParentTiles property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("max-overscale-factor-for-parent-tiles")?.let {
-        return it
-      }
-      maxOverscaleFactorForParentTiles?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Builder for RasterSource.
@@ -563,26 +260,10 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-     */
-    fun url(value: Expression) = apply {
-      val propertyValue = PropertyValue("url", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * An array of one or more tile source URLs, as in the TileJSON spec.
      */
     fun tiles(value: List<String>) = apply {
       val propertyValue = PropertyValue("tiles", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * An array of one or more tile source URLs, as in the TileJSON spec.
-     */
-    fun tiles(value: Expression) = apply {
-      val propertyValue = PropertyValue("tiles", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -597,28 +278,10 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * An array containing the longitude and latitude of the southwest and northeast corners of the source's
-     * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
-     * a source, no tiles outside of the given bounds are requested by Mapbox GL.
-     */
-    fun bounds(value: Expression) = apply {
-      val propertyValue = PropertyValue("bounds", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
     fun minzoom(value: Long = 0L) = apply {
       val propertyValue = PropertyValue("minzoom", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-     */
-    fun minzoom(value: Expression) = apply {
-      val propertyValue = PropertyValue("minzoom", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -632,27 +295,10 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-     * at the maxzoom are used when displaying the map at higher zoom levels.
-     */
-    fun maxzoom(value: Expression) = apply {
-      val propertyValue = PropertyValue("maxzoom", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
      */
     fun tileSize(value: Long = 512L) = apply {
       val propertyValue = PropertyValue("tileSize", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
-     */
-    fun tileSize(value: Expression) = apply {
-      val propertyValue = PropertyValue("tileSize", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -665,14 +311,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
-     */
-    fun scheme(value: Expression) = apply {
-      val propertyValue = PropertyValue("scheme", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
     fun attribution(value: String) = apply {
@@ -681,26 +319,10 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Contains an attribution to be displayed when the map is shown to a user.
-     */
-    fun attribution(value: Expression) = apply {
-      val propertyValue = PropertyValue("attribution", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * A setting to determine whether a source's tiles are cached locally.
      */
     fun volatile(value: Boolean = false) = apply {
       val propertyValue = PropertyValue("volatile", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * A setting to determine whether a source's tiles are cached locally.
-     */
-    fun volatile(value: Expression) = apply {
-      val propertyValue = PropertyValue("volatile", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -716,29 +338,10 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    fun prefetchZoomDelta(value: Expression) = apply {
-      val propertyValue = PropertyValue("prefetch-zoom-delta", value)
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
      */
     fun minimumTileUpdateInterval(value: Double = 0.0) = apply {
       val propertyValue = PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value))
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-     */
-    fun minimumTileUpdateInterval(value: Expression) = apply {
-      val propertyValue = PropertyValue("minimum-tile-update-interval", value)
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
 
@@ -750,17 +353,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
      */
     fun maxOverscaleFactorForParentTiles(value: Long) = apply {
       val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", TypeUtils.wrapToValue(value))
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * When a set of tiles for a current zoom level is being rendered and some of
-     * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
-     * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
-     * This property sets the maximum limit for how much a parent tile can be overscaled.
-     */
-    fun maxOverscaleFactorForParentTiles(value: Expression) = apply {
-      val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", value)
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
 
@@ -815,25 +407,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster", "minzoom").silentUnwrap()
 
     /**
-     * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-     */
-    val defaultMinzoomAsExpression: Expression?
-      /**
-       * Get the Minzoom property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster", "minzoom").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMinzoom?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
      * at the maxzoom are used when displaying the map at higher zoom levels.
      */
@@ -844,26 +417,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
        * @return Long
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster", "maxzoom").silentUnwrap()
-
-    /**
-     * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-     * at the maxzoom are used when displaying the map at higher zoom levels.
-     */
-    val defaultMaxzoomAsExpression: Expression?
-      /**
-       * Get the Maxzoom property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster", "maxzoom").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMaxzoom?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
 
     /**
      * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
@@ -882,27 +435,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       }
 
     /**
-     * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
-     * This is an Expression representation of this Property.
-     *
-     */
-    val defaultSchemeAsExpression: Expression?
-      /**
-       * Get the Scheme property as an Expression
-       *
-       * @return expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster", "scheme").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultScheme?.let {
-          return Expression.literal(it.value)
-        }
-        return null
-      }
-
-    /**
      * A setting to determine whether a source's tiles are cached locally.
      */
     val defaultVolatile: Boolean?
@@ -912,25 +444,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
        * @return Boolean
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster", "volatile").silentUnwrap()
-
-    /**
-     * A setting to determine whether a source's tiles are cached locally.
-     */
-    val defaultVolatileAsExpression: Expression?
-      /**
-       * Get the Volatile property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster", "volatile").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultVolatile?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
 
     /**
      * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
@@ -947,28 +460,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster", "prefetch-zoom-delta").silentUnwrap()
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    val defaultPrefetchZoomDeltaAsExpression: Expression?
-      /**
-       * Get the PrefetchZoomDelta property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster", "prefetch-zoom-delta").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultPrefetchZoomDelta?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
      */
     val defaultMinimumTileUpdateInterval: Double?
@@ -978,25 +469,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
        * @return Double
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster", "minimum-tile-update-interval").silentUnwrap()
-
-    /**
-     * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-     */
-    val defaultMinimumTileUpdateIntervalAsExpression: Expression?
-      /**
-       * Get the MinimumTileUpdateInterval property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("raster", "minimum-tile-update-interval").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMinimumTileUpdateInterval?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
   }
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -3,7 +3,6 @@
 package com.mapbox.maps.extension.style.sources.generated
 
 import com.mapbox.maps.StyleManager
-import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.sources.Source
 import com.mapbox.maps.extension.style.sources.TileSet
@@ -42,13 +41,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
   /**
    * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
    */
-  fun url(value: Expression) = apply {
-    setProperty(PropertyValue("url", value))
-  }
-
-  /**
-   * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-   */
   val url: String?
     /**
      * Get the Url property
@@ -58,36 +50,10 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("url")
 
   /**
-   * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-   */
-  val urlAsExpression: Expression?
-    /**
-     * Get the Url property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("url")?.let {
-        return it
-      }
-      url?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * An array of one or more tile source URLs, as in the TileJSON spec.
    */
   fun tiles(value: List<String>) = apply {
     setProperty(PropertyValue("tiles", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * An array of one or more tile source URLs, as in the TileJSON spec.
-   */
-  fun tiles(value: Expression) = apply {
-    setProperty(PropertyValue("tiles", value))
   }
 
   /**
@@ -102,25 +68,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("tiles")
 
   /**
-   * An array of one or more tile source URLs, as in the TileJSON spec.
-   */
-  val tilesAsExpression: Expression?
-    /**
-     * Get the Tiles property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("tiles")?.let {
-        return it
-      }
-      tiles?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * An array containing the longitude and latitude of the southwest and northeast corners of the source's
    * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
    * a source, no tiles outside of the given bounds are requested by Mapbox GL.
@@ -132,27 +79,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
      * @return List<Double>
      */
     get() = getPropertyValue("bounds")
-
-  /**
-   * An array containing the longitude and latitude of the southwest and northeast corners of the source's
-   * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
-   * a source, no tiles outside of the given bounds are requested by Mapbox GL.
-   */
-  val boundsAsExpression: Expression?
-    /**
-     * Get the Bounds property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("bounds")?.let {
-        return it
-      }
-      bounds?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
@@ -171,38 +97,10 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
   /**
-   * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
-   * This is an Expression representation of this Property.
-   *
-   */
-  val schemeAsExpression: Expression?
-    /**
-     * Get the Scheme property as an Expression
-     *
-     * @return expression
-     */
-    get() {
-      getPropertyValue<Expression>("scheme")?.let {
-        return it
-      }
-      scheme?.let {
-        return Expression.literal(it.value)
-      }
-      return null
-    }
-
-  /**
    * Minimum zoom level for which tiles are available, as in the TileJSON spec.
    */
   fun minzoom(value: Long = 0L) = apply {
     setProperty(PropertyValue("minzoom", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-   */
-  fun minzoom(value: Expression) = apply {
-    setProperty(PropertyValue("minzoom", value))
   }
 
   /**
@@ -217,38 +115,11 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("minzoom")
 
   /**
-   * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-   */
-  val minzoomAsExpression: Expression?
-    /**
-     * Get the Minzoom property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("minzoom")?.let {
-        return it
-      }
-      minzoom?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
    * at the maxzoom are used when displaying the map at higher zoom levels.
    */
   fun maxzoom(value: Long = 22L) = apply {
     setProperty(PropertyValue("maxzoom", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-   * at the maxzoom are used when displaying the map at higher zoom levels.
-   */
-  fun maxzoom(value: Expression) = apply {
-    setProperty(PropertyValue("maxzoom", value))
   }
 
   /**
@@ -264,26 +135,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("maxzoom")
 
   /**
-   * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-   * at the maxzoom are used when displaying the map at higher zoom levels.
-   */
-  val maxzoomAsExpression: Expression?
-    /**
-     * Get the Maxzoom property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("maxzoom")?.let {
-        return it
-      }
-      maxzoom?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Contains an attribution to be displayed when the map is shown to a user.
    */
   val attribution: String?
@@ -295,36 +146,10 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("attribution")
 
   /**
-   * Contains an attribution to be displayed when the map is shown to a user.
-   */
-  val attributionAsExpression: Expression?
-    /**
-     * Get the Attribution property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("attribution")?.let {
-        return it
-      }
-      attribution?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * A setting to determine whether a source's tiles are cached locally.
    */
   fun volatile(value: Boolean = false) = apply {
     setProperty(PropertyValue("volatile", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * A setting to determine whether a source's tiles are cached locally.
-   */
-  fun volatile(value: Expression) = apply {
-    setProperty(PropertyValue("volatile", value))
   }
 
   /**
@@ -337,25 +162,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
      * @return Boolean
      */
     get() = getPropertyValue("volatile")
-
-  /**
-   * A setting to determine whether a source's tiles are cached locally.
-   */
-  val volatileAsExpression: Expression?
-    /**
-     * Get the Volatile property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("volatile")?.let {
-        return it
-      }
-      volatile?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
@@ -373,16 +179,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
    * map at lower resolution as quick as possible. It will get clamped at the tile source
    * minimum zoom. The default `delta` is 4.
    */
-  fun prefetchZoomDelta(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("prefetch-zoom-delta", value))
-  }
-
-  /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
   val prefetchZoomDelta: Long?
     /**
      * Get the PrefetchZoomDelta property
@@ -392,39 +188,10 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("prefetch-zoom-delta")
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
-   */
-  val prefetchZoomDeltaAsExpression: Expression?
-    /**
-     * Get the PrefetchZoomDelta property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("prefetch-zoom-delta")?.let {
-        return it
-      }
-      prefetchZoomDelta?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
-
-  /**
    * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
    */
   fun minimumTileUpdateInterval(value: Double = 0.0) = apply {
     setVolatileProperty(PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value)))
-  }
-
-  /**
-   * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-   */
-  fun minimumTileUpdateInterval(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("minimum-tile-update-interval", value))
   }
 
   /**
@@ -437,25 +204,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
      * @return Double
      */
     get() = getPropertyValue("minimum-tile-update-interval")
-
-  /**
-   * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-   */
-  val minimumTileUpdateIntervalAsExpression: Expression?
-    /**
-     * Get the MinimumTileUpdateInterval property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("minimum-tile-update-interval")?.let {
-        return it
-      }
-      minimumTileUpdateInterval?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * When a set of tiles for a current zoom level is being rendered and some of
@@ -473,16 +221,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
    * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
    * This property sets the maximum limit for how much a parent tile can be overscaled.
    */
-  fun maxOverscaleFactorForParentTiles(value: Expression) = apply {
-    setVolatileProperty(PropertyValue("max-overscale-factor-for-parent-tiles", value))
-  }
-
-  /**
-   * When a set of tiles for a current zoom level is being rendered and some of
-   * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
-   * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
-   * This property sets the maximum limit for how much a parent tile can be overscaled.
-   */
   val maxOverscaleFactorForParentTiles: Long?
     /**
      * Get the MaxOverscaleFactorForParentTiles property
@@ -490,28 +228,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
      * @return Long
      */
     get() = getPropertyValue("max-overscale-factor-for-parent-tiles")
-
-  /**
-   * When a set of tiles for a current zoom level is being rendered and some of
-   * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
-   * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
-   * This property sets the maximum limit for how much a parent tile can be overscaled.
-   */
-  val maxOverscaleFactorForParentTilesAsExpression: Expression?
-    /**
-     * Get the MaxOverscaleFactorForParentTiles property as an Expression
-     *
-     * @return Expression
-     */
-    get() {
-      getPropertyValue<Expression>("max-overscale-factor-for-parent-tiles")?.let {
-        return it
-      }
-      maxOverscaleFactorForParentTiles?.let {
-        return Expression.literal(it)
-      }
-      return null
-    }
 
   /**
    * Builder for VectorSource.
@@ -533,26 +249,10 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
-     */
-    fun url(value: Expression) = apply {
-      val propertyValue = PropertyValue("url", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * An array of one or more tile source URLs, as in the TileJSON spec.
      */
     fun tiles(value: List<String>) = apply {
       val propertyValue = PropertyValue("tiles", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * An array of one or more tile source URLs, as in the TileJSON spec.
-     */
-    fun tiles(value: Expression) = apply {
-      val propertyValue = PropertyValue("tiles", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -567,16 +267,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * An array containing the longitude and latitude of the southwest and northeast corners of the source's
-     * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
-     * a source, no tiles outside of the given bounds are requested by Mapbox GL.
-     */
-    fun bounds(value: Expression) = apply {
-      val propertyValue = PropertyValue("bounds", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
      */
     fun scheme(value: Scheme = Scheme.XYZ) = apply {
@@ -585,26 +275,10 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
-     */
-    fun scheme(value: Expression) = apply {
-      val propertyValue = PropertyValue("scheme", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
     fun minzoom(value: Long = 0L) = apply {
       val propertyValue = PropertyValue("minzoom", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-     */
-    fun minzoom(value: Expression) = apply {
-      val propertyValue = PropertyValue("minzoom", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -618,15 +292,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-     * at the maxzoom are used when displaying the map at higher zoom levels.
-     */
-    fun maxzoom(value: Expression) = apply {
-      val propertyValue = PropertyValue("maxzoom", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
     fun attribution(value: String) = apply {
@@ -635,26 +300,10 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * Contains an attribution to be displayed when the map is shown to a user.
-     */
-    fun attribution(value: Expression) = apply {
-      val propertyValue = PropertyValue("attribution", value)
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * A setting to determine whether a source's tiles are cached locally.
      */
     fun volatile(value: Boolean = false) = apply {
       val propertyValue = PropertyValue("volatile", TypeUtils.wrapToValue(value))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * A setting to determine whether a source's tiles are cached locally.
-     */
-    fun volatile(value: Expression) = apply {
-      val propertyValue = PropertyValue("volatile", value)
       properties[propertyValue.propertyName] = propertyValue
     }
 
@@ -670,29 +319,10 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    fun prefetchZoomDelta(value: Expression) = apply {
-      val propertyValue = PropertyValue("prefetch-zoom-delta", value)
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
      * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
      */
     fun minimumTileUpdateInterval(value: Double = 0.0) = apply {
       val propertyValue = PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value))
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-     */
-    fun minimumTileUpdateInterval(value: Expression) = apply {
-      val propertyValue = PropertyValue("minimum-tile-update-interval", value)
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
 
@@ -704,17 +334,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
      */
     fun maxOverscaleFactorForParentTiles(value: Long) = apply {
       val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", TypeUtils.wrapToValue(value))
-      volatileProperties[propertyValue.propertyName] = propertyValue
-    }
-
-    /**
-     * When a set of tiles for a current zoom level is being rendered and some of
-     * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
-     * instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.
-     * This property sets the maximum limit for how much a parent tile can be overscaled.
-     */
-    fun maxOverscaleFactorForParentTiles(value: Expression) = apply {
-      val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", value)
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
 
@@ -774,27 +393,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       }
 
     /**
-     * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
-     * This is an Expression representation of this Property.
-     *
-     */
-    val defaultSchemeAsExpression: Expression?
-      /**
-       * Get the Scheme property as an Expression
-       *
-       * @return expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("vector", "scheme").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultScheme?.let {
-          return Expression.literal(it.value)
-        }
-        return null
-      }
-
-    /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
     val defaultMinzoom: Long?
@@ -804,25 +402,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
        * @return Long
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "minzoom").silentUnwrap()
-
-    /**
-     * Minimum zoom level for which tiles are available, as in the TileJSON spec.
-     */
-    val defaultMinzoomAsExpression: Expression?
-      /**
-       * Get the Minzoom property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("vector", "minzoom").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMinzoom?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
 
     /**
      * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
@@ -837,26 +416,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "maxzoom").silentUnwrap()
 
     /**
-     * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
-     * at the maxzoom are used when displaying the map at higher zoom levels.
-     */
-    val defaultMaxzoomAsExpression: Expression?
-      /**
-       * Get the Maxzoom property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("vector", "maxzoom").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMaxzoom?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * A setting to determine whether a source's tiles are cached locally.
      */
     val defaultVolatile: Boolean?
@@ -866,25 +425,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
        * @return Boolean
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "volatile").silentUnwrap()
-
-    /**
-     * A setting to determine whether a source's tiles are cached locally.
-     */
-    val defaultVolatileAsExpression: Expression?
-      /**
-       * Get the Volatile property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("vector", "volatile").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultVolatile?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
 
     /**
      * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
@@ -901,28 +441,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "prefetch-zoom-delta").silentUnwrap()
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
-     */
-    val defaultPrefetchZoomDeltaAsExpression: Expression?
-      /**
-       * Get the PrefetchZoomDelta property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("vector", "prefetch-zoom-delta").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultPrefetchZoomDelta?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
-
-    /**
      * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
      */
     val defaultMinimumTileUpdateInterval: Double?
@@ -932,25 +450,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
        * @return Double
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "minimum-tile-update-interval").silentUnwrap()
-
-    /**
-     * Minimum tile update interval in milliseconds, which is used to throttle the tile update network requests.
-     */
-    val defaultMinimumTileUpdateIntervalAsExpression: Expression?
-      /**
-       * Get the MinimumTileUpdateInterval property as an Expression
-       *
-       * @return Expression
-       */
-      get() {
-        StyleManager.getStyleSourcePropertyDefaultValue("vector", "minimum-tile-update-interval").silentUnwrap<Expression>()?.let {
-          return it
-        }
-        defaultMinimumTileUpdateInterval?.let {
-          return Expression.literal(it)
-        }
-        return null
-      }
   }
 }
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
@@ -71,21 +71,6 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun dataAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      data(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("data=[+, 2, 3]"))
-  }
-
-  @Test
   fun dataSetAfterBind() {
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
@@ -96,41 +81,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun dataAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-    testSource.data(expression)
-
-    verify { style.setStyleSourceProperty("testId", "data", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun dataGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(TEST_GEOJSON)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(TEST_GEOJSON.toString(), testSource.data?.toString())
-    verify { style.getStyleSourceProperty("testId", "data") }
-  }
-
-  @Test
-  fun dataAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.dataAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "data") }
   }
 
@@ -146,18 +102,6 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun urlExpressionSetTest() {
-    val expression = literal("testUrl")
-    val testSource = geoJsonSource("testId") {
-      url(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("data=$expression"))
-  }
-
-  @Test
   fun urlSetAfterBindTest() {
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
@@ -165,17 +109,6 @@ class GeoJsonSourceTest {
 
     verify { style.setStyleSourceProperty("testId", "data", capture(valueSlot)) }
     assertEquals(valueSlot.captured.toString(), "testUrl")
-  }
-
-  @Test
-  fun urlExpressionSetAfterBindTest() {
-    val expression = literal("testUrl")
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-    testSource.url(expression)
-
-    verify { style.setStyleSourceProperty("testId", "data", capture(valueSlot)) }
-    assertEquals(expression.toString(), valueSlot.captured.toString())
   }
 
   @Test
@@ -190,42 +123,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun maxzoomAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      maxzoom(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("maxzoom=[+, 2, 3]"))
-  }
-
-  @Test
   fun maxzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.maxzoom?.toString())
-    verify { style.getStyleSourceProperty("testId", "maxzoom") }
-  }
-
-  @Test
-  fun maxzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.maxzoomAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "maxzoom") }
   }
 
@@ -241,42 +144,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun attributionAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      attribution(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("attribution=[+, 2, 3]"))
-  }
-
-  @Test
   fun attributionGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals("abc".toString(), testSource.attribution?.toString())
-    verify { style.getStyleSourceProperty("testId", "attribution") }
-  }
-
-  @Test
-  fun attributionAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.attributionAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "attribution") }
   }
 
@@ -292,42 +165,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun bufferAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      buffer(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("buffer=[+, 2, 3]"))
-  }
-
-  @Test
   fun bufferGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.buffer?.toString())
-    verify { style.getStyleSourceProperty("testId", "buffer") }
-  }
-
-  @Test
-  fun bufferAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.bufferAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "buffer") }
   }
 
@@ -343,42 +186,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun toleranceAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      tolerance(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("tolerance=[+, 2, 3]"))
-  }
-
-  @Test
   fun toleranceGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1.0.toString(), testSource.tolerance?.toString())
-    verify { style.getStyleSourceProperty("testId", "tolerance") }
-  }
-
-  @Test
-  fun toleranceAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.toleranceAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "tolerance") }
   }
 
@@ -394,42 +207,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun clusterAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      cluster(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("cluster=[+, 2, 3]"))
-  }
-
-  @Test
   fun clusterGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(true.toString(), testSource.cluster?.toString())
-    verify { style.getStyleSourceProperty("testId", "cluster") }
-  }
-
-  @Test
-  fun clusterAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.clusterAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "cluster") }
   }
 
@@ -445,42 +228,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun clusterRadiusAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      clusterRadius(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("clusterRadius=[+, 2, 3]"))
-  }
-
-  @Test
   fun clusterRadiusGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.clusterRadius?.toString())
-    verify { style.getStyleSourceProperty("testId", "clusterRadius") }
-  }
-
-  @Test
-  fun clusterRadiusAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.clusterRadiusAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "clusterRadius") }
   }
 
@@ -496,42 +249,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun clusterMaxZoomAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      clusterMaxZoom(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("clusterMaxZoom=[+, 2, 3]"))
-  }
-
-  @Test
   fun clusterMaxZoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.clusterMaxZoom?.toString())
-    verify { style.getStyleSourceProperty("testId", "clusterMaxZoom") }
-  }
-
-  @Test
-  fun clusterMaxZoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.clusterMaxZoomAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "clusterMaxZoom") }
   }
 
@@ -547,42 +270,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun clusterPropertiesAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      clusterProperties(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("clusterProperties=[+, 2, 3]"))
-  }
-
-  @Test
   fun clusterPropertiesGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue((hashMapOf("key1" to "x", "key2" to "y") as HashMap<String, Any>))
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals((hashMapOf("key1" to "x", "key2" to "y") as HashMap<String, Any>).toString(), testSource.clusterProperties?.toString())
-    verify { style.getStyleSourceProperty("testId", "clusterProperties") }
-  }
-
-  @Test
-  fun clusterPropertiesAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.clusterPropertiesAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "clusterProperties") }
   }
   // Cluster Properties is not mutable so afterBind test is ignored
@@ -659,42 +352,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun lineMetricsAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      lineMetrics(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("lineMetrics=[+, 2, 3]"))
-  }
-
-  @Test
   fun lineMetricsGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(true.toString(), testSource.lineMetrics?.toString())
-    verify { style.getStyleSourceProperty("testId", "lineMetrics") }
-  }
-
-  @Test
-  fun lineMetricsAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.lineMetricsAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "lineMetrics") }
   }
 
@@ -710,42 +373,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun generateIdAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      generateId(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("generateId=[+, 2, 3]"))
-  }
-
-  @Test
   fun generateIdGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(true.toString(), testSource.generateId?.toString())
-    verify { style.getStyleSourceProperty("testId", "generateId") }
-  }
-
-  @Test
-  fun generateIdAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.generateIdAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "generateId") }
   }
 
@@ -761,21 +394,6 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun prefetchZoomDeltaAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {
-      prefetchZoomDelta(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun prefetchZoomDeltaSetAfterBind() {
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
@@ -786,41 +404,12 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun prefetchZoomDeltaAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-    testSource.prefetchZoomDelta(expression)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun prefetchZoomDeltaGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = geoJsonSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.prefetchZoomDelta?.toString())
-    verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
-  }
-
-  @Test
-  fun prefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = geoJsonSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
   }
 
@@ -994,36 +583,10 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun defaultMaxzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), GeoJsonSource.defaultMaxzoomAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "maxzoom") }
-  }
-
-  @Test
   fun defaultBufferGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
 
     assertEquals(1L.toString(), GeoJsonSource.defaultBuffer?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "buffer") }
-  }
-
-  @Test
-  fun defaultBufferAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), GeoJsonSource.defaultBufferAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "buffer") }
   }
 
@@ -1036,36 +599,10 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun defaultToleranceAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), GeoJsonSource.defaultToleranceAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "tolerance") }
-  }
-
-  @Test
   fun defaultClusterGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
 
     assertEquals(true.toString(), GeoJsonSource.defaultCluster?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "cluster") }
-  }
-
-  @Test
-  fun defaultClusterAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), GeoJsonSource.defaultClusterAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "cluster") }
   }
 
@@ -1078,36 +615,10 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun defaultClusterRadiusAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), GeoJsonSource.defaultClusterRadiusAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterRadius") }
-  }
-
-  @Test
   fun defaultClusterMaxZoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
 
     assertEquals(1L.toString(), GeoJsonSource.defaultClusterMaxZoom?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterMaxZoom") }
-  }
-
-  @Test
-  fun defaultClusterMaxZoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), GeoJsonSource.defaultClusterMaxZoomAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterMaxZoom") }
   }
 
@@ -1120,19 +631,6 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun defaultLineMetricsAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), GeoJsonSource.defaultLineMetricsAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "lineMetrics") }
-  }
-
-  @Test
   fun defaultGenerateIdGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
 
@@ -1141,36 +639,10 @@ class GeoJsonSourceTest {
   }
 
   @Test
-  fun defaultGenerateIdAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), GeoJsonSource.defaultGenerateIdAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId") }
-  }
-
-  @Test
   fun defaultPrefetchZoomDeltaGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
 
     assertEquals(1L.toString(), GeoJsonSource.defaultPrefetchZoomDelta?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "prefetch-zoom-delta") }
-  }
-
-  @Test
-  fun defaultPrefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), GeoJsonSource.defaultPrefetchZoomDeltaAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "prefetch-zoom-delta") }
   }
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/ImageSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/ImageSourceTest.kt
@@ -10,7 +10,6 @@ import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
 import com.mapbox.maps.extension.style.StyleInterface
-import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import io.mockk.*
 import org.junit.Assert.*
@@ -61,21 +60,6 @@ class ImageSourceTest {
   }
 
   @Test
-  fun urlAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = imageSource("testId") {
-      url(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("url=[+, 2, 3]"))
-  }
-
-  @Test
   fun urlSetAfterBind() {
     val testSource = imageSource("testId") {}
     testSource.bindTo(style)
@@ -86,41 +70,12 @@ class ImageSourceTest {
   }
 
   @Test
-  fun urlAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = imageSource("testId") {}
-    testSource.bindTo(style)
-    testSource.url(expression)
-
-    verify { style.setStyleSourceProperty("testId", "url", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun urlGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
     val testSource = imageSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals("abc".toString(), testSource.url?.toString())
-    verify { style.getStyleSourceProperty("testId", "url") }
-  }
-
-  @Test
-  fun urlAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = imageSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.urlAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "url") }
   }
 
@@ -136,21 +91,6 @@ class ImageSourceTest {
   }
 
   @Test
-  fun coordinatesAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = imageSource("testId") {
-      coordinates(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("coordinates=[+, 2, 3]"))
-  }
-
-  @Test
   fun coordinatesSetAfterBind() {
     val testSource = imageSource("testId") {}
     testSource.bindTo(style)
@@ -161,41 +101,12 @@ class ImageSourceTest {
   }
 
   @Test
-  fun coordinatesAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = imageSource("testId") {}
-    testSource.bindTo(style)
-    testSource.coordinates(expression)
-
-    verify { style.setStyleSourceProperty("testId", "coordinates", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun coordinatesGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(listOf(listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0)))
     val testSource = imageSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(listOf(listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0), listOf(0.0, 1.0)).toString(), testSource.coordinates?.toString())
-    verify { style.getStyleSourceProperty("testId", "coordinates") }
-  }
-
-  @Test
-  fun coordinatesAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = imageSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.coordinatesAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "coordinates") }
   }
 
@@ -211,21 +122,6 @@ class ImageSourceTest {
   }
 
   @Test
-  fun prefetchZoomDeltaAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = imageSource("testId") {
-      prefetchZoomDelta(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun prefetchZoomDeltaSetAfterBind() {
     val testSource = imageSource("testId") {}
     testSource.bindTo(style)
@@ -233,20 +129,6 @@ class ImageSourceTest {
 
     verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
     assertEquals(valueSlot.captured.toString(), "1")
-  }
-
-  @Test
-  fun prefetchZoomDeltaAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = imageSource("testId") {}
-    testSource.bindTo(style)
-    testSource.prefetchZoomDelta(expression)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
   }
 
   @Test
@@ -258,21 +140,6 @@ class ImageSourceTest {
     assertEquals(1L.toString(), testSource.prefetchZoomDelta?.toString())
     verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
   }
-
-  @Test
-  fun prefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = imageSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
-    verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
-  }
   // Default source property getters tests
 
   @Test
@@ -280,19 +147,6 @@ class ImageSourceTest {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
 
     assertEquals(1L.toString(), ImageSource.defaultPrefetchZoomDelta?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("image", "prefetch-zoom-delta") }
-  }
-
-  @Test
-  fun defaultPrefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), ImageSource.defaultPrefetchZoomDeltaAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("image", "prefetch-zoom-delta") }
   }
 }

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSourceTest.kt
@@ -10,7 +10,6 @@ import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
 import com.mapbox.maps.extension.style.StyleInterface
-import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import io.mockk.*
@@ -62,21 +61,6 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun urlAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      url(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("url=[+, 2, 3]"))
-  }
-
-  @Test
   fun urlSetAfterBind() {
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
@@ -87,41 +71,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun urlAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-    testSource.url(expression)
-
-    verify { style.setStyleSourceProperty("testId", "url", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun urlGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals("abc".toString(), testSource.url?.toString())
-    verify { style.getStyleSourceProperty("testId", "url") }
-  }
-
-  @Test
-  fun urlAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.urlAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "url") }
   }
 
@@ -137,21 +92,6 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun tilesAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      tiles(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("tiles=[+, 2, 3]"))
-  }
-
-  @Test
   fun tilesSetAfterBind() {
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
@@ -162,41 +102,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun tilesAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-    testSource.tiles(expression)
-
-    verify { style.setStyleSourceProperty("testId", "tiles", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun tilesGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(listOf("a", "b", "c"))
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(listOf("a", "b", "c").toString(), testSource.tiles?.toString())
-    verify { style.getStyleSourceProperty("testId", "tiles") }
-  }
-
-  @Test
-  fun tilesAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.tilesAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "tiles") }
   }
 
@@ -212,42 +123,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun boundsAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      bounds(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("bounds=[+, 2, 3]"))
-  }
-
-  @Test
   fun boundsGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(listOf(0.0, 1.0, 2.0, 3.0))
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(listOf(0.0, 1.0, 2.0, 3.0).toString(), testSource.bounds?.toString())
-    verify { style.getStyleSourceProperty("testId", "bounds") }
-  }
-
-  @Test
-  fun boundsAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.boundsAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "bounds") }
   }
 
@@ -263,21 +144,6 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun minzoomAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      minzoom(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("minzoom=[+, 2, 3]"))
-  }
-
-  @Test
   fun minzoomSetAfterBind() {
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
@@ -288,41 +154,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun minzoomAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-    testSource.minzoom(expression)
-
-    verify { style.setStyleSourceProperty("testId", "minzoom", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun minzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.minzoom?.toString())
-    verify { style.getStyleSourceProperty("testId", "minzoom") }
-  }
-
-  @Test
-  fun minzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.minzoomAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "minzoom") }
   }
 
@@ -338,21 +175,6 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun maxzoomAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      maxzoom(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("maxzoom=[+, 2, 3]"))
-  }
-
-  @Test
   fun maxzoomSetAfterBind() {
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
@@ -363,41 +185,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun maxzoomAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-    testSource.maxzoom(expression)
-
-    verify { style.setStyleSourceProperty("testId", "maxzoom", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun maxzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.maxzoom?.toString())
-    verify { style.getStyleSourceProperty("testId", "maxzoom") }
-  }
-
-  @Test
-  fun maxzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.maxzoomAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "maxzoom") }
   }
 
@@ -413,42 +206,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun tileSizeAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      tileSize(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("tileSize=[+, 2, 3]"))
-  }
-
-  @Test
   fun tileSizeGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.tileSize?.toString())
-    verify { style.getStyleSourceProperty("testId", "tileSize") }
-  }
-
-  @Test
-  fun tileSizeAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.tileSizeAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "tileSize") }
   }
 
@@ -464,42 +227,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun attributionAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      attribution(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("attribution=[+, 2, 3]"))
-  }
-
-  @Test
   fun attributionGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals("abc".toString(), testSource.attribution?.toString())
-    verify { style.getStyleSourceProperty("testId", "attribution") }
-  }
-
-  @Test
-  fun attributionAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.attributionAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "attribution") }
   }
 
@@ -515,42 +248,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun encodingAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      encoding(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("encoding=[+, 2, 3]"))
-  }
-
-  @Test
   fun encodingGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("terrarium")
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(Encoding.TERRARIUM, testSource.encoding)
-    verify { style.getStyleSourceProperty("testId", "encoding") }
-  }
-
-  @Test
-  fun encodingAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.encodingAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "encoding") }
   }
 
@@ -566,21 +269,6 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun volatileAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      volatile(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("volatile=[+, 2, 3]"))
-  }
-
-  @Test
   fun volatileSetAfterBind() {
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
@@ -591,41 +279,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun volatileAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-    testSource.volatile(expression)
-
-    verify { style.setStyleSourceProperty("testId", "volatile", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun volatileGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(true.toString(), testSource.volatile?.toString())
-    verify { style.getStyleSourceProperty("testId", "volatile") }
-  }
-
-  @Test
-  fun volatileAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.volatileAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "volatile") }
   }
 
@@ -641,21 +300,6 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun prefetchZoomDeltaAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      prefetchZoomDelta(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun prefetchZoomDeltaSetAfterBind() {
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
@@ -666,41 +310,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun prefetchZoomDeltaAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-    testSource.prefetchZoomDelta(expression)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun prefetchZoomDeltaGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.prefetchZoomDelta?.toString())
-    verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
-  }
-
-  @Test
-  fun prefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
   }
 
@@ -716,21 +331,6 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun minimumTileUpdateIntervalAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      minimumTileUpdateInterval(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "minimum-tile-update-interval", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun minimumTileUpdateIntervalSetAfterBind() {
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
@@ -741,41 +341,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun minimumTileUpdateIntervalAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-    testSource.minimumTileUpdateInterval(expression)
-
-    verify { style.setStyleSourceProperty("testId", "minimum-tile-update-interval", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun minimumTileUpdateIntervalGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1.0.toString(), testSource.minimumTileUpdateInterval?.toString())
-    verify { style.getStyleSourceProperty("testId", "minimum-tile-update-interval") }
-  }
-
-  @Test
-  fun minimumTileUpdateIntervalAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.minimumTileUpdateIntervalAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "minimum-tile-update-interval") }
   }
 
@@ -791,21 +362,6 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun maxOverscaleFactorForParentTilesAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {
-      maxOverscaleFactorForParentTiles(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun maxOverscaleFactorForParentTilesSetAfterBind() {
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
@@ -816,41 +372,12 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun maxOverscaleFactorForParentTilesAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-    testSource.maxOverscaleFactorForParentTiles(expression)
-
-    verify { style.setStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun maxOverscaleFactorForParentTilesGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterDemSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.maxOverscaleFactorForParentTiles?.toString())
-    verify { style.getStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles") }
-  }
-
-  @Test
-  fun maxOverscaleFactorForParentTilesAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterDemSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.maxOverscaleFactorForParentTilesAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles") }
   }
 
@@ -896,36 +423,10 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun defaultMinzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterDemSource.defaultMinzoomAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "minzoom") }
-  }
-
-  @Test
   fun defaultMaxzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
 
     assertEquals(1L.toString(), RasterDemSource.defaultMaxzoom?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "maxzoom") }
-  }
-
-  @Test
-  fun defaultMaxzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterDemSource.defaultMaxzoomAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "maxzoom") }
   }
 
@@ -938,36 +439,10 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun defaultEncodingAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterDemSource.defaultEncodingAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "encoding") }
-  }
-
-  @Test
   fun defaultVolatileGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
 
     assertEquals(true.toString(), RasterDemSource.defaultVolatile?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "volatile") }
-  }
-
-  @Test
-  fun defaultVolatileAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterDemSource.defaultVolatileAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "volatile") }
   }
 
@@ -980,36 +455,10 @@ class RasterDemSourceTest {
   }
 
   @Test
-  fun defaultPrefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterDemSource.defaultPrefetchZoomDeltaAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "prefetch-zoom-delta") }
-  }
-
-  @Test
   fun defaultMinimumTileUpdateIntervalGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
 
     assertEquals(1.0.toString(), RasterDemSource.defaultMinimumTileUpdateInterval?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "minimum-tile-update-interval") }
-  }
-
-  @Test
-  fun defaultMinimumTileUpdateIntervalAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterDemSource.defaultMinimumTileUpdateIntervalAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "minimum-tile-update-interval") }
   }
 }

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterSourceTest.kt
@@ -10,7 +10,6 @@ import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
 import com.mapbox.maps.extension.style.StyleInterface
-import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import io.mockk.*
@@ -62,21 +61,6 @@ class RasterSourceTest {
   }
 
   @Test
-  fun urlAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      url(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("url=[+, 2, 3]"))
-  }
-
-  @Test
   fun urlSetAfterBind() {
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
@@ -87,41 +71,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun urlAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-    testSource.url(expression)
-
-    verify { style.setStyleSourceProperty("testId", "url", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun urlGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals("abc".toString(), testSource.url?.toString())
-    verify { style.getStyleSourceProperty("testId", "url") }
-  }
-
-  @Test
-  fun urlAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.urlAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "url") }
   }
 
@@ -137,21 +92,6 @@ class RasterSourceTest {
   }
 
   @Test
-  fun tilesAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      tiles(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("tiles=[+, 2, 3]"))
-  }
-
-  @Test
   fun tilesSetAfterBind() {
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
@@ -162,41 +102,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun tilesAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-    testSource.tiles(expression)
-
-    verify { style.setStyleSourceProperty("testId", "tiles", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun tilesGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(listOf("a", "b", "c"))
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(listOf("a", "b", "c").toString(), testSource.tiles?.toString())
-    verify { style.getStyleSourceProperty("testId", "tiles") }
-  }
-
-  @Test
-  fun tilesAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.tilesAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "tiles") }
   }
 
@@ -212,42 +123,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun boundsAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      bounds(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("bounds=[+, 2, 3]"))
-  }
-
-  @Test
   fun boundsGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(listOf(0.0, 1.0, 2.0, 3.0))
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(listOf(0.0, 1.0, 2.0, 3.0).toString(), testSource.bounds?.toString())
-    verify { style.getStyleSourceProperty("testId", "bounds") }
-  }
-
-  @Test
-  fun boundsAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.boundsAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "bounds") }
   }
 
@@ -263,21 +144,6 @@ class RasterSourceTest {
   }
 
   @Test
-  fun minzoomAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      minzoom(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("minzoom=[+, 2, 3]"))
-  }
-
-  @Test
   fun minzoomSetAfterBind() {
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
@@ -288,41 +154,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun minzoomAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-    testSource.minzoom(expression)
-
-    verify { style.setStyleSourceProperty("testId", "minzoom", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun minzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.minzoom?.toString())
-    verify { style.getStyleSourceProperty("testId", "minzoom") }
-  }
-
-  @Test
-  fun minzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.minzoomAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "minzoom") }
   }
 
@@ -338,21 +175,6 @@ class RasterSourceTest {
   }
 
   @Test
-  fun maxzoomAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      maxzoom(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("maxzoom=[+, 2, 3]"))
-  }
-
-  @Test
   fun maxzoomSetAfterBind() {
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
@@ -363,41 +185,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun maxzoomAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-    testSource.maxzoom(expression)
-
-    verify { style.setStyleSourceProperty("testId", "maxzoom", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun maxzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.maxzoom?.toString())
-    verify { style.getStyleSourceProperty("testId", "maxzoom") }
-  }
-
-  @Test
-  fun maxzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.maxzoomAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "maxzoom") }
   }
 
@@ -413,42 +206,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun tileSizeAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      tileSize(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("tileSize=[+, 2, 3]"))
-  }
-
-  @Test
   fun tileSizeGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.tileSize?.toString())
-    verify { style.getStyleSourceProperty("testId", "tileSize") }
-  }
-
-  @Test
-  fun tileSizeAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.tileSizeAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "tileSize") }
   }
 
@@ -464,42 +227,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun schemeAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      scheme(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("scheme=[+, 2, 3]"))
-  }
-
-  @Test
   fun schemeGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("xyz")
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(Scheme.XYZ, testSource.scheme)
-    verify { style.getStyleSourceProperty("testId", "scheme") }
-  }
-
-  @Test
-  fun schemeAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.schemeAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "scheme") }
   }
 
@@ -515,42 +248,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun attributionAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      attribution(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("attribution=[+, 2, 3]"))
-  }
-
-  @Test
   fun attributionGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals("abc".toString(), testSource.attribution?.toString())
-    verify { style.getStyleSourceProperty("testId", "attribution") }
-  }
-
-  @Test
-  fun attributionAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.attributionAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "attribution") }
   }
 
@@ -566,21 +269,6 @@ class RasterSourceTest {
   }
 
   @Test
-  fun volatileAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      volatile(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("volatile=[+, 2, 3]"))
-  }
-
-  @Test
   fun volatileSetAfterBind() {
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
@@ -591,41 +279,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun volatileAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-    testSource.volatile(expression)
-
-    verify { style.setStyleSourceProperty("testId", "volatile", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun volatileGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(true.toString(), testSource.volatile?.toString())
-    verify { style.getStyleSourceProperty("testId", "volatile") }
-  }
-
-  @Test
-  fun volatileAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.volatileAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "volatile") }
   }
 
@@ -641,21 +300,6 @@ class RasterSourceTest {
   }
 
   @Test
-  fun prefetchZoomDeltaAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      prefetchZoomDelta(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun prefetchZoomDeltaSetAfterBind() {
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
@@ -666,41 +310,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun prefetchZoomDeltaAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-    testSource.prefetchZoomDelta(expression)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun prefetchZoomDeltaGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.prefetchZoomDelta?.toString())
-    verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
-  }
-
-  @Test
-  fun prefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
   }
 
@@ -716,21 +331,6 @@ class RasterSourceTest {
   }
 
   @Test
-  fun minimumTileUpdateIntervalAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      minimumTileUpdateInterval(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "minimum-tile-update-interval", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun minimumTileUpdateIntervalSetAfterBind() {
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
@@ -741,41 +341,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun minimumTileUpdateIntervalAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-    testSource.minimumTileUpdateInterval(expression)
-
-    verify { style.setStyleSourceProperty("testId", "minimum-tile-update-interval", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun minimumTileUpdateIntervalGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1.0.toString(), testSource.minimumTileUpdateInterval?.toString())
-    verify { style.getStyleSourceProperty("testId", "minimum-tile-update-interval") }
-  }
-
-  @Test
-  fun minimumTileUpdateIntervalAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.minimumTileUpdateIntervalAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "minimum-tile-update-interval") }
   }
 
@@ -791,21 +362,6 @@ class RasterSourceTest {
   }
 
   @Test
-  fun maxOverscaleFactorForParentTilesAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {
-      maxOverscaleFactorForParentTiles(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun maxOverscaleFactorForParentTilesSetAfterBind() {
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
@@ -816,41 +372,12 @@ class RasterSourceTest {
   }
 
   @Test
-  fun maxOverscaleFactorForParentTilesAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-    testSource.maxOverscaleFactorForParentTiles(expression)
-
-    verify { style.setStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun maxOverscaleFactorForParentTilesGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = rasterSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.maxOverscaleFactorForParentTiles?.toString())
-    verify { style.getStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles") }
-  }
-
-  @Test
-  fun maxOverscaleFactorForParentTilesAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = rasterSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.maxOverscaleFactorForParentTilesAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles") }
   }
 
@@ -896,36 +423,10 @@ class RasterSourceTest {
   }
 
   @Test
-  fun defaultMinzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterSource.defaultMinzoomAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "minzoom") }
-  }
-
-  @Test
   fun defaultMaxzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
 
     assertEquals(1L.toString(), RasterSource.defaultMaxzoom?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "maxzoom") }
-  }
-
-  @Test
-  fun defaultMaxzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterSource.defaultMaxzoomAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "maxzoom") }
   }
 
@@ -938,36 +439,10 @@ class RasterSourceTest {
   }
 
   @Test
-  fun defaultSchemeAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterSource.defaultSchemeAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "scheme") }
-  }
-
-  @Test
   fun defaultVolatileGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
 
     assertEquals(true.toString(), RasterSource.defaultVolatile?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "volatile") }
-  }
-
-  @Test
-  fun defaultVolatileAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterSource.defaultVolatileAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "volatile") }
   }
 
@@ -980,36 +455,10 @@ class RasterSourceTest {
   }
 
   @Test
-  fun defaultPrefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterSource.defaultPrefetchZoomDeltaAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "prefetch-zoom-delta") }
-  }
-
-  @Test
   fun defaultMinimumTileUpdateIntervalGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
 
     assertEquals(1.0.toString(), RasterSource.defaultMinimumTileUpdateInterval?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "minimum-tile-update-interval") }
-  }
-
-  @Test
-  fun defaultMinimumTileUpdateIntervalAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), RasterSource.defaultMinimumTileUpdateIntervalAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "minimum-tile-update-interval") }
   }
 }

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/VectorSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/VectorSourceTest.kt
@@ -10,7 +10,6 @@ import com.mapbox.maps.StylePropertyValue
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
 import com.mapbox.maps.extension.style.StyleInterface
-import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import io.mockk.*
@@ -62,21 +61,6 @@ class VectorSourceTest {
   }
 
   @Test
-  fun urlAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      url(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("url=[+, 2, 3]"))
-  }
-
-  @Test
   fun urlSetAfterBind() {
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
@@ -87,41 +71,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun urlAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-    testSource.url(expression)
-
-    verify { style.setStyleSourceProperty("testId", "url", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun urlGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals("abc".toString(), testSource.url?.toString())
-    verify { style.getStyleSourceProperty("testId", "url") }
-  }
-
-  @Test
-  fun urlAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.urlAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "url") }
   }
 
@@ -137,21 +92,6 @@ class VectorSourceTest {
   }
 
   @Test
-  fun tilesAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      tiles(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("tiles=[+, 2, 3]"))
-  }
-
-  @Test
   fun tilesSetAfterBind() {
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
@@ -162,41 +102,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun tilesAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-    testSource.tiles(expression)
-
-    verify { style.setStyleSourceProperty("testId", "tiles", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun tilesGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(listOf("a", "b", "c"))
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(listOf("a", "b", "c").toString(), testSource.tiles?.toString())
-    verify { style.getStyleSourceProperty("testId", "tiles") }
-  }
-
-  @Test
-  fun tilesAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.tilesAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "tiles") }
   }
 
@@ -212,42 +123,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun boundsAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      bounds(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("bounds=[+, 2, 3]"))
-  }
-
-  @Test
   fun boundsGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(listOf(0.0, 1.0, 2.0, 3.0))
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(listOf(0.0, 1.0, 2.0, 3.0).toString(), testSource.bounds?.toString())
-    verify { style.getStyleSourceProperty("testId", "bounds") }
-  }
-
-  @Test
-  fun boundsAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.boundsAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "bounds") }
   }
 
@@ -263,42 +144,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun schemeAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      scheme(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("scheme=[+, 2, 3]"))
-  }
-
-  @Test
   fun schemeGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("xyz")
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(Scheme.XYZ, testSource.scheme)
-    verify { style.getStyleSourceProperty("testId", "scheme") }
-  }
-
-  @Test
-  fun schemeAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.schemeAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "scheme") }
   }
 
@@ -314,21 +165,6 @@ class VectorSourceTest {
   }
 
   @Test
-  fun minzoomAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      minzoom(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("minzoom=[+, 2, 3]"))
-  }
-
-  @Test
   fun minzoomSetAfterBind() {
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
@@ -339,41 +175,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun minzoomAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-    testSource.minzoom(expression)
-
-    verify { style.setStyleSourceProperty("testId", "minzoom", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun minzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.minzoom?.toString())
-    verify { style.getStyleSourceProperty("testId", "minzoom") }
-  }
-
-  @Test
-  fun minzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.minzoomAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "minzoom") }
   }
 
@@ -389,21 +196,6 @@ class VectorSourceTest {
   }
 
   @Test
-  fun maxzoomAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      maxzoom(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("maxzoom=[+, 2, 3]"))
-  }
-
-  @Test
   fun maxzoomSetAfterBind() {
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
@@ -414,41 +206,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun maxzoomAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-    testSource.maxzoom(expression)
-
-    verify { style.setStyleSourceProperty("testId", "maxzoom", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun maxzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.maxzoom?.toString())
-    verify { style.getStyleSourceProperty("testId", "maxzoom") }
-  }
-
-  @Test
-  fun maxzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.maxzoomAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "maxzoom") }
   }
 
@@ -464,42 +227,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun attributionAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      attribution(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("attribution=[+, 2, 3]"))
-  }
-
-  @Test
   fun attributionGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals("abc".toString(), testSource.attribution?.toString())
-    verify { style.getStyleSourceProperty("testId", "attribution") }
-  }
-
-  @Test
-  fun attributionAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.attributionAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "attribution") }
   }
 
@@ -515,21 +248,6 @@ class VectorSourceTest {
   }
 
   @Test
-  fun volatileAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      volatile(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.addStyleSource("testId", capture(valueSlot)) }
-    assertTrue(valueSlot.captured.toString().contains("volatile=[+, 2, 3]"))
-  }
-
-  @Test
   fun volatileSetAfterBind() {
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
@@ -540,41 +258,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun volatileAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-    testSource.volatile(expression)
-
-    verify { style.setStyleSourceProperty("testId", "volatile", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun volatileGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(true.toString(), testSource.volatile?.toString())
-    verify { style.getStyleSourceProperty("testId", "volatile") }
-  }
-
-  @Test
-  fun volatileAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.volatileAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "volatile") }
   }
 
@@ -590,21 +279,6 @@ class VectorSourceTest {
   }
 
   @Test
-  fun prefetchZoomDeltaAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      prefetchZoomDelta(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun prefetchZoomDeltaSetAfterBind() {
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
@@ -615,41 +289,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun prefetchZoomDeltaAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-    testSource.prefetchZoomDelta(expression)
-
-    verify { style.setStyleSourceProperty("testId", "prefetch-zoom-delta", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun prefetchZoomDeltaGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.prefetchZoomDelta?.toString())
-    verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
-  }
-
-  @Test
-  fun prefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.prefetchZoomDeltaAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "prefetch-zoom-delta") }
   }
 
@@ -665,21 +310,6 @@ class VectorSourceTest {
   }
 
   @Test
-  fun minimumTileUpdateIntervalAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      minimumTileUpdateInterval(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "minimum-tile-update-interval", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun minimumTileUpdateIntervalSetAfterBind() {
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
@@ -690,41 +320,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun minimumTileUpdateIntervalAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-    testSource.minimumTileUpdateInterval(expression)
-
-    verify { style.setStyleSourceProperty("testId", "minimum-tile-update-interval", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun minimumTileUpdateIntervalGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1.0.toString(), testSource.minimumTileUpdateInterval?.toString())
-    verify { style.getStyleSourceProperty("testId", "minimum-tile-update-interval") }
-  }
-
-  @Test
-  fun minimumTileUpdateIntervalAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.minimumTileUpdateIntervalAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "minimum-tile-update-interval") }
   }
 
@@ -740,21 +341,6 @@ class VectorSourceTest {
   }
 
   @Test
-  fun maxOverscaleFactorForParentTilesAsExpressionSet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {
-      maxOverscaleFactorForParentTiles(expression)
-    }
-    testSource.bindTo(style)
-
-    verify { style.setStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles", capture(valueSlot)) }
-    assertEquals("[+, 2, 3]", valueSlot.captured.toString())
-  }
-
-  @Test
   fun maxOverscaleFactorForParentTilesSetAfterBind() {
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
@@ -765,41 +351,12 @@ class VectorSourceTest {
   }
 
   @Test
-  fun maxOverscaleFactorForParentTilesAsExpressionSetAfterBind() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-    testSource.maxOverscaleFactorForParentTiles(expression)
-
-    verify { style.setStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "[+, 2, 3]")
-  }
-
-  @Test
   fun maxOverscaleFactorForParentTilesGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
     val testSource = vectorSource("testId") {}
     testSource.bindTo(style)
 
     assertEquals(1L.toString(), testSource.maxOverscaleFactorForParentTiles?.toString())
-    verify { style.getStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles") }
-  }
-
-  @Test
-  fun maxOverscaleFactorForParentTilesAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-    val testSource = vectorSource("testId") {}
-    testSource.bindTo(style)
-
-    assertEquals(expression.toString(), testSource.maxOverscaleFactorForParentTilesAsExpression?.toString())
     verify { style.getStyleSourceProperty("testId", "max-overscale-factor-for-parent-tiles") }
   }
 
@@ -845,36 +402,10 @@ class VectorSourceTest {
   }
 
   @Test
-  fun defaultSchemeAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), VectorSource.defaultSchemeAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "scheme") }
-  }
-
-  @Test
   fun defaultMinzoomGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1L)
 
     assertEquals(1L.toString(), VectorSource.defaultMinzoom?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "minzoom") }
-  }
-
-  @Test
-  fun defaultMinzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), VectorSource.defaultMinzoomAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "minzoom") }
   }
 
@@ -887,36 +418,10 @@ class VectorSourceTest {
   }
 
   @Test
-  fun defaultMaxzoomAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), VectorSource.defaultMaxzoomAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "maxzoom") }
-  }
-
-  @Test
   fun defaultVolatileGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(true)
 
     assertEquals(true.toString(), VectorSource.defaultVolatile?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "volatile") }
-  }
-
-  @Test
-  fun defaultVolatileAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), VectorSource.defaultVolatileAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "volatile") }
   }
 
@@ -929,36 +434,10 @@ class VectorSourceTest {
   }
 
   @Test
-  fun defaultPrefetchZoomDeltaAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), VectorSource.defaultPrefetchZoomDeltaAsExpression?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "prefetch-zoom-delta") }
-  }
-
-  @Test
   fun defaultMinimumTileUpdateIntervalGet() {
     every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
 
     assertEquals(1.0.toString(), VectorSource.defaultMinimumTileUpdateInterval?.toString())
-    verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "minimum-tile-update-interval") }
-  }
-
-  @Test
-  fun defaultMinimumTileUpdateIntervalAsExpressionGet() {
-    val expression = sum {
-      literal(2)
-      literal(3)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(expression)
-    every { styleProperty.kind } returns StylePropertyValueKind.EXPRESSION
-
-    assertEquals(expression.toString(), VectorSource.defaultMinimumTileUpdateIntervalAsExpression?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "minimum-tile-update-interval") }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Remove the expression getter/setters for source properties.</changelog>`.

### Summary of changes

Currently we generate expression getter/setters for source properties, however, capturing from gl-native team, sources don't support expressions at all.

We need to remove the expression getter/setters for source properties.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->