### PR TITLE
[gestures] use the gesture focal point for fling displacement

### DIFF
--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesConstants.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesConstants.kt
@@ -2,7 +2,17 @@ package com.mapbox.maps.plugin.gestures
 
 internal const val SCHEDULED_ANIMATION_TIMEOUT = 150L
 
+/**
+ * The velocity threshold value at which a fling gesture is ignored.
+ * The Android OS produces fling gestures fairly easy, this results in unwanted fling invocations.
+ */
 internal const val VELOCITY_THRESHOLD_IGNORE_FLING: Long = 1000
+
+/**
+ * Fling limiting factor. Velocity values produces by Android OS are not related to any pixel value.
+ * We add a limiting factor to produce values that create a good user experience when flinging.
+ */
+internal const val FLING_LIMITING_FACTOR: Double = 10.0
 
 /**
  * Last scale span delta to XY velocity ratio required to execute scale velocity animation.
@@ -50,11 +60,6 @@ internal const val SHOVE_PIXEL_CHANGE_FACTOR = 0.1f
 internal const val MINIMUM_PITCH = 0.0
 
 /**
- * Maximum locked pitch value.
- */
-internal const val NORMAL_MAX_PITCH = 60.0
-
-/**
  * The currently supported maximum unlocked pitch value.
  */
 internal const val MAXIMUM_PITCH = 85.0
@@ -63,13 +68,3 @@ internal const val MAXIMUM_PITCH = 85.0
  * Default animation time
  */
 internal const val ANIMATION_DURATION = 300
-
-/**
- * Default short animation time
- */
-internal const val ANIMATION_DURATION_SHORT = 150
-
-/**
- * Animation time of a fling gesture
- */
-internal const val ANIMATION_DURATION_FLING_BASE = ANIMATION_DURATION_SHORT.toLong()

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
@@ -341,11 +341,14 @@ class GesturePluginTest {
         any()
       )
     } returns CameraOptions.Builder().build()
-    val result = presenter.handleFlingEvent(mockk(), mockk(), 10000f, 10000f)
+    val motionEvent = mockk<MotionEvent>()
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), 10000f, 10000f)
     verify {
       mapCameraManagerDelegate.getDragCameraOptions(
         ScreenCoordinate(0.0, 0.0),
-        ScreenCoordinate(666.6666666666667, 666.6666666666667)
+        ScreenCoordinate(1000.0, 1000.0)
       )
     }
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }
@@ -368,11 +371,14 @@ class GesturePluginTest {
       )
     } returns CameraOptions.Builder().build()
     presenter.updateSettings { panScrollMode = PanScrollMode.VERTICAL }
-    val result = presenter.handleFlingEvent(mockk(), mockk(), 10000f, 10000f)
+    val motionEvent = mockk<MotionEvent>()
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), 10000f, 10000f)
     verify {
       mapCameraManagerDelegate.getDragCameraOptions(
         ScreenCoordinate(0.0, 0.0),
-        ScreenCoordinate(0.0, 666.6666666666667)
+        ScreenCoordinate(0.0, 1000.0)
       )
     }
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }
@@ -395,11 +401,14 @@ class GesturePluginTest {
       )
     } returns CameraOptions.Builder().build()
     presenter.updateSettings { panScrollMode = PanScrollMode.HORIZONTAL }
-    val result = presenter.handleFlingEvent(mockk(), mockk(), 10000f, 10000f)
+    val motionEvent = mockk<MotionEvent>()
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), 10000f, 10000f)
     verify {
       mapCameraManagerDelegate.getDragCameraOptions(
         ScreenCoordinate(0.0, 0.0),
-        ScreenCoordinate(666.6666666666667, 0.0)
+        ScreenCoordinate(1000.0, 0.0)
       )
     }
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Use touch focal point to calculate the correct fling displacement.</changelog>`.

### Summary of changes

This PR changes the focal point of the fling gesture to match the motion event focal point (instead of center of screen). This is the equivalent of https://github.com/mapbox/mapbox-maps-android/pull/593 but for the fling event instead of scrolling. This PR does a cleanup of unused constants and simplifies the fling calculation. The used arbitrary boundary value of `VELOCITY_THRESHOLD_IGNORE_FLING` remains 1000 after testing multiple variations. Additionally, this PR cleans up the commented code of `cameraChangeDispatcher` which is a remains of the previous version of the SDK. 

#### Before 

https://user-images.githubusercontent.com/2151639/131368931-d8dec247-45c5-4fa6-bf50-2188539a44ea.mp4

#### After

https://user-images.githubusercontent.com/2151639/131368864-89eb6f0f-6674-4ffa-85b2-f49ab57ea63f.mp4