### PR TITLE
Enable update bitmap for annotations

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -391,12 +391,10 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
             if (image.startsWith(PointAnnotation.ICON_DEFAULT_NAME_PREFIX)) {
               // User set the bitmap icon, add the icon to style
               symbol.iconImageBitmap?.let { bitmap ->
-                if (style.getStyleImage(image) == null) {
-                  val imagePlugin = image(image) {
-                    bitmap(bitmap)
-                  }
-                  style.addImage(imagePlugin)
+                val imagePlugin = image(image) {
+                  bitmap(bitmap)
                 }
+                style.addImage(imagePlugin)
               }
             }
           }
@@ -432,12 +430,10 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
             if (image.startsWith(PointAnnotation.ICON_DEFAULT_NAME_PREFIX)) {
               // User set the bitmap icon, add the icon to style
               symbol.iconImageBitmap?.let { bitmap ->
-                if (style.getStyleImage(image) == null) {
-                  val imagePlugin = image(image) {
-                    bitmap(bitmap)
-                  }
-                  style.addImage(imagePlugin)
+                val imagePlugin = image(image) {
+                  bitmap(bitmap)
                 }
+                style.addImage(imagePlugin)
               }
             }
           }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -83,7 +83,6 @@ class CircleAnnotationManagerTest {
     every { style.removeStyleLayer(any()) } returns mockk()
     every { style.removeStyleSource(any()) } returns mockk()
     every { style.pixelRatio } returns 1.0f
-    every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMoveListener(any()) } just Runs

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -87,7 +87,6 @@ class PointAnnotationManagerTest {
     every { style.removeStyleLayer(any()) } returns mockk()
     every { style.removeStyleSource(any()) } returns mockk()
     every { style.pixelRatio } returns 1.0f
-    every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMoveListener(any()) } just Runs
@@ -288,15 +287,14 @@ class PointAnnotationManagerTest {
 
     verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
 
-    every { style.getStyleImage(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.generationId) } returns mockk()
     val annotation2 = manager.create(
       PointAnnotationOptions()
         .withIconImage(bitmap)
         .withPoint(Point.fromLngLat(0.0, 0.0))
     )
     assertEquals(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.generationId, annotation2.iconImage)
-
-    verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+    // The first one will trigger twice and the second one once.
+    verify(exactly = 3) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
   }
 
   @Test
@@ -307,7 +305,7 @@ class PointAnnotationManagerTest {
         .withPoint(Point.fromLngLat(0.0, 0.0))
     )
     verify(exactly = 0) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
-    annotation.iconImageBitmap = bitmap
+    annotation.iconImageBitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
     manager.update(annotation)
     verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
   }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -84,7 +84,6 @@ class PolygonAnnotationManagerTest {
     every { style.removeStyleLayer(any()) } returns mockk()
     every { style.removeStyleSource(any()) } returns mockk()
     every { style.pixelRatio } returns 1.0f
-    every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMoveListener(any()) } just Runs

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -85,7 +85,6 @@ class PolylineAnnotationManagerTest {
     every { style.removeStyleLayer(any()) } returns mockk()
     every { style.removeStyleSource(any()) } returns mockk()
     every { style.pixelRatio } returns 1.0f
-    every { style.getStyleImage(any()) } returns null
     every { gesturesPlugin.addOnMapClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMapLongClickListener(any()) } just Runs
     every { gesturesPlugin.addOnMoveListener(any()) } just Runs


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #587 

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes
In the past, we will check if the image has been added to style while updating annotations. While users update the image, we will not add that new image, so remove the check to enable image update.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->