### PR TITLE
Fix point annotation update bitmap affect others issue.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/PointAnnotationActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/PointAnnotationActivity.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.testapp.examples.markersandcallouts
 
 import android.animation.ValueAnimator
+import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
@@ -45,7 +46,7 @@ class PointAnnotationActivity : AppCompatActivity() {
       return AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]
     }
   private lateinit var annotationPlugin: AnnotationPlugin
-
+  private lateinit var blueBitmap: Bitmap
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val binding = ActivityAnnotationBinding.inflate(layoutInflater)
@@ -141,12 +142,25 @@ class PointAnnotationActivity : AppCompatActivity() {
             .withSymbolSortKey(10.0)
             .withDraggable(true)
           pointAnnotation = create(pointAnnotationOptions)
+
+          // random add symbols across the globe
+          val pointAnnotationOptionsList: MutableList<PointAnnotationOptions> = ArrayList()
+          for (i in 0..5) {
+            pointAnnotationOptionsList.add(
+              PointAnnotationOptions()
+                .withPoint(AnnotationUtils.createRandomPoint())
+                .withIconImage(it)
+                .withDraggable(true)
+            )
+          }
+          create(pointAnnotationOptionsList)
         }
 
         bitmapFromDrawableRes(
           this@PointAnnotationActivity,
           R.drawable.mapbox_user_icon
         )?.let {
+          blueBitmap = it
           // create nearby symbols
           val nearbyOptions: PointAnnotationOptions = PointAnnotationOptions()
             .withPoint(Point.fromLngLat(NEARBY_LONGITUDE, NEARBY_LATITUDE))
@@ -224,6 +238,7 @@ class PointAnnotationActivity : AppCompatActivity() {
         }
       }
       R.id.menu_action_icon -> pointAnnotation?.iconImage = MAKI_ICON_CAFE
+      R.id.menu_action_bitmap_blue -> pointAnnotation?.iconImageBitmap = blueBitmap
       R.id.menu_action_rotation -> pointAnnotation?.iconRotate = 45.0
       R.id.menu_action_text -> pointAnnotation?.textField = "Hello world!"
       R.id.menu_action_anchor -> pointAnnotation?.iconAnchor = IconAnchor.BOTTOM

--- a/app/src/main/res/menu/menu_symbol.xml
+++ b/app/src/main/res/menu/menu_symbol.xml
@@ -15,6 +15,10 @@
         android:title="@string/change_icon_to_coffee"
         app:showAsAction="never" />
     <item
+        android:id="@+id/menu_action_bitmap_blue"
+        android:title="@string/change_icon_to_bitmap_blue"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/menu_action_rotation"
         android:title="@string/set_icon_rotation_to_45"
         app:showAsAction="never" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="consume_click_event">Toggle consume click state</string>
     <string name="consume_click_event_toast">Click listener will consume click event: </string>
     <string name="change_icon_to_coffee">Change icon to coffee</string>
+    <string name="change_icon_to_bitmap_blue">Change icon to blue bitmap</string>
     <string name="set_icon_rotation_to_45">Set icon rotation to 45</string>
     <string name="set_icon_anchor_bottom">Set icon anchor bottom</string>
     <string name="set_icon_opacity_to_0_5f">Set icon opacity to 0.5f</string>

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
@@ -65,8 +65,9 @@ class PointAnnotation(
     set(value) {
       value?.let {
         field = it
-        if (iconImage == null) {
-          iconImage = ICON_DEFAULT_NAME_PREFIX + it.generationId
+        if (iconImage == null || iconImage!!.startsWith(ICON_DEFAULT_NAME_PREFIX)) {
+          // User does not set iconImage, update iconImage to this new bitmap
+          iconImage = ICON_DEFAULT_NAME_PREFIX + it.hashCode()
         }
       }
     }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -270,7 +270,7 @@ class PointAnnotationManagerTest {
         .withIconImage(bitmap)
         .withPoint(Point.fromLngLat(0.0, 0.0))
     )
-    assertEquals(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.generationId, annotation.iconImage)
+    assertEquals(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.hashCode(), annotation.iconImage)
 
     verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
   }
@@ -283,18 +283,18 @@ class PointAnnotationManagerTest {
         .withIconImage(bitmap)
         .withPoint(Point.fromLngLat(0.0, 0.0))
     )
-    assertEquals(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.generationId, annotation.iconImage)
+    assertEquals(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.hashCode(), annotation.iconImage)
 
-    verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+    verify(exactly = 1) { style.addStyleImage(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.hashCode(), any(), any(), any(), any(), any(), any()) }
 
     val annotation2 = manager.create(
       PointAnnotationOptions()
         .withIconImage(bitmap)
         .withPoint(Point.fromLngLat(0.0, 0.0))
     )
-    assertEquals(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.generationId, annotation2.iconImage)
+    assertEquals(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.hashCode(), annotation2.iconImage)
     // The first one will trigger twice and the second one once.
-    verify(exactly = 3) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+    verify(exactly = 3) { style.addStyleImage(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.hashCode(), any(), any(), any(), any(), any(), any()) }
   }
 
   @Test
@@ -302,12 +302,15 @@ class PointAnnotationManagerTest {
     every { style.styleSourceExists(any()) } returns true
     val annotation = manager.create(
       PointAnnotationOptions()
+        .withIconImage(bitmap)
         .withPoint(Point.fromLngLat(0.0, 0.0))
     )
-    verify(exactly = 0) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
-    annotation.iconImageBitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
+    verify(exactly = 1) { style.addStyleImage(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.hashCode(), any(), any(), any(), any(), any(), any()) }
+    val createBitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
+    annotation.iconImageBitmap = createBitmap
     manager.update(annotation)
-    verify(exactly = 1) { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) }
+    assertEquals(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + createBitmap.hashCode(), annotation.iconImage)
+    verify(exactly = 1) { style.addStyleImage(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + createBitmap.hashCode(), any(), any(), any(), any(), any(), any()) }
   }
   @Test
   fun create() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #587 

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix point annotation update bitmap affect others issue.</changelog>`.

### Summary of changes
This pr changes the way to generate `iconImage` value for PointAnnotation and update the check condition for updating bitmap.

https://user-images.githubusercontent.com/8577318/132826011-d2a99d8f-7597-4224-a263-48df7efe6795.mp4

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->