### PR TITLE
[locationcomponent] Enable location-indicator model type for 3D location puck.

### DIFF
--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapper.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapper.kt
@@ -13,6 +13,7 @@ internal class ModelLayerWrapper(
     layerProperties["id"] = Value(layerId)
     layerProperties["type"] = Value("model")
     layerProperties["source"] = Value(sourceId)
+    layerProperties["model-type"] = Value("location-indicator")
     layerProperties["model-scale"] = Value(modelScale.map { Value(it) })
     layerProperties["model-rotation"] = Value(modelRotation.map { Value(it) })
     layerProperties["model-translation"] = Value(modelTranslation.map { Value(it) })

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LayerSourceProviderTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LayerSourceProviderTest.kt
@@ -46,7 +46,7 @@ class LayerSourceProviderTest {
     val modelLayer = layerSourceProvider.getModelLayer(locationPuck3D)
     assertEquals(MODEL_LAYER, modelLayer.layerId)
     assertEquals(
-      "{model-rotation=[3.0, 2.0, 1.0], id=mapbox-location-model-layer, source=mapbox-location-model-source, type=model, model-scale=[1.0, 2.0, 3.0], model-translation=[0.0, 0.0, 0.0]}",
+      "{model-type=location-indicator, model-rotation=[3.0, 2.0, 1.0], id=mapbox-location-model-layer, source=mapbox-location-model-source, type=model, model-scale=[1.0, 2.0, 3.0], model-translation=[0.0, 0.0, 0.0]}",
       modelLayer.toValue().toString()
     )
   }

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapperTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapperTest.kt
@@ -38,7 +38,7 @@ class ModelLayerWrapperTest {
   @Test
   fun testInitialProperties() {
     val value = layer.toValue()
-    assertEquals("{model-rotation=[8.0], id=modelLayerId, source=modelSourceId, type=model, model-scale=[6.0], model-translation=[0.0]}", value.toString())
+    assertEquals("{model-type=location-indicator, model-rotation=[8.0], id=modelLayerId, source=modelSourceId, type=model, model-scale=[6.0], model-translation=[0.0]}", value.toString())
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Make 3D puck always over (in front of) 3D layers (buildings, landmarks, custom layer) but behind hill (terrain).</changelog>`.

### Summary of changes

Enable location-indicator model type for 3D location puck.

### User impact (optional)

The 3D puck will always over (in front of) 3D layers (buildings, landmarks, custom layer) but behind hill (terrain).