### PR TITLE
Revert AGP bump

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -98,30 +98,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Maps Android uses portions of the Kotlin Stdlib.
-
-URL: [https://kotlinlang.org/](https://kotlinlang.org/)
-
-License: [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Maps Android uses portions of the Kotlin Stdlib Common.
-
-URL: [https://kotlinlang.org/](https://kotlinlang.org/)
-
-License: [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Maps Android uses portions of the Kotlin Stdlib Jdk7.
-
-URL: [https://kotlinlang.org/](https://kotlinlang.org/)
-
-License: [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox Maps Android uses portions of the Mapbox Android Commmon OkHttp SDK.
 
 URL: [https://github.com/mapbox/mapbox-sdk](https://github.com/mapbox/mapbox-sdk)
@@ -191,6 +167,30 @@ Mapbox Maps Android uses portions of the Okio.
 URL: [https://github.com/square/okio/](https://github.com/square/okio/)
 
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Maps Android uses portions of the org.jetbrains.kotlin:kotlin-stdlib.
+
+URL: [https://kotlinlang.org/](https://kotlinlang.org/)
+
+License: [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Maps Android uses portions of the org.jetbrains.kotlin:kotlin-stdlib-common.
+
+URL: [https://kotlinlang.org/](https://kotlinlang.org/)
+
+License: [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Maps Android uses portions of the org.jetbrains.kotlin:kotlin-stdlib-jdk7.
+
+URL: [https://kotlinlang.org/](https://kotlinlang.org/)
+
+License: [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 

--- a/android-auto-app/build.gradle.kts
+++ b/android-auto-app/build.gradle.kts
@@ -15,7 +15,9 @@ android {
     versionName = "0.1.0"
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    testInstrumentationRunnerArguments = mapOf(
+      "clearPackageData" to "true"
+    )
   }
 
   compileOptions {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,9 @@ android {
     versionName = "0.1.0"
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    testInstrumentationRunnerArguments = mapOf(
+      "clearPackageData" to "true"
+    )
   }
   buildTypes {
     getByName("release") {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/LegacyOfflineActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/LegacyOfflineActivity.kt
@@ -1,11 +1,9 @@
 package com.mapbox.maps.testapp.examples
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.common.Logger
-import com.mapbox.common.OfflineSwitch
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
 import com.mapbox.maps.testapp.databinding.ActivityLegacyOfflineBinding
@@ -73,10 +71,7 @@ class LegacyOfflineActivity : AppCompatActivity() {
     )
   }
 
-  @SuppressLint("Lifecycle")
   private fun downloadComplete() {
-    // Disable network stack, so that the map can only load from downloaded region.
-    OfflineSwitch.getInstance().isMapboxStackConnected = false
     binding.downloadProgress.visibility = View.GONE
     binding.showMapButton.visibility = View.VISIBLE
     binding.showMapButton.setOnClickListener {
@@ -88,14 +83,25 @@ class LegacyOfflineActivity : AppCompatActivity() {
         mapboxMap.loadStyleUri(styleUrl)
       }
       setContentView(mapView)
+
       mapView?.onStart()
     }
+  }
+
+  override fun onStart() {
+    super.onStart()
+    mapView?.onStart()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView?.onStop()
   }
 
   override fun onDestroy() {
     super.onDestroy()
     offlineRegion.invalidate { }
-    OfflineSwitch.getInstance().isMapboxStackConnected = true
+    mapView?.onDestroy()
   }
 
   companion object {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/MapViewCustomizationActivity.kt
@@ -102,8 +102,24 @@ class MapViewCustomizationActivity : AppCompatActivity() {
     customMapView.getMapboxMap().loadStyleUri(Style.SATELLITE)
   }
 
+  override fun onStart() {
+    super.onStart()
+    customMapView.onStart()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    customMapView.onStop()
+  }
+
+  override fun onLowMemory() {
+    super.onLowMemory()
+    customMapView.onLowMemory()
+  }
+
   override fun onDestroy() {
     super.onDestroy()
+    customMapView.onDestroy()
     // Restore the default application-scoped resource settings, otherwise it will affect other activities
     ResourceOptionsManager.destroyDefault()
   }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/OfflineActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/OfflineActivity.kt
@@ -85,7 +85,6 @@ class OfflineActivity : AppCompatActivity() {
     }
   }
 
-  @SuppressLint("Lifecycle")
   private fun prepareViewMapButton() {
     // Disable network stack, so that the map can only load from downloaded region.
     OfflineSwitch.getInstance().isMapboxStackConnected = false
@@ -338,12 +337,23 @@ class OfflineActivity : AppCompatActivity() {
     offlineLogsAdapter.addLog(OfflineLog.Success(message))
   }
 
+  override fun onStart() {
+    super.onStart()
+    mapView?.onStart()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView?.onStop()
+  }
+
   override fun onDestroy() {
     super.onDestroy()
     // Remove downloaded style packs and tile regions.
     removeOfflineRegions()
     // Bring back the network connectivity when exiting the OfflineActivity.
     OfflineSwitch.getInstance().isMapboxStackConnected = true
+    mapView?.onDestroy()
   }
 
   private class OfflineLogsAdapter : RecyclerView.Adapter<OfflineLogsAdapter.ViewHolder>() {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/SurfaceRecyclerViewActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/SurfaceRecyclerViewActivity.kt
@@ -86,7 +86,6 @@ class SurfaceRecyclerViewActivity : AppCompatActivity() {
       }
     }
 
-    @SuppressLint("Lifecycle")
     override fun onViewAttachedToWindow(holder: RecyclerView.ViewHolder) {
       super.onViewAttachedToWindow(holder)
       if (holder is MapHolder) {
@@ -95,7 +94,6 @@ class SurfaceRecyclerViewActivity : AppCompatActivity() {
       }
     }
 
-    @SuppressLint("Lifecycle")
     override fun onViewDetachedFromWindow(holder: RecyclerView.ViewHolder) {
       super.onViewDetachedFromWindow(holder)
       if (holder is MapHolder) {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/java/DSLStylingJavaActivity.java
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/java/DSLStylingJavaActivity.java
@@ -192,4 +192,28 @@ public class DSLStylingJavaActivity extends AppCompatActivity implements OnMapCl
         builder.addLayer(rasterLayer);
         return builder.build();
     }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        mapView.onStart();
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        mapView.onStop();
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        mapView.onLowMemory();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        mapView.onDestroy();
+    }
 }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/java/RuntimeStylingJavaActivity.java
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/java/RuntimeStylingJavaActivity.java
@@ -388,4 +388,28 @@ public class RuntimeStylingJavaActivity extends AppCompatActivity {
         style.setStyleLayerProperty("layer", "icon-size", new Value(5.0));
         style.setStyleLayerProperty("layer", "icon-color", new Value("white"));
     }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        mapView.onStart();
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        mapView.onStop();
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        mapView.onLowMemory();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        mapView.onDestroy();
+    }
 }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/linesandpolygons/PolygonHolesActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/linesandpolygons/PolygonHolesActivity.kt
@@ -66,6 +66,26 @@ class PolygonHolesActivity : AppCompatActivity() {
     }
   }
 
+  override fun onStart() {
+    super.onStart()
+    mapView.onStart()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView.onStop()
+  }
+
+  override fun onLowMemory() {
+    super.onLowMemory()
+    mapView.onLowMemory()
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    mapView.onDestroy()
+  }
+
   companion object {
     val BLUE_COLOR = Color.parseColor("#3bb2d0")
     val POLYGON_COORDINATES = listOf(

--- a/app/src/main/res/layout/activity_annotation.xml
+++ b/app/src/main/res/layout/activity_annotation.xml
@@ -23,8 +23,7 @@
         android:layout_gravity="end|bottom"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:src="@drawable/ic_clear"
-        android:contentDescription="@string/delete_all" />
+        android:src="@drawable/ic_clear" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/changeStyle"
@@ -33,6 +32,5 @@
         android:layout_gravity="end|bottom"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="86dp"
-        android:src="@drawable/ic_layers"
-        android:contentDescription="@string/change_style" />
+        android:src="@drawable/ic_layers" />
 </FrameLayout>

--- a/app/src/main/res/layout/activity_custom_attribution.xml
+++ b/app/src/main/res/layout/activity_custom_attribution.xml
@@ -43,7 +43,6 @@
         android:layout_gravity="end|bottom"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:src="@drawable/ic_baseline_refresh_24"
-        android:contentDescription="@string/custom_attribution" />
+        android:src="@drawable/ic_baseline_refresh_24" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/activity_custom_layer.xml
+++ b/app/src/main/res/layout/activity_custom_layer.xml
@@ -19,7 +19,6 @@
         android:layout_margin="@dimen/fab_margin"
         android:src="@drawable/ic_layers"
         android:tint="@color/primary"
-        app:backgroundTint="@android:color/white"
-        android:contentDescription="@string/switch_visibility" />
+        app:backgroundTint="@android:color/white"/>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_fill_extrusion.xml
+++ b/app/src/main/res/layout/activity_fill_extrusion.xml
@@ -18,8 +18,7 @@
         android:layout_marginBottom="82dp"
         android:src="@drawable/ic_clear"
         app:backgroundTint="@color/accent"
-        app:layout_anchorGravity="top"
-        android:contentDescription="@string/toggle_light_position" />
+        app:layout_anchorGravity="top" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabLightColor"
@@ -28,7 +27,6 @@
         android:layout_gravity="end|bottom"
         android:layout_margin="16dp"
         android:src="@drawable/ic_paint"
-        app:backgroundTint="@color/primary"
-        android:contentDescription="@string/toggle_light_color" />
+        app:backgroundTint="@color/primary" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/activity_inset_map.xml
+++ b/app/src/main/res/layout/activity_inset_map.xml
@@ -34,7 +34,6 @@
         android:layout_gravity="end|bottom"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:src="@drawable/ic_swap_horiz_white_24dp"
-        android:contentDescription="@string/show_bounds_toggle" />
+        android:src="@drawable/ic_swap_horiz_white_24dp" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/activity_map_localization.xml
+++ b/app/src/main/res/layout/activity_map_localization.xml
@@ -30,8 +30,7 @@
         app:fabSize="normal"
         app:layout_constraintBottom_toTopOf="@id/fabLocalize"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        android:contentDescription="@string/switch_styles" />
+        app:layout_constraintRight_toRightOf="parent"/>
 
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -44,7 +43,6 @@
         app:backgroundTint="@color/primary"
         app:fabSize="normal"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:contentDescription="@string/localize" />
+        app:layout_constraintEnd_toEndOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_map_overlay.xml
+++ b/app/src/main/res/layout/activity_map_overlay.xml
@@ -51,7 +51,6 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="116dp"
         android:src="@drawable/ic_baseline_refresh_24"
-        app:backgroundTint="@color/primary"
-        android:contentDescription="@string/reframe" />
+        app:backgroundTint="@color/primary" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_rts_fill_pattern_tint.xml
+++ b/app/src/main/res/layout/activity_rts_fill_pattern_tint.xml
@@ -21,7 +21,6 @@
         android:layout_gravity="end|bottom"
         android:layout_margin="16dp"
         android:src="@drawable/ic_paint"
-        mapbox:backgroundTint="@color/primary"
-        android:contentDescription="@string/toggle_paint" />
+        mapbox:backgroundTint="@color/primary" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/activity_show_hide_layers.xml
+++ b/app/src/main/res/layout/activity_show_hide_layers.xml
@@ -21,7 +21,6 @@
         android:layout_gravity="end|bottom"
         android:layout_margin="16dp"
         android:src="@drawable/ic_layers_24dp"
-        tools:backgroundTint="@color/pink"
-        android:contentDescription="@string/toggle_layer" />
+        tools:backgroundTint="@color/pink"/>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_view_snapshot.xml
+++ b/app/src/main/res/layout/activity_view_snapshot.xml
@@ -19,8 +19,7 @@
         android:layout_margin="@dimen/fab_margin"
         android:src="@drawable/ic_layers"
         android:tint="@color/primary"
-        app:backgroundTint="@android:color/white"
-        android:contentDescription="@string/snapshot" />
+        app:backgroundTint="@android:color/white"/>
 
     <ImageView
         android:id="@+id/imageView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,17 +137,4 @@
     <string name="magnitude">Magnitude:</string>
     <string name="location">Location:</string>
     <string name="date">Date:</string>
-    <string name="delete_all">Delete All</string>
-    <string name="change_style">Change Style</string>
-    <string name="custom_attribution">Custom Attribution</string>
-    <string name="switch_visibility">Switch Visibility</string>
-    <string name="switch_styles">Switch styles</string>
-    <string name="localize">Localize</string>
-    <string name="toggle_layer">Toggle layer</string>
-    <string name="reframe">Reframe</string>
-    <string name="show_bounds_toggle">Show bounds toggle</string>
-    <string name="toggle_light_position">Toggle light position</string>
-    <string name="toggle_light_color">Toggle light color</string>
-    <string name="toggle_paint">Toggle paint</string>
-    <string name="snapshot">Snapshot</string>
 </resources>

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -65,10 +65,10 @@ object Dependencies {
 }
 
 object Versions {
-  const val pluginAndroidGradle = "4.2.2"
-  const val pluginKotlin = "1.5.21"
+  const val pluginAndroidGradle = "4.0.1"
+  const val pluginKotlin = "1.4.0"
   const val pluginLicense = "0.8.5"
-  const val pluginDokka =  "1.4.20"
+  const val pluginDokka =  "1.4.10"
   const val pluginJacoco = "0.2"
   const val mapboxAccessToken="0.2.1"
   const val mapboxSdkRegistry="0.4.0"

--- a/extension-style-app/build.gradle.kts
+++ b/extension-style-app/build.gradle.kts
@@ -15,7 +15,9 @@ android {
     versionName = "0.1.0"
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    testInstrumentationRunnerArguments = mapOf(
+      "clearPackageData" to "true"
+    )
   }
 
   compileOptions {

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.hiya.jacoco-android'
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.4"
 }
 
 tasks.withType(Test) {

--- a/gradle/lint.gradle
+++ b/gradle/lint.gradle
@@ -3,6 +3,6 @@ android {
         checkReleaseBuilds false
         warningsAsErrors true
         xmlReport false
-        disable 'AllowBackup', 'Recycle'
+        disable 'AllowBackup'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -16,7 +16,9 @@ android {
     targetSdkVersion(AndroidVersions.targetSdkVersion)
     consumerProguardFiles("proguard-rules.pro")
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    testInstrumentationRunnerArguments = mapOf(
+      "clearPackageData" to "true"
+    )
 
     if (project.hasProperty("android.injected.invoked.from.ide")) {
       buildConfigField("boolean", "RUN_FROM_IDE", "true")


### PR DESCRIPTION
Proposal to revert Android Gradle Plugin upgrade for now. This breaks building from source as upstream projects are still using older syntax that is not compatible with the 4.2.2 version. To re-revert this commit, we should start bumping the android tools version from top down (common -> gl-native -> mapbox-maps-android). 

@mapbox/maps-android thoughts?