### PR TITLE
Remove strong ref dependency in snapshotter

### DIFF
--- a/sdk/src/test/java/com/mapbox/maps/SnapshotterTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/SnapshotterTest.kt
@@ -150,7 +150,7 @@ class SnapshotterTest {
   fun destroy() {
     snapshotter.destroy()
     verify { coreSnapshotter.cancel() }
-    Assert.assertNull(snapshotter.coreSnapshotter)
+    verify { coreSnapshotter.unsubscribe(any()) }
     Assert.assertNull(snapshotter.snapshotStyleCallback)
     Assert.assertNull(snapshotter.snapshotCreatedCallback)
   }
@@ -160,11 +160,5 @@ class SnapshotterTest {
     val callback = mockk<AsyncOperationResultCallback>(relaxed = true)
     snapshotter.clearData(callback)
     verify { Map.clearData(resourceOptions, callback) }
-  }
-
-  @Test(expected = NullPointerException::class)
-  fun isInTileModeWithException() {
-    snapshotter.destroy()
-    snapshotter.isInTileMode()
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #570 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Remove strong ref dependency in snapshotter that was leading to a memory leak if Snapshotter#destroy was not called explicitly.</changelog>`.

### Summary of changes

Remove strong ref dependency in snapshotter that was leading to a memory leak if Snapshotter#destroy was not called explicitly.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->