### PR TITLE
fixes property to enum conversion in PointAnnotation

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
@@ -83,8 +83,8 @@ class PointAnnotation(
      */
     get() {
       val value = jsonObject.get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR)
-      value?.let {
-        return IconAnchor.valueOf(it.asString)
+      value?.let { element ->
+        return IconAnchor.values().firstOrNull { it.value == element.asString }
       }
       return null
     }
@@ -268,8 +268,8 @@ class PointAnnotation(
      */
     get() {
       val value = jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR)
-      value?.let {
-        return TextAnchor.valueOf(it.asString)
+      value?.let { element ->
+        return TextAnchor.values().firstOrNull { it.value == element.asString }
       }
       return null
     }
@@ -330,8 +330,8 @@ class PointAnnotation(
      */
     get() {
       val value = jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)
-      value?.let {
-        return TextJustify.valueOf(it.asString)
+      value?.let { element ->
+        return TextJustify.values().firstOrNull { it.value == element.asString }
       }
       return null
     }
@@ -546,8 +546,8 @@ class PointAnnotation(
      */
     get() {
       val value = jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM)
-      value?.let {
-        return TextTransform.valueOf(it.asString)
+      value?.let { element ->
+        return TextTransform.values().firstOrNull { it.value == element.asString }
       }
       return null
     }


### PR DESCRIPTION
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/576

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix crash when accessing enum-type properties of PointAnnotation</changelog>`.

### Summary of changes

Parse enums in `PointAnnotation` by comparing `Enum.value` instead of the enum-case name.

### User impact (optional)

Users can access `iconAnchor` of PointAnnotation without the app crashing.