### PR TITLE
Use the touch focal point to calculate the scroll displacement

### DIFF
--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesExt.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesExt.kt
@@ -3,6 +3,7 @@
 package com.mapbox.maps.plugin.gestures
 
 import com.mapbox.android.gestures.AndroidGesturesManager
+import com.mapbox.maps.plugin.PanScrollMode
 import com.mapbox.maps.plugin.Plugin
 import com.mapbox.maps.plugin.delegates.MapPluginExtensionsDelegate
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
@@ -142,3 +143,19 @@ fun MapPluginExtensionsDelegate.setGesturesManager(
  */
 fun MapPluginExtensionsDelegate.getGesturesSettings() =
   gesturesPlugin { getSettings() } as GesturesSettings?
+
+/**
+ * Returns if the panning is horizontally limited,
+ * In other words, the pan scroll mode is set to vertical.
+ */
+fun GesturesSettings.isPanHorizontallyLimited(): Boolean {
+  return panScrollMode == PanScrollMode.VERTICAL
+}
+
+/**
+ * Returns if the panning is vertically limited,
+ * In other words, the pan scroll mode is set to horizontal.
+ */
+fun GesturesSettings.isPanVerticallyLimited(): Boolean {
+  return panScrollMode == PanScrollMode.HORIZONTAL
+}

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
@@ -449,7 +449,13 @@ class GesturePluginTest {
         any()
       )
     } returns CameraOptions.Builder().build()
-    val handled = presenter.handleMove(mockk(), 50.0f, 50.0f)
+
+    val moveGestureDetector = mockk<MoveGestureDetector>()
+    every {
+      moveGestureDetector.focalPoint
+    } returns PointF(0.0f, 0.0f)
+
+    val handled = presenter.handleMove(moveGestureDetector, 50.0f, 50.0f)
     assert(handled)
     verify { listener.onMove(any()) }
     verify {


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Use touch focal point to calculate the correct scroll displacement when the map is pitched.</changelog>`.

### Summary of changes

This PR changes the scroll behavior to use the focal point of the gesture versus the center of the map. 
This results in a correct displacement when the map is pitched. 

#### Before

https://user-images.githubusercontent.com/2151639/130958023-ba6b6389-8b25-40c9-abb1-d9a38df102e7.mp4

#### After
https://user-images.githubusercontent.com/2151639/130957920-3bb0462a-4e2c-453b-bc36-8a2205db0cc2.mp4

