### PR TITLE
Introduce drag layer/source for annotation plugin

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/CircleAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/CircleAnnotationManagerAndroidTest.kt
@@ -138,6 +138,20 @@ class CircleAnnotationManagerAndroidTest : BaseMapTest() {
   }
 
   @Test
+  fun deleteAndAdd() {
+    val circleAnnotationManager = mapView.annotations.createCircleAnnotationManager(mapView)
+    val annotation = circleAnnotationManager.create(
+      CircleAnnotationOptions()
+        .withPoint(Point.fromLngLat(0.0, 0.0))
+    )
+    assertEquals(annotation, circleAnnotationManager.annotations[0])
+    circleAnnotationManager.delete(annotation)
+    assertTrue(circleAnnotationManager.annotations.isEmpty())
+    circleAnnotationManager.addAnnotation(annotation)
+    assertEquals(annotation, circleAnnotationManager.annotations[0])
+  }
+
+  @Test
   fun deleteList() {
     val circleAnnotationManager = mapView.annotations.createCircleAnnotationManager(mapView)
     val list = listOf(

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PointAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PointAnnotationManagerAndroidTest.kt
@@ -338,6 +338,20 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
   }
 
   @Test
+  fun deleteAndAdd() {
+    val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
+    val annotation = pointAnnotationManager.create(
+      PointAnnotationOptions()
+        .withPoint(Point.fromLngLat(0.0, 0.0))
+    )
+    assertEquals(annotation, pointAnnotationManager.annotations[0])
+    pointAnnotationManager.delete(annotation)
+    assertTrue(pointAnnotationManager.annotations.isEmpty())
+    pointAnnotationManager.addAnnotation(annotation)
+    assertEquals(annotation, pointAnnotationManager.annotations[0])
+  }
+
+  @Test
   fun deleteList() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     val list = listOf(

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolygonAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolygonAnnotationManagerAndroidTest.kt
@@ -131,6 +131,20 @@ class PolygonAnnotationManagerAndroidTest : BaseMapTest() {
   }
 
   @Test
+  fun deleteAndAdd() {
+    val polygonAnnotationManager = mapView.annotations.createPolygonAnnotationManager(mapView)
+    val annotation = polygonAnnotationManager.create(
+      PolygonAnnotationOptions()
+        .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0), Point.fromLngLat(0.0, 1.0), Point.fromLngLat(1.0, 0.0))))
+    )
+    assertEquals(annotation, polygonAnnotationManager.annotations[0])
+    polygonAnnotationManager.delete(annotation)
+    assertTrue(polygonAnnotationManager.annotations.isEmpty())
+    polygonAnnotationManager.addAnnotation(annotation)
+    assertEquals(annotation, polygonAnnotationManager.annotations[0])
+  }
+
+  @Test
   fun deleteList() {
     val polygonAnnotationManager = mapView.annotations.createPolygonAnnotationManager(mapView)
     val list = listOf(

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolylineAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolylineAnnotationManagerAndroidTest.kt
@@ -157,6 +157,20 @@ class PolylineAnnotationManagerAndroidTest : BaseMapTest() {
   }
 
   @Test
+  fun deleteAndAdd() {
+    val polylineAnnotationManager = mapView.annotations.createPolylineAnnotationManager(mapView)
+    val annotation = polylineAnnotationManager.create(
+      PolylineAnnotationOptions()
+        .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
+    )
+    assertEquals(annotation, polylineAnnotationManager.annotations[0])
+    polylineAnnotationManager.delete(annotation)
+    assertTrue(polylineAnnotationManager.annotations.isEmpty())
+    polylineAnnotationManager.addAnnotation(annotation)
+    assertEquals(annotation, polylineAnnotationManager.annotations[0])
+  }
+
+  @Test
   fun deleteList() {
     val polylineAnnotationManager = mapView.annotations.createPolylineAnnotationManager(mapView)
     val list = listOf(

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/CircleAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/CircleAnnotationActivity.kt
@@ -69,7 +69,7 @@ class CircleAnnotationActivity : AppCompatActivity() {
 
         // random add circles across the globe
         val circleAnnotationOptionsList: MutableList<CircleAnnotationOptions> = ArrayList()
-        for (i in 0..20) {
+        for (i in 0..2000) {
           val color = Color.argb(255, random.nextInt(256), random.nextInt(256), random.nextInt(256))
           circleAnnotationOptionsList.add(
             CircleAnnotationOptions()

--- a/app/src/main/res/values/example_descriptions.xml
+++ b/app/src/main/res/values/example_descriptions.xml
@@ -67,7 +67,7 @@
     <string name="description_custom_attribution">Custom attribution showcase</string>
     <string name="description_annotation_fill">Show polygon annotations on a map</string>
     <string name="description_annotation_circle">Show circle annotations on a map</string>
-    <string name="description_annotation_symbol">Show symbol annotations on a map</string>
+    <string name="description_annotation_symbol">Show point annotations on a map</string>
     <string name="description_animate_annotation_symbol">Animate PointAnnotations on a map</string>
     <string name="description_annotation_symbol_cluster">Show fire hydrants in Washington DC area in a cluster</string>
     <string name="description_annotation_line">Show polyline annotations on a map</string>

--- a/app/src/main/res/values/example_titles.xml
+++ b/app/src/main/res/values/example_titles.xml
@@ -67,7 +67,7 @@
     <string name="activity_custom_attribution">Custom Attribution</string>
     <string name="activity_fill">Add a Fill/Polygon Annotation</string>
     <string name="activity_circle">Add Circle Annotations</string>
-    <string name="activity_symbol">Add Symbol Annotations</string>
+    <string name="activity_symbol">Add Point Annotations</string>
     <string name="activity_animate_symbol">AnimatePointAnnotation</string>
     <string name="activity_symbol_cluster">Add Cluster Symbol Annotations</string>
     <string name="activity_line">Add Polylines Annotations</string>

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps.plugin.annotation
 
 import android.graphics.PointF
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import com.mapbox.android.gestures.MoveGestureDetector
 import com.mapbox.common.Logger
 import com.mapbox.geojson.Feature
@@ -67,12 +68,14 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   private val mapClickResolver = MapClick()
   private val mapLongClickResolver = MapLongClick()
   private val mapMoveResolver = MapMove()
-  private var draggedAnnotation: T? = null
+  private var draggingAnnotation: T? = null
   private val annotationMap = ConcurrentHashMap<Long, T>()
   protected var touchAreaShiftX: Int = mapView.scrollX
   protected var touchAreaShiftY: Int = mapView.scrollY
   protected abstract val layerId: String
   protected abstract val sourceId: String
+  protected abstract val dragLayerId: String
+  protected abstract val dragSourceId: String
 
   @Suppress("UNCHECKED_CAST")
   private var gesturesPlugin: GesturesPlugin = delegateProvider.mapPluginProviderDelegate.getPlugin(
@@ -85,8 +88,14 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   /** The layer created by this manger. Annotations will be added to this layer.*/
   internal var layer: L? = null
 
-  /** The source created by this manger. Feature data will bed added to this source.*/
+  /** The source created by this manger. Feature data will be added to this source.*/
   internal var source: GeoJsonSource? = null
+
+  /** The drag layer created by this manger. The dragging annotation will be added to this layer.*/
+  internal var dragLayer: L? = null
+
+  /** The drag source created by this manger. The feature data of dragging annotation will be added to this source.*/
+  internal var dragSource: GeoJsonSource? = null
 
   /**
    * The added annotations
@@ -137,6 +146,13 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   protected abstract fun createLayer(): L
 
   /**
+   * Create the drag layer for dragging annotation
+   *
+   * @return the layer created
+   */
+  protected abstract fun createDragLayer(): L
+
+  /**
    * Set filter on the managed annotations.
    */
   abstract var layerFilter: Expression?
@@ -169,11 +185,19 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     }
   }
 
+  private fun createDragSource(): GeoJsonSource {
+    return geoJsonSource(dragSourceId) {
+      featureCollection(FeatureCollection.fromFeatures(listOf()))
+    }
+  }
+
   protected fun initLayerAndSource(style: StyleInterface) {
     if (layer == null || source == null) {
       initializeDataDrivenPropertyMap()
       source = createSource()
       layer = createLayer()
+      dragSource = createDragSource()
+      dragLayer = createDragLayer()
     }
 
     source?.let {
@@ -181,6 +205,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         style.addSource(it)
       }
     }
+
     layer?.let {
       if (!style.styleLayerExists(it.layerId)) {
         var layerAdded = false
@@ -198,6 +223,20 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         }
         if (!layerAdded) {
           style.addPersistentLayer(it)
+        }
+      }
+    }
+
+    dragSource?.let {
+      if (!style.styleSourceExists(it.sourceId)) {
+        style.addSource(it)
+      }
+    }
+    dragLayer?.let {
+      if (!style.styleLayerExists(it.layerId)) {
+        layer?.layerId?.let { aboveLayerId ->
+          // Add drag layer above the annotation layer
+          style.addPersistentLayer(it, LayerPosition(aboveLayerId, null, null))
         }
       }
     }
@@ -278,6 +317,19 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   }
 
   /**
+   * Add an annotation to MapView.
+   *
+   * @param annotation the annotation added to MapView.
+   */
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  fun addAnnotation(annotation: T) {
+    annotationMap[annotation.id] = annotation
+    delegateProvider.getStyle { style ->
+      updateSource(style)
+    }
+  }
+
+  /**
    * Create some annotations with the options
    */
   override fun create(options: List<S>): List<T> {
@@ -322,6 +374,37 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     annotationMap.clear()
     delegateProvider.getStyle { style ->
       updateSource(style)
+    }
+  }
+
+  private fun updateDragSource(style: StyleInterface) {
+    dragSource?.let { geoJsonSource ->
+      if (!style.styleSourceExists(geoJsonSource.sourceId)) {
+        Logger.e(TAG, "Can't update dragSource: source has not been added to style.")
+        return
+      }
+      val features = mutableListOf<Feature>()
+      draggingAnnotation?.let {
+        if (it.getType() == AnnotationType.PointAnnotation) {
+          val symbol = it as PointAnnotation
+          symbol.iconImage?.let { image ->
+            if (image.startsWith(PointAnnotation.ICON_DEFAULT_NAME_PREFIX)) {
+              // User set the bitmap icon, add the icon to style
+              symbol.iconImageBitmap?.let { bitmap ->
+                if (style.getStyleImage(image) == null) {
+                  val imagePlugin = image(image) {
+                    bitmap(bitmap)
+                  }
+                  style.addImage(imagePlugin)
+                }
+              }
+            }
+          }
+        }
+        features.add(Feature.fromGeometry(it.geometry, it.getJsonObjectCopy()))
+      }
+
+      geoJsonSource.featureCollection(FeatureCollection.fromFeatures(features), onDataParsed = {})
     }
   }
 
@@ -526,14 +609,14 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
      * Called when the move gesture is executing.
      */
     override fun onMove(detector: MoveGestureDetector): Boolean {
-      if (draggedAnnotation != null && (detector.pointersCount > 1 || !draggedAnnotation!!.isDraggable)) {
+      if (draggingAnnotation != null && (detector.pointersCount > 1 || !draggingAnnotation!!.isDraggable)) {
         // Stopping the drag when we don't work with a simple, on-pointer move anymore
         stopDragging()
         return true
       }
 
       // Updating symbol's position
-      draggedAnnotation?.let { annotation ->
+      draggingAnnotation?.let { annotation ->
         val moveObject = detector.getMoveObject(0)
         val x = moveObject.currentX - touchAreaShiftX
         val y = moveObject.currentY - touchAreaShiftY
@@ -550,7 +633,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         shiftedGeometry?.let { geometry ->
           annotation.geometry = geometry
           delegateProvider.getStyle { style ->
-            updateSource(style)
+            updateDragSource(style)
           }
           dragListeners.forEach {
             it.onAnnotationDrag(annotation)
@@ -572,17 +655,28 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     private fun startDragging(annotation: T): Boolean {
       if (annotation.isDraggable) {
         dragListeners.forEach { it.onAnnotationDragStarted(annotation) }
-        draggedAnnotation = annotation
+        draggingAnnotation = annotation
+        // Delete the dragging annotation from original source
+        delete(annotation)
+        delegateProvider.getStyle { style ->
+          // Add the dragging annotation to drag layer
+          updateDragSource(style)
+        }
         return true
       }
       return false
     }
 
     private fun stopDragging() {
-      draggedAnnotation?.let { annotation ->
+      draggingAnnotation?.let { annotation ->
         dragListeners.forEach { it.onAnnotationDragFinished(annotation) }
+        draggingAnnotation = null
+        addAnnotation(annotation)
       }
-      draggedAnnotation = null
+      // Remove dragging annotation from drag layer
+      delegateProvider.getStyle { style ->
+        updateDragSource(style)
+      }
     }
   }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -85,16 +85,16 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
       "is it available on the clazz path and loaded through the map?"
   )
 
-  /** The layer created by this manger. Annotations will be added to this layer.*/
+  /** The layer created by this manager. Annotations will be added to this layer.*/
   internal var layer: L? = null
 
-  /** The source created by this manger. Feature data will be added to this source.*/
+  /** The source created by this manager. Feature data will be added to this source.*/
   internal var source: GeoJsonSource? = null
 
-  /** The drag layer created by this manger. The dragging annotation will be added to this layer.*/
+  /** The drag layer created by this manager. The dragging annotation will be added to this layer.*/
   internal var dragLayer: L? = null
 
-  /** The drag source created by this manger. The feature data of dragging annotation will be added to this source.*/
+  /** The drag source created by this manager. The feature data of dragging annotation will be added to this source.*/
   internal var dragSource: GeoJsonSource? = null
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
@@ -30,7 +30,8 @@ class CircleAnnotationManager(
   private val id = ID_GENERATOR.incrementAndGet()
   override val layerId = annotationConfig?.layerId ?: "mapbox-android-circleAnnotation-layer-$id"
   override val sourceId = annotationConfig?.sourceId ?: "mapbox-android-circleAnnotation-source-$id"
-
+  override val dragLayerId = annotationConfig?.layerId ?: "mapbox-android-circleAnnotation-draglayer"
+  override val dragSourceId = annotationConfig?.sourceId ?: "mapbox-android-circleAnnotation-dragsource"
   init {
     delegateProvider.getStyle {
       initLayerAndSource(it)
@@ -50,14 +51,38 @@ class CircleAnnotationManager(
 
   override fun setDataDrivenPropertyIsUsed(property: String) {
     when (property) {
-      CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY -> layer?.circleSortKey(get(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY))
-      CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR -> layer?.circleBlur(get(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR))
-      CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR -> layer?.circleColor(get(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR))
-      CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY -> layer?.circleOpacity(get(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY))
-      CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS -> layer?.circleRadius(get(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS))
-      CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR -> layer?.circleStrokeColor(get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR))
-      CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY -> layer?.circleStrokeOpacity(get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY))
-      CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH -> layer?.circleStrokeWidth(get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH))
+      CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY -> {
+        layer?.circleSortKey(get(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY))
+        dragLayer?.circleSortKey(get(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY))
+      }
+      CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR -> {
+        layer?.circleBlur(get(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR))
+        dragLayer?.circleBlur(get(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR))
+      }
+      CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR -> {
+        layer?.circleColor(get(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR))
+        dragLayer?.circleColor(get(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR))
+      }
+      CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY -> {
+        layer?.circleOpacity(get(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY))
+        dragLayer?.circleOpacity(get(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY))
+      }
+      CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS -> {
+        layer?.circleRadius(get(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS))
+        dragLayer?.circleRadius(get(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS))
+      }
+      CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR -> {
+        layer?.circleStrokeColor(get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR))
+        dragLayer?.circleStrokeColor(get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR))
+      }
+      CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY -> {
+        layer?.circleStrokeOpacity(get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY))
+        dragLayer?.circleStrokeOpacity(get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY))
+      }
+      CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH -> {
+        layer?.circleStrokeWidth(get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH))
+        dragLayer?.circleStrokeWidth(get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH))
+      }
     }
   }
 
@@ -233,7 +258,9 @@ class CircleAnnotationManager(
   override fun createLayer(): CircleLayer {
     return circleLayer(layerId, sourceId) {}
   }
-
+  override fun createDragLayer(): CircleLayer {
+    return circleLayer(dragLayerId, dragSourceId) {}
+  }
   /**
    * The filter on the managed circleAnnotations.
    *

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
@@ -30,7 +30,8 @@ class PointAnnotationManager(
   private val id = ID_GENERATOR.incrementAndGet()
   override val layerId = annotationConfig?.layerId ?: "mapbox-android-pointAnnotation-layer-$id"
   override val sourceId = annotationConfig?.sourceId ?: "mapbox-android-pointAnnotation-source-$id"
-
+  override val dragLayerId = annotationConfig?.layerId ?: "mapbox-android-pointAnnotation-draglayer"
+  override val dragSourceId = annotationConfig?.sourceId ?: "mapbox-android-pointAnnotation-dragsource"
   init {
     delegateProvider.getStyle {
       initLayerAndSource(it)
@@ -73,32 +74,110 @@ class PointAnnotationManager(
 
   override fun setDataDrivenPropertyIsUsed(property: String) {
     when (property) {
-      PointAnnotationOptions.PROPERTY_ICON_ANCHOR -> layer?.iconAnchor(get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR))
-      PointAnnotationOptions.PROPERTY_ICON_IMAGE -> layer?.iconImage(get(PointAnnotationOptions.PROPERTY_ICON_IMAGE))
-      PointAnnotationOptions.PROPERTY_ICON_OFFSET -> layer?.iconOffset(get(PointAnnotationOptions.PROPERTY_ICON_OFFSET))
-      PointAnnotationOptions.PROPERTY_ICON_ROTATE -> layer?.iconRotate(get(PointAnnotationOptions.PROPERTY_ICON_ROTATE))
-      PointAnnotationOptions.PROPERTY_ICON_SIZE -> layer?.iconSize(get(PointAnnotationOptions.PROPERTY_ICON_SIZE))
-      PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY -> layer?.symbolSortKey(get(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY))
-      PointAnnotationOptions.PROPERTY_TEXT_ANCHOR -> layer?.textAnchor(get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR))
-      PointAnnotationOptions.PROPERTY_TEXT_FIELD -> layer?.textField(get(PointAnnotationOptions.PROPERTY_TEXT_FIELD))
-      PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY -> layer?.textJustify(get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY))
-      PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING -> layer?.textLetterSpacing(get(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING))
-      PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH -> layer?.textMaxWidth(get(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH))
-      PointAnnotationOptions.PROPERTY_TEXT_OFFSET -> layer?.textOffset(get(PointAnnotationOptions.PROPERTY_TEXT_OFFSET))
-      PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET -> layer?.textRadialOffset(get(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET))
-      PointAnnotationOptions.PROPERTY_TEXT_ROTATE -> layer?.textRotate(get(PointAnnotationOptions.PROPERTY_TEXT_ROTATE))
-      PointAnnotationOptions.PROPERTY_TEXT_SIZE -> layer?.textSize(get(PointAnnotationOptions.PROPERTY_TEXT_SIZE))
-      PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM -> layer?.textTransform(get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM))
-      PointAnnotationOptions.PROPERTY_ICON_COLOR -> layer?.iconColor(get(PointAnnotationOptions.PROPERTY_ICON_COLOR))
-      PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR -> layer?.iconHaloBlur(get(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR))
-      PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR -> layer?.iconHaloColor(get(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR))
-      PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH -> layer?.iconHaloWidth(get(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH))
-      PointAnnotationOptions.PROPERTY_ICON_OPACITY -> layer?.iconOpacity(get(PointAnnotationOptions.PROPERTY_ICON_OPACITY))
-      PointAnnotationOptions.PROPERTY_TEXT_COLOR -> layer?.textColor(get(PointAnnotationOptions.PROPERTY_TEXT_COLOR))
-      PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR -> layer?.textHaloBlur(get(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR))
-      PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR -> layer?.textHaloColor(get(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR))
-      PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH -> layer?.textHaloWidth(get(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH))
-      PointAnnotationOptions.PROPERTY_TEXT_OPACITY -> layer?.textOpacity(get(PointAnnotationOptions.PROPERTY_TEXT_OPACITY))
+      PointAnnotationOptions.PROPERTY_ICON_ANCHOR -> {
+        layer?.iconAnchor(get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR))
+        dragLayer?.iconAnchor(get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR))
+      }
+      PointAnnotationOptions.PROPERTY_ICON_IMAGE -> {
+        layer?.iconImage(get(PointAnnotationOptions.PROPERTY_ICON_IMAGE))
+        dragLayer?.iconImage(get(PointAnnotationOptions.PROPERTY_ICON_IMAGE))
+      }
+      PointAnnotationOptions.PROPERTY_ICON_OFFSET -> {
+        layer?.iconOffset(get(PointAnnotationOptions.PROPERTY_ICON_OFFSET))
+        dragLayer?.iconOffset(get(PointAnnotationOptions.PROPERTY_ICON_OFFSET))
+      }
+      PointAnnotationOptions.PROPERTY_ICON_ROTATE -> {
+        layer?.iconRotate(get(PointAnnotationOptions.PROPERTY_ICON_ROTATE))
+        dragLayer?.iconRotate(get(PointAnnotationOptions.PROPERTY_ICON_ROTATE))
+      }
+      PointAnnotationOptions.PROPERTY_ICON_SIZE -> {
+        layer?.iconSize(get(PointAnnotationOptions.PROPERTY_ICON_SIZE))
+        dragLayer?.iconSize(get(PointAnnotationOptions.PROPERTY_ICON_SIZE))
+      }
+      PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY -> {
+        layer?.symbolSortKey(get(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY))
+        dragLayer?.symbolSortKey(get(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_ANCHOR -> {
+        layer?.textAnchor(get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR))
+        dragLayer?.textAnchor(get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_FIELD -> {
+        layer?.textField(get(PointAnnotationOptions.PROPERTY_TEXT_FIELD))
+        dragLayer?.textField(get(PointAnnotationOptions.PROPERTY_TEXT_FIELD))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY -> {
+        layer?.textJustify(get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY))
+        dragLayer?.textJustify(get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING -> {
+        layer?.textLetterSpacing(get(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING))
+        dragLayer?.textLetterSpacing(get(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH -> {
+        layer?.textMaxWidth(get(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH))
+        dragLayer?.textMaxWidth(get(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_OFFSET -> {
+        layer?.textOffset(get(PointAnnotationOptions.PROPERTY_TEXT_OFFSET))
+        dragLayer?.textOffset(get(PointAnnotationOptions.PROPERTY_TEXT_OFFSET))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET -> {
+        layer?.textRadialOffset(get(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET))
+        dragLayer?.textRadialOffset(get(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_ROTATE -> {
+        layer?.textRotate(get(PointAnnotationOptions.PROPERTY_TEXT_ROTATE))
+        dragLayer?.textRotate(get(PointAnnotationOptions.PROPERTY_TEXT_ROTATE))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_SIZE -> {
+        layer?.textSize(get(PointAnnotationOptions.PROPERTY_TEXT_SIZE))
+        dragLayer?.textSize(get(PointAnnotationOptions.PROPERTY_TEXT_SIZE))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM -> {
+        layer?.textTransform(get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM))
+        dragLayer?.textTransform(get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM))
+      }
+      PointAnnotationOptions.PROPERTY_ICON_COLOR -> {
+        layer?.iconColor(get(PointAnnotationOptions.PROPERTY_ICON_COLOR))
+        dragLayer?.iconColor(get(PointAnnotationOptions.PROPERTY_ICON_COLOR))
+      }
+      PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR -> {
+        layer?.iconHaloBlur(get(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR))
+        dragLayer?.iconHaloBlur(get(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR))
+      }
+      PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR -> {
+        layer?.iconHaloColor(get(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR))
+        dragLayer?.iconHaloColor(get(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR))
+      }
+      PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH -> {
+        layer?.iconHaloWidth(get(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH))
+        dragLayer?.iconHaloWidth(get(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH))
+      }
+      PointAnnotationOptions.PROPERTY_ICON_OPACITY -> {
+        layer?.iconOpacity(get(PointAnnotationOptions.PROPERTY_ICON_OPACITY))
+        dragLayer?.iconOpacity(get(PointAnnotationOptions.PROPERTY_ICON_OPACITY))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_COLOR -> {
+        layer?.textColor(get(PointAnnotationOptions.PROPERTY_TEXT_COLOR))
+        dragLayer?.textColor(get(PointAnnotationOptions.PROPERTY_TEXT_COLOR))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR -> {
+        layer?.textHaloBlur(get(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR))
+        dragLayer?.textHaloBlur(get(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR -> {
+        layer?.textHaloColor(get(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR))
+        dragLayer?.textHaloColor(get(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH -> {
+        layer?.textHaloWidth(get(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH))
+        dragLayer?.textHaloWidth(get(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH))
+      }
+      PointAnnotationOptions.PROPERTY_TEXT_OPACITY -> {
+        layer?.textOpacity(get(PointAnnotationOptions.PROPERTY_TEXT_OPACITY))
+        dragLayer?.textOpacity(get(PointAnnotationOptions.PROPERTY_TEXT_OPACITY))
+      }
     }
   }
 
@@ -886,7 +965,9 @@ class PointAnnotationManager(
   override fun createLayer(): SymbolLayer {
     return symbolLayer(layerId, sourceId) {}
   }
-
+  override fun createDragLayer(): SymbolLayer {
+    return symbolLayer(dragLayerId, dragSourceId) {}
+  }
   /**
    * The filter on the managed pointAnnotations.
    *

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
@@ -30,7 +30,8 @@ class PolygonAnnotationManager(
   private val id = ID_GENERATOR.incrementAndGet()
   override val layerId = annotationConfig?.layerId ?: "mapbox-android-polygonAnnotation-layer-$id"
   override val sourceId = annotationConfig?.sourceId ?: "mapbox-android-polygonAnnotation-source-$id"
-
+  override val dragLayerId = annotationConfig?.layerId ?: "mapbox-android-polygonAnnotation-draglayer"
+  override val dragSourceId = annotationConfig?.sourceId ?: "mapbox-android-polygonAnnotation-dragsource"
   init {
     delegateProvider.getStyle {
       initLayerAndSource(it)
@@ -47,11 +48,26 @@ class PolygonAnnotationManager(
 
   override fun setDataDrivenPropertyIsUsed(property: String) {
     when (property) {
-      PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY -> layer?.fillSortKey(get(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY))
-      PolygonAnnotationOptions.PROPERTY_FILL_COLOR -> layer?.fillColor(get(PolygonAnnotationOptions.PROPERTY_FILL_COLOR))
-      PolygonAnnotationOptions.PROPERTY_FILL_OPACITY -> layer?.fillOpacity(get(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY))
-      PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR -> layer?.fillOutlineColor(get(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR))
-      PolygonAnnotationOptions.PROPERTY_FILL_PATTERN -> layer?.fillPattern(get(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN))
+      PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY -> {
+        layer?.fillSortKey(get(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY))
+        dragLayer?.fillSortKey(get(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY))
+      }
+      PolygonAnnotationOptions.PROPERTY_FILL_COLOR -> {
+        layer?.fillColor(get(PolygonAnnotationOptions.PROPERTY_FILL_COLOR))
+        dragLayer?.fillColor(get(PolygonAnnotationOptions.PROPERTY_FILL_COLOR))
+      }
+      PolygonAnnotationOptions.PROPERTY_FILL_OPACITY -> {
+        layer?.fillOpacity(get(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY))
+        dragLayer?.fillOpacity(get(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY))
+      }
+      PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR -> {
+        layer?.fillOutlineColor(get(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR))
+        dragLayer?.fillOutlineColor(get(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR))
+      }
+      PolygonAnnotationOptions.PROPERTY_FILL_PATTERN -> {
+        layer?.fillPattern(get(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN))
+        dragLayer?.fillPattern(get(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN))
+      }
     }
   }
 
@@ -197,7 +213,9 @@ class PolygonAnnotationManager(
   override fun createLayer(): FillLayer {
     return fillLayer(layerId, sourceId) {}
   }
-
+  override fun createDragLayer(): FillLayer {
+    return fillLayer(dragLayerId, dragSourceId) {}
+  }
   /**
    * The filter on the managed polygonAnnotations.
    *

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
@@ -30,7 +30,8 @@ class PolylineAnnotationManager(
   private val id = ID_GENERATOR.incrementAndGet()
   override val layerId = annotationConfig?.layerId ?: "mapbox-android-polylineAnnotation-layer-$id"
   override val sourceId = annotationConfig?.sourceId ?: "mapbox-android-polylineAnnotation-source-$id"
-
+  override val dragLayerId = annotationConfig?.layerId ?: "mapbox-android-polylineAnnotation-draglayer"
+  override val dragSourceId = annotationConfig?.sourceId ?: "mapbox-android-polylineAnnotation-dragsource"
   init {
     delegateProvider.getStyle {
       initLayerAndSource(it)
@@ -51,15 +52,42 @@ class PolylineAnnotationManager(
 
   override fun setDataDrivenPropertyIsUsed(property: String) {
     when (property) {
-      PolylineAnnotationOptions.PROPERTY_LINE_JOIN -> layer?.lineJoin(get(PolylineAnnotationOptions.PROPERTY_LINE_JOIN))
-      PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY -> layer?.lineSortKey(get(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY))
-      PolylineAnnotationOptions.PROPERTY_LINE_BLUR -> layer?.lineBlur(get(PolylineAnnotationOptions.PROPERTY_LINE_BLUR))
-      PolylineAnnotationOptions.PROPERTY_LINE_COLOR -> layer?.lineColor(get(PolylineAnnotationOptions.PROPERTY_LINE_COLOR))
-      PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH -> layer?.lineGapWidth(get(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH))
-      PolylineAnnotationOptions.PROPERTY_LINE_OFFSET -> layer?.lineOffset(get(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET))
-      PolylineAnnotationOptions.PROPERTY_LINE_OPACITY -> layer?.lineOpacity(get(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY))
-      PolylineAnnotationOptions.PROPERTY_LINE_PATTERN -> layer?.linePattern(get(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN))
-      PolylineAnnotationOptions.PROPERTY_LINE_WIDTH -> layer?.lineWidth(get(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH))
+      PolylineAnnotationOptions.PROPERTY_LINE_JOIN -> {
+        layer?.lineJoin(get(PolylineAnnotationOptions.PROPERTY_LINE_JOIN))
+        dragLayer?.lineJoin(get(PolylineAnnotationOptions.PROPERTY_LINE_JOIN))
+      }
+      PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY -> {
+        layer?.lineSortKey(get(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY))
+        dragLayer?.lineSortKey(get(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY))
+      }
+      PolylineAnnotationOptions.PROPERTY_LINE_BLUR -> {
+        layer?.lineBlur(get(PolylineAnnotationOptions.PROPERTY_LINE_BLUR))
+        dragLayer?.lineBlur(get(PolylineAnnotationOptions.PROPERTY_LINE_BLUR))
+      }
+      PolylineAnnotationOptions.PROPERTY_LINE_COLOR -> {
+        layer?.lineColor(get(PolylineAnnotationOptions.PROPERTY_LINE_COLOR))
+        dragLayer?.lineColor(get(PolylineAnnotationOptions.PROPERTY_LINE_COLOR))
+      }
+      PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH -> {
+        layer?.lineGapWidth(get(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH))
+        dragLayer?.lineGapWidth(get(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH))
+      }
+      PolylineAnnotationOptions.PROPERTY_LINE_OFFSET -> {
+        layer?.lineOffset(get(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET))
+        dragLayer?.lineOffset(get(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET))
+      }
+      PolylineAnnotationOptions.PROPERTY_LINE_OPACITY -> {
+        layer?.lineOpacity(get(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY))
+        dragLayer?.lineOpacity(get(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY))
+      }
+      PolylineAnnotationOptions.PROPERTY_LINE_PATTERN -> {
+        layer?.linePattern(get(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN))
+        dragLayer?.linePattern(get(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN))
+      }
+      PolylineAnnotationOptions.PROPERTY_LINE_WIDTH -> {
+        layer?.lineWidth(get(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH))
+        dragLayer?.lineWidth(get(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH))
+      }
     }
   }
 
@@ -285,7 +313,9 @@ class PolylineAnnotationManager(
   override fun createLayer(): LineLayer {
     return lineLayer(layerId, sourceId) {}
   }
-
+  override fun createDragLayer(): LineLayer {
+    return lineLayer(dragLayerId, dragSourceId) {}
+  }
   /**
    * The filter on the managed polylineAnnotations.
    *

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -366,10 +366,7 @@ class CircleAnnotationManagerTest {
 
     every { feature.getProperty(any()).asLong } returns 0L
 
-    val listener = mockk<OnCircleAnnotationDragListener>()
-    every { listener.onAnnotationDragStarted(any()) } just Runs
-    every { listener.onAnnotationDragFinished(any()) } just Runs
-    every { listener.onAnnotationDrag(any()) } just Runs
+    val listener = mockk<OnCircleAnnotationDragListener>(relaxed = true)
     manager.addDragListener(listener)
 
     annotation.isDraggable = true
@@ -380,6 +377,7 @@ class CircleAnnotationManagerTest {
 
     captureSlot.captured.onMoveBegin(moveGestureDetector)
     verify { listener.onAnnotationDragStarted(annotation) }
+    assertTrue(manager.annotations.isEmpty())
 
     val moveDistancesObject = mockk<MoveDistancesObject>()
     every { moveDistancesObject.currentX } returns 1f
@@ -389,12 +387,14 @@ class CircleAnnotationManagerTest {
     every { moveGestureDetector.getMoveObject(any()) } returns moveDistancesObject
     captureSlot.captured.onMove(moveGestureDetector)
     verify { listener.onAnnotationDrag(annotation) }
+    assertTrue(manager.annotations.isEmpty())
 
     captureSlot.captured.onMoveEnd(moveGestureDetector)
     verify { listener.onAnnotationDragFinished(annotation) }
 
     manager.removeDragListener(listener)
     assertTrue(manager.dragListeners.isEmpty())
+    assertEquals(1, manager.annotations.size)
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -479,10 +479,7 @@ class PointAnnotationManagerTest {
 
     every { feature.getProperty(any()).asLong } returns 0L
 
-    val listener = mockk<OnPointAnnotationDragListener>()
-    every { listener.onAnnotationDragStarted(any()) } just Runs
-    every { listener.onAnnotationDragFinished(any()) } just Runs
-    every { listener.onAnnotationDrag(any()) } just Runs
+    val listener = mockk<OnPointAnnotationDragListener>(relaxed = true)
     manager.addDragListener(listener)
 
     annotation.isDraggable = true
@@ -493,6 +490,7 @@ class PointAnnotationManagerTest {
 
     captureSlot.captured.onMoveBegin(moveGestureDetector)
     verify { listener.onAnnotationDragStarted(annotation) }
+    assertTrue(manager.annotations.isEmpty())
 
     val moveDistancesObject = mockk<MoveDistancesObject>()
     every { moveDistancesObject.currentX } returns 1f
@@ -502,12 +500,14 @@ class PointAnnotationManagerTest {
     every { moveGestureDetector.getMoveObject(any()) } returns moveDistancesObject
     captureSlot.captured.onMove(moveGestureDetector)
     verify { listener.onAnnotationDrag(annotation) }
+    assertTrue(manager.annotations.isEmpty())
 
     captureSlot.captured.onMoveEnd(moveGestureDetector)
     verify { listener.onAnnotationDragFinished(annotation) }
 
     manager.removeDragListener(listener)
     assertTrue(manager.dragListeners.isEmpty())
+    assertEquals(1, manager.annotations.size)
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -364,10 +364,7 @@ class PolygonAnnotationManagerTest {
 
     every { feature.getProperty(any()).asLong } returns 0L
 
-    val listener = mockk<OnPolygonAnnotationDragListener>()
-    every { listener.onAnnotationDragStarted(any()) } just Runs
-    every { listener.onAnnotationDragFinished(any()) } just Runs
-    every { listener.onAnnotationDrag(any()) } just Runs
+    val listener = mockk<OnPolygonAnnotationDragListener>(relaxed = true)
     manager.addDragListener(listener)
 
     annotation.isDraggable = true
@@ -378,6 +375,7 @@ class PolygonAnnotationManagerTest {
 
     captureSlot.captured.onMoveBegin(moveGestureDetector)
     verify { listener.onAnnotationDragStarted(annotation) }
+    assertTrue(manager.annotations.isEmpty())
 
     val moveDistancesObject = mockk<MoveDistancesObject>()
     every { moveDistancesObject.currentX } returns 1f
@@ -387,12 +385,14 @@ class PolygonAnnotationManagerTest {
     every { moveGestureDetector.getMoveObject(any()) } returns moveDistancesObject
     captureSlot.captured.onMove(moveGestureDetector)
     verify { listener.onAnnotationDrag(annotation) }
+    assertTrue(manager.annotations.isEmpty())
 
     captureSlot.captured.onMoveEnd(moveGestureDetector)
     verify { listener.onAnnotationDragFinished(annotation) }
 
     manager.removeDragListener(listener)
     assertTrue(manager.dragListeners.isEmpty())
+    assertEquals(1, manager.annotations.size)
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -369,10 +369,7 @@ class PolylineAnnotationManagerTest {
 
     every { feature.getProperty(any()).asLong } returns 0L
 
-    val listener = mockk<OnPolylineAnnotationDragListener>()
-    every { listener.onAnnotationDragStarted(any()) } just Runs
-    every { listener.onAnnotationDragFinished(any()) } just Runs
-    every { listener.onAnnotationDrag(any()) } just Runs
+    val listener = mockk<OnPolylineAnnotationDragListener>(relaxed = true)
     manager.addDragListener(listener)
 
     annotation.isDraggable = true
@@ -383,6 +380,7 @@ class PolylineAnnotationManagerTest {
 
     captureSlot.captured.onMoveBegin(moveGestureDetector)
     verify { listener.onAnnotationDragStarted(annotation) }
+    assertTrue(manager.annotations.isEmpty())
 
     val moveDistancesObject = mockk<MoveDistancesObject>()
     every { moveDistancesObject.currentX } returns 1f
@@ -392,12 +390,14 @@ class PolylineAnnotationManagerTest {
     every { moveGestureDetector.getMoveObject(any()) } returns moveDistancesObject
     captureSlot.captured.onMove(moveGestureDetector)
     verify { listener.onAnnotationDrag(annotation) }
+    assertTrue(manager.annotations.isEmpty())
 
     captureSlot.captured.onMoveEnd(moveGestureDetector)
     verify { listener.onAnnotationDragFinished(annotation) }
 
     manager.removeDragListener(listener)
     assertTrue(manager.dragListeners.isEmpty())
+    assertEquals(1, manager.annotations.size)
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Introduce drag layer/source for annotation plugin to improve drag performance.</changelog>`.

### Summary of changes
In the past we will update all annotations while dragging, so the more annotations, the worse performance will be.
In this pr, a drag layer/source is introduced and will only refresh the drag annotation on this layer while dragging. This can improve drag performance dramatically.

The following is a compare test with 2000+ CircleAnnotations  

before:

https://user-images.githubusercontent.com/8577318/130190840-9b07876a-f1c0-48ae-80e5-583f8ad2e9f1.mp4

after

https://user-images.githubusercontent.com/8577318/130190854-a89298ce-b63d-4b77-a6d6-29d754885c5e.mp4


<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)
Since we need to add the drag annotation back the original source, this will trigger a refresh for all annotations, so the drag annotation will blinks at the end of drag.
<!--
If this PR introduces user-facing changes, please note them here.
-->