### PR TITLE
Fix camera animators ordering on Android 6 and lower

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -522,6 +522,19 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ExampleOverviewActivity" />
         </activity>
+
+        <activity
+            android:name=".examples.OngoingAnimationActivity"
+            android:description="@string/description_animate_camera_during_gesture"
+            android:exported="true"
+            android:label="@string/activity_camera_animate_during_gesture">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_camera" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".ExampleOverviewActivity" />
+        </activity>
         <activity
             android:name=".examples.markersandcallouts.MultipleGeometriesActivity"
             android:description="@string/description_dds_multiple_geometries"

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/OngoingAnimationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/OngoingAnimationActivity.kt
@@ -1,0 +1,54 @@
+package com.mapbox.maps.testapp.examples
+
+import android.animation.ValueAnimator
+import android.os.Bundle
+import android.view.animation.LinearInterpolator
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.MapView
+import com.mapbox.maps.plugin.animation.CameraAnimatorOptions
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.maps.plugin.gestures.gestures
+import java.util.concurrent.TimeUnit
+
+class OngoingAnimationActivity : AppCompatActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val mapView = MapView(this)
+    setContentView(mapView)
+    mapView.getMapboxMap()
+      .apply {
+        setCamera(
+          CameraOptions.Builder()
+            .center(Point.fromLngLat(LONGITUDE, LATITUDE))
+            .zoom(9.0)
+            .build()
+        )
+      }
+
+    mapView.gestures.addProtectedAnimationOwner(OWNER)
+
+    val anim = mapView.camera.createPitchAnimator(
+      CameraAnimatorOptions.cameraAnimatorOptions(0.0, 30.0) {
+        owner(OWNER)
+      }
+    ) {
+      repeatCount = ValueAnimator.INFINITE
+      repeatMode = ValueAnimator.REVERSE
+      duration = TimeUnit.SECONDS.toMillis(2)
+      interpolator = LinearInterpolator()
+    }
+
+    mapView.camera.registerAnimators(anim)
+
+    anim.start()
+  }
+
+  companion object {
+    private const val OWNER = "Example"
+    private const val LATITUDE = 40.0
+    private const val LONGITUDE = -74.5
+  }
+}

--- a/app/src/main/res/values/example_descriptions.xml
+++ b/app/src/main/res/values/example_descriptions.xml
@@ -35,6 +35,7 @@
     <string name="activity_camera_animate_description">Animate the camera changes with the fly-to animation. This causes the camera to ease from a starting point to an end destination.</string>
     <string name="activity_camera_predefined_animators_description">Use setCamera to animate the camera position.</string>
     <string name="description_camera_low_level">Animate the map camera to a new position using camera animators. Individual camera properties such as zoom, bearing, and center coordinate can be animated independently.</string>
+    <string name="description_animate_camera_during_gesture">Animate the map camera properties during user gestures.</string>
     <string name="description_fill_extrusion">Use extrusions to display buildings height in 3D map.</string>
     <string name="description_icon_property">Use different images to represent features within a symbol layer based on properties.</string>
     <string name="description_animated_image_source">Use an ImageSource and RasterLayer to animate weather data</string>

--- a/app/src/main/res/values/example_titles.xml
+++ b/app/src/main/res/values/example_titles.xml
@@ -38,6 +38,7 @@
     <string name="activity_animated_image_source">Animated ImageSource</string>
     <string name="activity_camera_predefined_animators_title">Using camera animations</string>
     <string name="activity_camera_low_level">Using custom camera animations</string>
+    <string name="activity_camera_animate_during_gesture">Continue camera animation during gestures</string>
     <string name="activity_dds_multiple_geometries_title">Draw multiple geometries</string>
     <string name="activity_wms_source">WMS Source</string>
     <string name="activity_within">Within expression</string>

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
@@ -174,6 +174,12 @@ abstract class CameraAnimator<out T> (
     super.cancel()
   }
 
+  /**
+   * true if CameraAnimator have any external listeners registered.
+   */
+  internal val hasUserListeners: Boolean
+    get() = userUpdateListeners.isNotEmpty()
+
   internal fun addInternalUpdateListener(listener: AnimatorUpdateListener) {
     super.removeAllUpdateListeners()
     internalUpdateListener = listener

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsChangeListenersTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsChangeListenersTest.kt
@@ -6,8 +6,11 @@ import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.plugin.animation.CameraAnimationsPluginImplTest.Companion.cameraState
 import org.junit.Assert
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import kotlin.math.pow
 
+@RunWith(RobolectricTestRunner::class)
 class CameraAnimationsChangeListenersTest {
 
   @Test

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -140,6 +140,9 @@ class CameraAnimationsPluginImplTest {
       playTogether(*animators)
       start()
     }
+
+    shadowOf(getMainLooper()).idle()
+
     verify { mapCameraManagerDelegate.setCamera(any<CameraOptions>()) }
   }
 
@@ -828,26 +831,6 @@ class CameraAnimationsPluginImplTest {
   }
 
   @Test
-  fun easeToTestNonZeroDurationWithListener() {
-    val options = mapAnimationOptions {
-      duration(1000)
-      animatorListener(object : AnimatorListenerAdapter() {})
-    }
-    cameraAnimationsPluginImpl.easeTo(cameraState.toCameraOptions(), options)
-    assert(cameraAnimationsPluginImpl.highLevelListener != null)
-  }
-
-  @Test
-  fun easeToTestZeroDurationWithListener() {
-    val options = mapAnimationOptions {
-      duration(0)
-      animatorListener(object : AnimatorListenerAdapter() {})
-    }
-    cameraAnimationsPluginImpl.easeTo(cameraState.toCameraOptions(), options)
-    assert(cameraAnimationsPluginImpl.highLevelListener == null)
-  }
-
-  @Test
   fun registerOnlyCameraAnimatorsTest() {
     val pitch = createPitchAnimator(15.0, 0, 5)
     val bearing = createBearingAnimator(10.0, 0, 5)
@@ -962,13 +945,9 @@ class CameraAnimationsPluginImplTest {
     bearingAnimator.start()
     pitchAnimator.start()
     shadowOf(getMainLooper()).idle()
-    // first bearing tick as first animation -
-    // bearing updated to start value and pitch is not updated
-    assertEquals(20.0, updateList[0].bearing!!, EPS)
-    assertEquals(0.0, updateList[0].pitch!!, EPS)
-    // second bearing tick as first animation -
-    // pitch is updated to start value
-    assertEquals(10.0, updateList[1].pitch!!, EPS)
+    // Both, tick and bearing are updated to the start values at first tick.
+    assertEquals(20.0, updateList.first().bearing!!, EPS)
+    assertEquals(10.0, updateList.first().pitch!!, EPS)
   }
 
   @Test


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix issue with camera animators ordering on Android 6 and lower by revisiting overall approach of applying accumulated camera changes.</changelog>`.

Fixes: #596

### Summary of changes

The root of the problem is in the order of callbacks from ValueAnimators, that is different on Android 6. This PR changes core logic of applying animators making it easier to support and delegating updating accumulated `CameraOptions` to `Handler` instead of relying on update of "oldest" animator (which as said before is not working as expected on Android 6 and below). This should not affect camera animation in any way, the only possible drawback is applying camera changes on each animator update if user has added `ValueAnimator.AnimatorUpdateListener` instead of accumulating which should be a pretty rare use-case.
