### PR TITLE
Allow empty geojson source

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     package="com.mapbox.maps.testapp">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:name=".MapboxApplication"
@@ -19,8 +19,8 @@
         <activity
             android:name=".ExampleOverviewActivity"
             android:exported="true"
-            android:launchMode="singleTop"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -120,14 +120,12 @@
             android:name=".examples.java.DSLStylingJavaActivity"
             android:description="@string/description_dsl_styling"
             android:exported="true"
-            android:label="@string/activity_dsl_styling">
-        </activity>
+            android:label="@string/activity_dsl_styling"></activity>
         <activity
             android:name=".examples.java.RuntimeStylingJavaActivity"
             android:description="@string/description_dsl_styling"
             android:exported="true"
-            android:label="@string/activity_dsl_styling">
-        </activity>
+            android:label="@string/activity_dsl_styling"></activity>
         <activity
             android:name=".examples.HeatmapLayerActivity"
             android:description="@string/description_heatmap_layer"

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/GeoJsonSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/GeoJsonSourceTest.kt
@@ -45,6 +45,14 @@ class GeoJsonSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
+  fun emptyDataTest() {
+    val testSource = geoJsonSource("testId")
+    setupSource(testSource)
+    assertNotNull(testSource.data)
+  }
+
+  @Test
+  @UiThreadTest
   fun urlTest() {
     val testSource = geoJsonSource("testId") {
       url(TEST_URI)

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -603,6 +603,13 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
+     * Initialize GeoJsonSource builder with default data to allow empty data source.
+     */
+    init {
+      this.data("")
+    }
+
+    /**
      * Build the GeoJsonSource.
      *
      * @return the GeoJsonSource
@@ -741,6 +748,17 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "prefetch-zoom-delta").silentUnwrap()
   }
 }
+
+/**
+ * DSL function for [GeoJsonSource] accepting empty data source.
+ * Immediately returns [GeoJsonSource] with no data set
+ *
+ * Using this method means that it is user's responsibility to proceed with adding data,
+ * layers or other style objects in [onGeoJsonParsed] callback.
+ */
+fun geoJsonSource(
+  id: String
+) = GeoJsonSource.Builder(id) {}.build()
 
 /**
  * DSL function for [GeoJsonSource] performing parsing using background thread.

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
@@ -414,6 +414,15 @@ class GeoJsonSourceTest {
   }
 
   @Test
+  fun emptyDataTest() {
+    val testSource = geoJsonSource("testId")
+    testSource.bindTo(style)
+
+    verify { style.addStyleSource("testId", capture(valueSlot)) }
+    assertTrue(valueSlot.captured.toString().contains("data="))
+  }
+
+  @Test
   fun featureAfterBindTest() {
     val feature = Feature.fromJson(
       """


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Allow geojson source to initialise with empty data.</changelog>`.

### Summary of changes
Allowing initialisation of geojson source with empty data.
Fixes : #552 

https://user-images.githubusercontent.com/11589497/131514678-115a09fc-9c37-49dd-868b-9a91d2d2358a.mp4
