### PR TITLE
[build] use gradle.properties configuration to enable building from s…

### DIFF
--- a/android-auto-app/build.gradle.kts
+++ b/android-auto-app/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
   id("com.mapbox.maps.token")
 }
 
+val buildFromSource: String by project
+
 android {
   compileSdkVersion(AndroidVersions.compileSdkVersion)
   defaultConfig {
@@ -28,6 +30,12 @@ android {
   testOptions {
     if (!project.hasProperty("android.injected.invoked.from.ide")) {
       execution = "ANDROIDX_TEST_ORCHESTRATOR"
+    }
+  }
+
+  if (buildFromSource.toBoolean()) {
+    packagingOptions {
+      pickFirst("**/libc++_shared.so")
     }
   }
 }
@@ -66,5 +74,5 @@ project.apply {
   from("$rootDir/gradle/lint.gradle")
 }
 
-the<com.mapbox.AccessTokenExtension>().file =
-  "${project.rootDir}/android-auto-app/src/main/res/values/developer-config.xml"
+val localPath:String = org.apache.commons.io.FilenameUtils.getFullPathNoEndSeparator(project.buildscript.sourceFile.toString())
+the<com.mapbox.AccessTokenExtension>().file = "${localPath}/src/main/res/values/developer-config.xml"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
   id("com.mapbox.maps.token")
 }
 
+val buildFromSource: String by project
+
 android {
   compileSdkVersion(AndroidVersions.compileSdkVersion)
   defaultConfig {
@@ -53,6 +55,12 @@ android {
   dexOptions {
     javaMaxHeapSize = "4g"
   }
+
+  if (buildFromSource.toBoolean()) {
+    packagingOptions {
+      pickFirst("**/libc++_shared.so")
+    }
+  }
 }
 
 dependencies {
@@ -96,5 +104,5 @@ project.apply {
   from("$rootDir/gradle/lint.gradle")
 }
 
-the<com.mapbox.AccessTokenExtension>().file =
-  "${project.rootDir}/app/src/main/res/values/developer-config.xml"
+val localPath:String = org.apache.commons.io.FilenameUtils.getFullPathNoEndSeparator(project.buildscript.sourceFile.toString())
+the<com.mapbox.AccessTokenExtension>().file = "${localPath}/src/main/res/values/developer-config.xml"

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -62,6 +62,7 @@ object Dependencies {
   const val lintTests = "com.android.tools.lint:lint-tests:${Versions.lint}"
   const val testUtils = "com.android.tools:testutils:${Versions.lint}"
   const val hamcrest = "org.hamcrest:hamcrest:${Versions.hamcrest}"
+  const val annotations = androidxAnnotations
 }
 
 object Versions {

--- a/extension-style-app/build.gradle.kts
+++ b/extension-style-app/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
   id("com.mapbox.maps.token")
 }
 
+val buildFromSource: String by project
+
 android {
   compileSdkVersion(AndroidVersions.compileSdkVersion)
   defaultConfig {
@@ -28,6 +30,12 @@ android {
   testOptions {
     if (!project.hasProperty("android.injected.invoked.from.ide")) {
       execution = "ANDROIDX_TEST_ORCHESTRATOR"
+    }
+  }
+
+  if (buildFromSource.toBoolean()) {
+    packagingOptions {
+      pickFirst("**/libc++_shared.so")
     }
   }
 }
@@ -55,5 +63,5 @@ project.apply {
   from("$rootDir/gradle/lint.gradle")
 }
 
-the<com.mapbox.AccessTokenExtension>().file =
-  "${project.rootDir}/extension-style-app/src/main/res/values/developer-config.xml"
+val localPath:String = org.apache.commons.io.FilenameUtils.getFullPathNoEndSeparator(project.buildscript.sourceFile.toString())
+the<com.mapbox.AccessTokenExtension>().file = "${localPath}/src/main/res/values/developer-config.xml"

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,5 @@ kotlin.code.style=official
 # https://github.com/bcgit/bc-java/issues/762
 # https://issuetracker.google.com/issues/172784894
 android.jetifier.blacklist=bcprov-jdk15on
+# Build flag to build the full mapbox stack from source versus using binaries
+buildFromSource=false

--- a/sdk-base/build.gradle.kts
+++ b/sdk-base/build.gradle.kts
@@ -17,14 +17,21 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 }
+val buildFromSource: String by project
 
 dependencies {
   implementation(Dependencies.kotlin)
   implementation(Dependencies.mapboxBase)
   implementation(Dependencies.androidxAnnotations)
   api(Dependencies.mapboxGestures)
-  api(Dependencies.mapboxGlNative)
-  api(Dependencies.mapboxCoreCommon)
+  if (buildFromSource.toBoolean()) {
+    api(project(":maps-core"))
+    api(project(":common"))
+  } else {
+    api(Dependencies.mapboxGlNative)
+    api(Dependencies.mapboxCoreCommon)
+  }
+
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.mockk)
   testImplementation(Dependencies.androidxTestCore)

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -43,9 +43,16 @@ android {
   }
 }
 
+val buildFromSource: String by project
+
 dependencies {
   api(Dependencies.mapboxBase)
-  api(Dependencies.mapboxOkHttp)
+  if (buildFromSource.toBoolean()) {
+    api(project(":okhttp"))
+  } else {
+    api(Dependencies.mapboxOkHttp)
+  }
+
   implementation(Dependencies.mapboxAnnotations)
   api(project(":sdk-base"))
   implementation(project(":module-telemetry"))


### PR DESCRIPTION
This PR adds configuration needed to build the SDK from source when used as submodule as part of an internal repository. 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

 - add check against `buildFromSource` gradle.properties configuration
 - add either using binary or build from source for upstream deps (maps-core, common and okhttp)
 - include a pickFirst configuration for `"**/libc++_shared.so"` when building from source conform to upstream app configurations. This is expected to have duplicate behavior when building full stack. Doesn't and shouldn't occur when using binary dependencies.
 - patch up mapbox access token generation to use a local path vs root-dir. This enables multi folder modular builds where the  modules are picked up in one root folder level higher. 
