### PR TITLE
Remove mbx-ci setup in snapshot build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,8 +209,6 @@ commands:
                   LAST_RELEASE=$(git describe --tags --abbrev=0)
                   if [[ -n ${CIRCLE_BRANCH+x} ]] && [[ $CIRCLE_BRANCH != "main" ]] && [[ "$(git log -1)" = *"publish_android_snapshot"* ]]; then
                     sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${LAST_RELEASE:9}-${CIRCLE_BRANCH}-SNAPSHOT/" gradle.properties
-                    curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci
-                    ./mbx-ci aws setup
                     make sdkRegistryUpload
                   fi
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Remove mbx-ci setup in snapshot build</changelog>`.

### Summary of changes
No need to setup mbx-ci for snapshot build as we set it in release job.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->