### PR TITLE
Fix get annotation enum property crash

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PointAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PointAnnotationManagerAndroidTest.kt
@@ -296,8 +296,16 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val annotation = pointAnnotationManager.create(PointAnnotationOptions().withPoint(Point.fromLngLat(0.0, 0.0)))
     assertEquals(annotation, pointAnnotationManager.annotations[0])
     annotation.point = Point.fromLngLat(1.0, 1.0)
+    annotation.iconAnchor = IconAnchor.CENTER
+    annotation.textAnchor = TextAnchor.CENTER
+    annotation.textJustify = TextJustify.AUTO
+    annotation.textTransform = TextTransform.NONE
     pointAnnotationManager.update(annotation)
     assertEquals(annotation, pointAnnotationManager.annotations[0])
+    assertEquals(IconAnchor.CENTER, annotation.iconAnchor)
+    assertEquals(TextAnchor.CENTER, annotation.textAnchor)
+    assertEquals(TextJustify.AUTO, annotation.textJustify)
+    assertEquals(TextTransform.NONE, annotation.textTransform)
   }
 
   @Test

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolylineAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolylineAnnotationManagerAndroidTest.kt
@@ -121,8 +121,10 @@ class PolylineAnnotationManagerAndroidTest : BaseMapTest() {
     val annotation = polylineAnnotationManager.create(PolylineAnnotationOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0))))
     assertEquals(annotation, polylineAnnotationManager.annotations[0])
     annotation.points = listOf(Point.fromLngLat(1.0, 1.0), Point.fromLngLat(1.0, 1.0))
+    annotation.lineJoin = LineJoin.BEVEL
     polylineAnnotationManager.update(annotation)
     assertEquals(annotation, polylineAnnotationManager.annotations[0])
+    assertEquals(LineJoin.BEVEL, annotation.lineJoin)
   }
 
   @Test

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
@@ -84,7 +84,7 @@ class PointAnnotation(
     get() {
       val value = jsonObject.get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR)
       value?.let {
-        return IconAnchor.valueOf(it.asString)
+        return IconAnchor.valueOf(it.asString.uppercase())
       }
       return null
     }
@@ -269,7 +269,7 @@ class PointAnnotation(
     get() {
       val value = jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR)
       value?.let {
-        return TextAnchor.valueOf(it.asString)
+        return TextAnchor.valueOf(it.asString.uppercase())
       }
       return null
     }
@@ -331,7 +331,7 @@ class PointAnnotation(
     get() {
       val value = jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)
       value?.let {
-        return TextJustify.valueOf(it.asString)
+        return TextJustify.valueOf(it.asString.uppercase())
       }
       return null
     }
@@ -547,7 +547,7 @@ class PointAnnotation(
     get() {
       val value = jsonObject.get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM)
       value?.let {
-        return TextTransform.valueOf(it.asString)
+        return TextTransform.valueOf(it.asString.uppercase())
       }
       return null
     }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotation.kt
@@ -64,7 +64,7 @@ class PolylineAnnotation(
     get() {
       val value = jsonObject.get(PolylineAnnotationOptions.PROPERTY_LINE_JOIN)
       value?.let {
-        return LineJoin.valueOf(it.asString)
+        return LineJoin.valueOf(it.asString.uppercase())
       }
       return null
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #576

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix get annotation enum property crash</changelog>`.

### Summary of changes
While using `valueOf` to create an enum,  the param must the same with enum name which is upper case, however, the value we saved in annotation is lower case, so the compare will fail and crash. 
This pr changes the value to the upper case while creating new enum instance.

cc: @AndreasBoehm 
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->