### PR TITLE
Preserve EGL setup on renderer stop

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -277,6 +277,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       handlerThread.post {
         if (this.surface != surface) {
           releaseEgl()
+          this.surface?.release()
           this.surface = surface
         }
         this.width = width

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -253,7 +253,8 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
         Choreographer.getInstance().removeFrameCallback(this)
         shouldExit = true
         lock.withLock {
-          if (mapboxRenderer.needDestroy) {
+          // TODO https://github.com/mapbox/mapbox-maps-android/issues/607
+          if (mapboxRenderer.needDestroy || mapboxRenderer is MapboxTextureViewRenderer) {
             mapboxRenderer.onSurfaceDestroyed()
             releaseEgl()
             surface?.release()

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -26,7 +26,7 @@ class MapboxRenderThreadTest {
   private lateinit var mapboxRenderer: MapboxRenderer
   private lateinit var eglCore: EGLCore
   private lateinit var workerThread: WorkerHandlerThread
-  private val waitTime = 100L
+  private val waitTime = 200L
 
   @Before
   fun setUp() {
@@ -126,8 +126,6 @@ class MapboxRenderThreadTest {
 
   @Test
   fun onSurfaceOnlyDestroyedTest() {
-    val latch = CountDownLatch(1)
-    every { mapboxRenderer.onSurfaceDestroyed() } answers { latch.countDown() }
     every { mapboxRenderer.needDestroy } returns false
     val surface = mockk<Surface>(relaxUnitFun = true)
     every { surface.isValid } returns true
@@ -135,10 +133,7 @@ class MapboxRenderThreadTest {
     every { eglCore.createWindowSurface(any()) } returns mockk(relaxed = true)
     mapboxRenderThread.onSurfaceCreated(surface, 1, 1)
     mapboxRenderThread.onSurfaceDestroyed()
-    if (!latch.await(waitTime, TimeUnit.MILLISECONDS)) {
-      throw TimeoutException()
-    }
-    verify { mapboxRenderer.onSurfaceDestroyed() }
+    verify(exactly = 0) { mapboxRenderer.onSurfaceDestroyed() }
     assert(workerThread.handlerThread.isAlive)
   }
 
@@ -162,8 +157,6 @@ class MapboxRenderThreadTest {
 
   @Test
   fun onSurfaceDestroyedWithRenderCallAfterTest() {
-    val latch = CountDownLatch(1)
-    every { mapboxRenderer.onSurfaceDestroyed() } answers { latch.countDown() }
     every { mapboxRenderer.needDestroy } returns false
     val surface = mockk<Surface>(relaxUnitFun = true)
     every { surface.isValid } returns true
@@ -174,14 +167,14 @@ class MapboxRenderThreadTest {
     Shadows.shadowOf(workerThread.handler?.looper).idle()
     mapboxRenderThread.requestRender()
     Shadows.shadowOf(workerThread.handler?.looper).idle()
-    if (!latch.await(waitTime, TimeUnit.MILLISECONDS)) {
-      throw TimeoutException()
-    }
-    verify(exactly = 1) {
+    // we do not destroy native renderer if it's stop and not destroy
+    verify(exactly = 0) {
       mapboxRenderer.onSurfaceDestroyed()
     }
-    // we should not even start preparing EGL again until new surface will not arrive
-    assert(!mapboxRenderThread.eglPrepared)
+    // EGL should still be prepared
+    assert(mapboxRenderThread.eglPrepared)
+    // EGL surface should be null
+    Assert.assertNull(mapboxRenderThread.eglSurface)
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/595

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Preserve EGL setup on renderer stop. This fixes full map reloading when map is brought out from background.</changelog>`.

### Summary of changes

Preserve EGL setup on renderer stop. It was too much releasing the whole surface, it should be enough to release only `EGLSurface`. For situations when there's not enough resources while app is in the background and GL context will be lost / Android did provide us new surface we have the code to recreate EGL setup fully.

This fixes full map reloading when map is brought out from background.

Before:


https://user-images.githubusercontent.com/15800566/131340782-0d723033-8e8f-47fe-8feb-93ee3ff6b484.mp4


After:

https://user-images.githubusercontent.com/15800566/131340269-4e0d7848-b2c3-47e8-b131-7bc6535a4425.mp4



<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->