### PR TITLE
Update prefetch zoom delta documentation to match actual behavior

### DIFF
--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -255,20 +255,22 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("generateId")
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   fun prefetchZoomDelta(value: Long = 4L) = apply {
     setVolatileProperty(PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value)))
   }
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   val prefetchZoomDelta: Long?
     /**
@@ -559,10 +561,11 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     fun prefetchZoomDelta(value: Long = 4L) = apply {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
@@ -734,10 +737,11 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId").silentUnwrap()
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     val defaultPrefetchZoomDelta: Long?
       /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -67,20 +67,22 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("coordinates")
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   fun prefetchZoomDelta(value: Long = 4L) = apply {
     setVolatileProperty(PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value)))
   }
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   val prefetchZoomDelta: Long?
     /**
@@ -118,10 +120,11 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     fun prefetchZoomDelta(value: Long = 4L) = apply {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
@@ -141,10 +144,11 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
   companion object {
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     val defaultPrefetchZoomDelta: Long?
       /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -175,20 +175,22 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("volatile")
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   fun prefetchZoomDelta(value: Long = 4L) = apply {
     setVolatileProperty(PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value)))
   }
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   val prefetchZoomDelta: Long?
     /**
@@ -327,10 +329,11 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     fun prefetchZoomDelta(value: Long = 4L) = apply {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
@@ -446,10 +449,11 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "volatile").silentUnwrap()
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     val defaultPrefetchZoomDelta: Long?
       /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -175,20 +175,22 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("volatile")
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   fun prefetchZoomDelta(value: Long = 4L) = apply {
     setVolatileProperty(PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value)))
   }
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   val prefetchZoomDelta: Long?
     /**
@@ -327,10 +329,11 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     fun prefetchZoomDelta(value: Long = 4L) = apply {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
@@ -446,10 +449,11 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster", "volatile").silentUnwrap()
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     val defaultPrefetchZoomDelta: Long?
       /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -164,20 +164,22 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("volatile")
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   fun prefetchZoomDelta(value: Long = 4L) = apply {
     setVolatileProperty(PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value)))
   }
 
   /**
-   * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-   * will first request a tile for `zoom - delta` in a attempt to display a full
-   * map at lower resolution as quick as possible. It will get clamped at the tile source
-   * minimum zoom. The default `delta` is 4.
+   * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+   * will first request a tile at zoom level lower than zoom - delta, but so that
+   * the zoom level is multiple of delta, in an attempt to display a full map at
+   * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+   * The default delta is 4.
    */
   val prefetchZoomDelta: Long?
     /**
@@ -308,10 +310,11 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     fun prefetchZoomDelta(value: Long = 4L) = apply {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
@@ -427,10 +430,11 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "volatile").silentUnwrap()
 
     /**
-     * When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map
-     * will first request a tile for `zoom - delta` in a attempt to display a full
-     * map at lower resolution as quick as possible. It will get clamped at the tile source
-     * minimum zoom. The default `delta` is 4.
+     * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
+     * will first request a tile at zoom level lower than zoom - delta, but so that
+     * the zoom level is multiple of delta, in an attempt to display a full map at
+     * lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
+     * The default delta is 4.
      */
     val defaultPrefetchZoomDelta: Long?
       /**


### PR DESCRIPTION
## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Update prefetch zoom delta documentation to match actual behavior</changelog>`.

### Summary of changes
Update prefetch zoom delta documentation to match actual behavior:

```
When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
will first request a tile at zoom level lower than zoom - delta, but so that
the zoom level is multiple of delta, in an attempt to display a full map at
lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
The default delta is 4.
```
