### PR TITLE
No need to check style load state for annotation plugin

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -310,7 +310,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     return option.build(currentId, this).also {
       annotationMap[it.id] = it
       currentId++
-      delegateProvider.getStyle { style ->
+      delegateProvider.getStyle(false) { style ->
         updateSource(style)
       }
     }
@@ -324,7 +324,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   fun addAnnotation(annotation: T) {
     annotationMap[annotation.id] = annotation
-    delegateProvider.getStyle { style ->
+    delegateProvider.getStyle(false) { style ->
       updateSource(style)
     }
   }
@@ -339,7 +339,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         currentId++
       }
     }
-    delegateProvider.getStyle { style ->
+    delegateProvider.getStyle(false) { style ->
       updateSource(style)
     }
     return list
@@ -350,7 +350,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
    */
   override fun delete(annotation: T) {
     annotationMap.remove(annotation.id)
-    delegateProvider.getStyle { style ->
+    delegateProvider.getStyle(false) { style ->
       updateSource(style)
     }
   }
@@ -362,7 +362,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     annotations.forEach {
       this.annotationMap.remove(it.id)
     }
-    delegateProvider.getStyle { style ->
+    delegateProvider.getStyle(false) { style ->
       updateSource(style)
     }
   }
@@ -372,7 +372,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
    */
   override fun deleteAll() {
     annotationMap.clear()
-    delegateProvider.getStyle { style ->
+    delegateProvider.getStyle(false) { style ->
       updateSource(style)
     }
   }
@@ -410,10 +410,6 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
    * Trigger an update to the underlying source
    */
   private fun updateSource(style: StyleInterface) {
-    if (!styleStateDelegate.isFullyLoaded()) {
-      Logger.e(TAG, "Can't update source: style is not fully loaded.")
-      return
-    }
     if (source == null || layer == null) {
       initLayerAndSource(style)
     }
@@ -454,7 +450,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   override fun update(annotation: T) {
     if (annotationMap.containsKey(annotation.id)) {
       annotationMap[annotation.id] = annotation
-      delegateProvider.getStyle { style ->
+      delegateProvider.getStyle(false) { style ->
         updateSource(style)
       }
     } else {
@@ -479,7 +475,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         )
       }
     }
-    delegateProvider.getStyle { style ->
+    delegateProvider.getStyle(false) { style ->
       updateSource(style)
     }
   }
@@ -488,7 +484,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
    * Invoked when Mapview or Annotation manager is destroyed.
    */
   override fun onDestroy() {
-    delegateProvider.getStyle { style ->
+    delegateProvider.getStyle(false) { style ->
       layer?.let {
         if (style.styleLayerExists(it.layerId)) {
           style.removeStyleLayer(it.layerId)
@@ -628,7 +624,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         }
         shiftedGeometry?.let { geometry ->
           annotation.geometry = geometry
-          delegateProvider.getStyle { style ->
+          delegateProvider.getStyle(false) { style ->
             updateDragSource(style)
           }
           dragListeners.forEach {
@@ -654,7 +650,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         draggingAnnotation = annotation
         // Delete the dragging annotation from original source
         delete(annotation)
-        delegateProvider.getStyle { style ->
+        delegateProvider.getStyle(false) { style ->
           // Add the dragging annotation to drag layer
           updateDragSource(style)
         }
@@ -670,7 +666,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
         addAnnotation(annotation)
       }
       // Remove dragging annotation from drag layer
-      delegateProvider.getStyle { style ->
+      delegateProvider.getStyle(false) { style ->
         updateDragSource(style)
       }
     }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
@@ -33,7 +33,7 @@ class CircleAnnotationManager(
   override val dragLayerId = annotationConfig?.layerId ?: "mapbox-android-circleAnnotation-draglayer"
   override val dragSourceId = annotationConfig?.sourceId ?: "mapbox-android-circleAnnotation-dragsource"
   init {
-    delegateProvider.getStyle {
+    delegateProvider.getStyle(false) {
       initLayerAndSource(it)
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
@@ -33,7 +33,7 @@ class PointAnnotationManager(
   override val dragLayerId = annotationConfig?.layerId ?: "mapbox-android-pointAnnotation-draglayer"
   override val dragSourceId = annotationConfig?.sourceId ?: "mapbox-android-pointAnnotation-dragsource"
   init {
-    delegateProvider.getStyle {
+    delegateProvider.getStyle(false) {
       initLayerAndSource(it)
       // Show all icons and texts by default. 
       iconAllowOverlap = true

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
@@ -33,7 +33,7 @@ class PolygonAnnotationManager(
   override val dragLayerId = annotationConfig?.layerId ?: "mapbox-android-polygonAnnotation-draglayer"
   override val dragSourceId = annotationConfig?.sourceId ?: "mapbox-android-polygonAnnotation-dragsource"
   init {
-    delegateProvider.getStyle {
+    delegateProvider.getStyle(false) {
       initLayerAndSource(it)
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
@@ -33,7 +33,7 @@ class PolylineAnnotationManager(
   override val dragLayerId = annotationConfig?.layerId ?: "mapbox-android-polylineAnnotation-draglayer"
   override val dragSourceId = annotationConfig?.sourceId ?: "mapbox-android-polylineAnnotation-dragsource"
   init {
-    delegateProvider.getStyle {
+    delegateProvider.getStyle(false) {
       initLayerAndSource(it)
     }
   }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -68,7 +68,7 @@ class CircleAnnotationManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceUtils")
     val captureCallback = slot<(StyleInterface) -> Unit>()
-    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }
     val styleStateDelegate = mockk<MapStyleStateDelegate>()
@@ -164,11 +164,11 @@ class CircleAnnotationManagerTest {
   fun initializeBeforeStyleLoad() {
     every { style.styleLayerExists("test_layer") } returns true
     val captureCallback = slot<(StyleInterface) -> Unit>()
-    every { delegateProvider.getStyle(capture(captureCallback)) } just Runs
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } just Runs
     manager = CircleAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
     // Style is not loaded, can't create and add layer to style
     verify(exactly = 0) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
-    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }
     manager.create(

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -72,7 +72,7 @@ class PointAnnotationManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceUtils")
     val captureCallback = slot<(StyleInterface) -> Unit>()
-    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }
     val styleStateDelegate = mockk<MapStyleStateDelegate>()
@@ -189,11 +189,11 @@ class PointAnnotationManagerTest {
   fun initializeBeforeStyleLoad() {
     every { style.styleLayerExists("test_layer") } returns true
     val captureCallback = slot<(StyleInterface) -> Unit>()
-    every { delegateProvider.getStyle(capture(captureCallback)) } just Runs
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } just Runs
     manager = PointAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
     // Style is not loaded, can't create and add layer to style
     verify(exactly = 0) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
-    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }
     manager.create(

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -69,7 +69,7 @@ class PolygonAnnotationManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceUtils")
     val captureCallback = slot<(StyleInterface) -> Unit>()
-    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }
     val styleStateDelegate = mockk<MapStyleStateDelegate>()
@@ -162,11 +162,11 @@ class PolygonAnnotationManagerTest {
   fun initializeBeforeStyleLoad() {
     every { style.styleLayerExists("test_layer") } returns true
     val captureCallback = slot<(StyleInterface) -> Unit>()
-    every { delegateProvider.getStyle(capture(captureCallback)) } just Runs
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } just Runs
     manager = PolygonAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
     // Style is not loaded, can't create and add layer to style
     verify(exactly = 0) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
-    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }
     manager.create(

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -70,7 +70,7 @@ class PolylineAnnotationManagerTest {
     mockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
     mockkStatic("com.mapbox.maps.extension.style.sources.SourceUtils")
     val captureCallback = slot<(StyleInterface) -> Unit>()
-    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }
     val styleStateDelegate = mockk<MapStyleStateDelegate>()
@@ -167,11 +167,11 @@ class PolylineAnnotationManagerTest {
   fun initializeBeforeStyleLoad() {
     every { style.styleLayerExists("test_layer") } returns true
     val captureCallback = slot<(StyleInterface) -> Unit>()
-    every { delegateProvider.getStyle(capture(captureCallback)) } just Runs
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } just Runs
     manager = PolylineAnnotationManager(mapView, delegateProvider, AnnotationConfig("test_layer"))
     // Style is not loaded, can't create and add layer to style
     verify(exactly = 0) { style.addPersistentLayer(any(), LayerPosition(null, "test_layer", null)) }
-    every { delegateProvider.getStyle(capture(captureCallback)) } answers {
+    every { delegateProvider.getStyle(false, capture(captureCallback)) } answers {
       captureCallback.captured.invoke(style)
     }
     manager.create(

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapDelegateProvider.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapDelegateProvider.kt
@@ -29,8 +29,10 @@ interface MapDelegateProvider {
 
   /**
    * Delegate used to interact with map's plugins.
+   * @param checkLoaded whether check the load state of the style. If set to true will only get the callback while style is loaded
+   * @param callback the callback to be invoked when the style is initialized or fully loaded
    */
-  fun getStyle(callback: (StyleInterface) -> Unit)
+  fun getStyle(checkLoaded: Boolean = true, callback: (StyleInterface) -> Unit)
 
   /**
    * Delegate used to interact with map's plugins.

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -216,11 +216,15 @@ class MapboxMap internal constructor(
   /**
    * Get the Style of the map asynchronously.
    *
-   * @param onStyleLoaded the callback to be invoked when the style is fully loaded
+   * @param checkLoaded whether check the load state of the style. If set to true will only get the callback while style is loaded
+   * @param onStyleLoaded the callback to be invoked when the style is initialized or fully loaded
    */
-  fun getStyle(onStyleLoaded: Style.OnStyleLoaded) {
+  fun getStyle(checkLoaded: Boolean = true, onStyleLoaded: Style.OnStyleLoaded) {
     if (::style.isInitialized) {
-      if (style.isStyleLoaded) {
+      if (!checkLoaded) {
+        // No check to check style state, return the style.
+        onStyleLoaded.onStyleLoaded(style)
+      } else if (style.isStyleLoaded) {
         // style has loaded, notify callback immediately
         onStyleLoaded.onStyleLoaded(style)
       } else {

--- a/sdk/src/main/java/com/mapbox/maps/plugin/MapDelegateProviderImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/plugin/MapDelegateProviderImpl.kt
@@ -17,7 +17,7 @@ internal class MapDelegateProviderImpl constructor(val mapboxMap: MapboxMap, map
   override val mapListenerDelegate: MapListenerDelegate by lazy { mapboxMap }
   override val styleStateDelegate: MapStyleStateDelegate by lazy { mapboxMap }
 
-  override fun getStyle(callback: (StyleInterface) -> Unit) {
-    mapboxMap.getStyle { style -> callback(style) }
+  override fun getStyle(checkLoaded: Boolean, callback: (StyleInterface) -> Unit) {
+    mapboxMap.getStyle(checkLoaded) { style -> callback(style) }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -190,8 +190,15 @@ class MapboxMapTest {
     mapboxMap.style = style
     every { style.isStyleLoaded } returns true
     val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
-    mapboxMap.getStyle(styleLoadCallback)
+    mapboxMap.getStyle(true, styleLoadCallback)
     verify { styleLoadCallback.onStyleLoaded(style) }
+
+    every { style.isStyleLoaded } returns false
+    val styleLoadCallback2 = mockk<Style.OnStyleLoaded>(relaxed = true)
+    mapboxMap.getStyle(true, styleLoadCallback2)
+    verify(exactly = 0) { styleLoadCallback2.onStyleLoaded(style) }
+    mapboxMap.getStyle(false, styleLoadCallback2)
+    verify(exactly = 1) { styleLoadCallback2.onStyleLoaded(style) }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/plugin/MapDelegateProviderTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/plugin/MapDelegateProviderTest.kt
@@ -64,7 +64,7 @@ class MapDelegateProviderTest {
   @Test
   fun styleExtensionDelegate() {
     val captureCallback = slot<Style.OnStyleLoaded>()
-    every { mapboxMap.getStyle(capture(captureCallback)) } answers {
+    every { mapboxMap.getStyle(true, capture(captureCallback)) } answers {
       captureCallback.captured.onStyleLoaded(mockk())
     }
     val mapDelegateProvider = MapDelegateProviderImpl(mapboxMap, mockk(), mockk())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #542

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>o need to check style load state for annotation plugin</changelog>`.

### Summary of changes
In the past, we can only get the style while it is fully loaded.  So if the style is loading, no annotation will be added to map before style load is complete.
But annotation plugin only needs the style, no matter the style is fully loaded or not. This pr add a default param `checkloaded` for `getStyle` API and let the annotation plugin don't check style load state.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->