### PR TITLE
#618: continue to listen for event while map is stopped.

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/LoadStyleCallbackTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/LoadStyleCallbackTest.kt
@@ -1,0 +1,134 @@
+package com.mapbox.maps.testapp
+
+import android.app.Activity
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.mapbox.maps.Style
+import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
+import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class LoadStyleCallbackTest {
+
+  @get:Rule
+  var testActivity = ActivityScenarioRule(TestMapActivity::class.java)
+
+  @Test
+  fun loadStyleWhileStarted() {
+    val activity = testActivity.getActivity()
+
+    if (!activity.startLatch.await(2, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+
+    val latch = CountDownLatch(1)
+    testActivity.scenario.onActivity {
+      activity.mapView.getMapboxMap().loadStyleUri(
+        styleUri = Style.LIGHT,
+        onStyleLoaded = {
+          latch.countDown()
+        },
+        onMapLoadErrorListener = object : OnMapLoadErrorListener {
+          override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
+            throw AssertionError("Load $mapLoadErrorType failed with $message")
+          }
+        }
+      )
+    }
+
+    if (!latch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun stopAfterLoadStyle() {
+    val activity = testActivity.getActivity()
+
+    if (!activity.startLatch.await(2, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+
+    val latch = CountDownLatch(1)
+    testActivity.scenario.onActivity {
+      activity.mapView.getMapboxMap().loadStyleUri(
+        styleUri = Style.LIGHT,
+        onStyleLoaded = {
+          latch.countDown()
+        },
+        onMapLoadErrorListener = object : OnMapLoadErrorListener {
+          override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
+            throw AssertionError("Load $mapLoadErrorType failed with $message")
+          }
+        }
+      )
+
+      activity.mapView.onStop()
+    }
+
+    testActivity.scenario.moveToState(Lifecycle.State.CREATED)
+
+    if (!activity.stopLatch.await(2, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+
+    testActivity.scenario.moveToState(Lifecycle.State.RESUMED)
+
+    if (!latch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun loadStyleWhileStopped() {
+    val activity = testActivity.getActivity()
+
+    if (!activity.startLatch.await(2, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+
+    testActivity.scenario.moveToState(Lifecycle.State.CREATED)
+
+    if (!activity.stopLatch.await(2, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+
+    val latch = CountDownLatch(1)
+    testActivity.scenario.onActivity {
+      activity.mapView.getMapboxMap().loadStyleUri(
+        styleUri = Style.LIGHT,
+        onStyleLoaded = {
+          latch.countDown()
+        },
+        onMapLoadErrorListener = object : OnMapLoadErrorListener {
+          override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
+            throw AssertionError("Load $mapLoadErrorType failed with $message")
+          }
+        }
+      )
+    }
+
+    Thread.sleep(100)
+
+    testActivity.scenario.moveToState(Lifecycle.State.RESUMED)
+
+    if (!latch.await(10, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  private fun <T : Activity> ActivityScenarioRule<T>.getActivity(): T {
+    var activity: T? = null
+    scenario.onActivity { activity = it }
+    return activity!!
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1064,5 +1064,9 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ExampleOverviewActivity" />
         </activity>
+
+        <activity
+            android:name=".TestMapActivity"
+            android:exported="true" />
     </application>
 </manifest>

--- a/app/src/main/java/com/mapbox/maps/testapp/TestMapActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/TestMapActivity.kt
@@ -1,0 +1,51 @@
+package com.mapbox.maps.testapp
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.MapView
+import java.util.concurrent.CountDownLatch
+
+class TestMapActivity : AppCompatActivity() {
+  var startLatch = CountDownLatch(1)
+    private set
+  var stopLatch = CountDownLatch(0)
+    private set
+
+  lateinit var mapView: MapView
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    mapView = MapView(this)
+    setContentView(mapView)
+    mapView.getMapboxMap()
+      .apply {
+        setCamera(
+          CameraOptions.Builder()
+            .center(Point.fromLngLat(LONGITUDE, LATITUDE))
+            .zoom(9.0)
+            .build()
+        )
+      }
+  }
+
+  override fun onStart() {
+    super.onStart()
+    startLatch.countDown()
+    stopLatch = CountDownLatch(1)
+  }
+
+  override fun onStop() {
+    super.onStop()
+
+    stopLatch.countDown()
+    startLatch = CountDownLatch(1)
+  }
+
+  companion object {
+    private const val LATITUDE = 40.0
+    private const val LONGITUDE = -74.5
+  }
+}

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -119,7 +119,6 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     lifecycleState = LifecycleState.STATE_STARTED
 
     nativeObserver.apply {
-      onStart()
       addOnCameraChangeListener(onCameraChangedListener)
       addOnStyleDataLoadedListener(onStyleDataLoadedListener)
     }
@@ -142,7 +141,6 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     nativeObserver.apply {
       removeOnCameraChangeListener(onCameraChangedListener)
       removeOnStyleDataLoadedListener(onStyleDataLoadedListener)
-      onStop()
     }
     renderer.onStop()
     pluginRegistry.onStop()
@@ -155,7 +153,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     lifecycleState = LifecycleState.STATE_DESTROYED
 
     mapboxMap.onDestroy()
-    nativeObserver.clearListeners()
+    nativeObserver.onDestroy()
     renderer.onDestroy()
     pluginRegistry.cleanup()
   }

--- a/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
@@ -101,14 +101,6 @@ internal class NativeObserver(
     }
   }
 
-  internal fun onStop() {
-    observable.get()?.unsubscribe(this)
-  }
-
-  internal fun onStart() {
-    observable.get()?.subscribe(this, observedEvents)
-  }
-
   //
   // Add / Remove
   //
@@ -309,7 +301,9 @@ internal class NativeObserver(
     }
   }
 
-  fun clearListeners() {
+  fun onDestroy() {
+    observable.get()?.unsubscribe(this)
+
     onCameraChangeListeners.clear()
 
     onMapIdleListeners.clear()

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -124,7 +124,7 @@ class MapControllerTest {
   @Test
   fun onDestroy() {
     mapController.onDestroy()
-    verify { nativeObserver.clearListeners() }
+    verify { nativeObserver.onDestroy() }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
@@ -588,7 +588,9 @@ class NativeObserverTest {
     nativeObserver.onStyleImageUnusedListeners.add(mockk(relaxed = true))
     nativeObserver.onStyleDataLoadedListeners.add(mockk(relaxed = true))
 
-    nativeObserver.clearListeners()
+    nativeObserver.onDestroy()
+
+    verify { observableInterface.unsubscribe(eq(nativeObserver)) }
 
     assertTrue(nativeObserver.onCameraChangeListeners.isEmpty())
 


### PR DESCRIPTION
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #618 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

With these changes all MapboxMap callbacks will be called if a fragment/activity is stopped.

changelog: `<changelog>onStyleLoaded/onMapLoaded callbacks are called even if hosting fragment/activity is stopped</changelog>`