### PR TITLE
Add CHANGE_NETWORK_STATE permission 

### DIFF
--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -1,1 +1,8 @@
-<manifest package="com.mapbox.maps" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.mapbox.maps">
+    <!--
+    Android 6.0 OS bug, need to include CHANGE_NETWORK_STATE permission
+    java.lang.SecurityException: was not granted: android.permission.CHANGE_NETWORK_STATE
+    when calling android.net.ConnectivityManager.requestNetwork
+    -->
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+</manifest>


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes
Add `CHANGE_NETWORK_STATE` permission to SDK manifest, this to workaround crash happening on Android 6.0 when the SDK calls into `android.net.ConnectivityManager.requestNetwork`. Only applicable to this specific Android version, see [SO](https://stackoverflow.com/questions/32185628/connectivitymanager-requestnetwork-in-android-6-0/34175655#34175655) for additional context. 
