### PR TITLE
Add support for promoteId

### DIFF
--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/GeoJsonSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/GeoJsonSourceTest.kt
@@ -8,6 +8,7 @@ import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.extension.style.expressions.dsl.generated.*
 import com.mapbox.maps.extension.style.sources.generated.*
+import com.mapbox.maps.extension.style.types.PromoteId
 import com.mapbox.maps.testapp.style.BaseStyleTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -247,6 +248,17 @@ class GeoJsonSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
+  fun promoteIdTest() {
+    val testSource = geoJsonSource("testId") {
+      url(TEST_URI)
+      promoteId(PromoteId(propertyName = "abc"))
+    }
+    setupSource(testSource)
+    assertEquals(PromoteId(propertyName = "abc"), testSource.promoteId)
+  }
+
+  @Test
+  @UiThreadTest
   fun prefetchZoomDeltaTest() {
     val testSource = geoJsonSource("testId") {
       url(TEST_URI)
@@ -455,6 +467,7 @@ class GeoJsonSourceTest : BaseStyleTest() {
     assertNotNull("defaultClusterMaxZoom should not be null", GeoJsonSource.defaultClusterMaxZoom)
     assertNotNull("defaultLineMetrics should not be null", GeoJsonSource.defaultLineMetrics)
     assertNotNull("defaultGenerateId should not be null", GeoJsonSource.defaultGenerateId)
+    assertNotNull("defaultPromoteId should not be null", GeoJsonSource.defaultPromoteId)
     assertNotNull("defaultPrefetchZoomDelta should not be null", GeoJsonSource.defaultPrefetchZoomDelta)
   }
 

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/VectorSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/VectorSourceTest.kt
@@ -6,6 +6,7 @@ import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.sources.generated.*
+import com.mapbox.maps.extension.style.types.PromoteId
 import com.mapbox.maps.testapp.style.BaseStyleTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -146,6 +147,17 @@ class VectorSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
+  fun promoteIdTest() {
+    val testSource = vectorSource("testId") {
+      url(TEST_URI)
+      promoteId(PromoteId(propertyName = "abc"))
+    }
+    setupSource(testSource)
+    assertEquals(PromoteId(propertyName = "abc"), testSource.promoteId)
+  }
+
+  @Test
+  @UiThreadTest
   fun volatileTest() {
     val testSource = vectorSource("testId") {
       url(TEST_URI)
@@ -262,6 +274,7 @@ class VectorSourceTest : BaseStyleTest() {
     assertNotNull("defaultScheme should not be null", VectorSource.defaultScheme)
     assertNotNull("defaultMinzoom should not be null", VectorSource.defaultMinzoom)
     assertNotNull("defaultMaxzoom should not be null", VectorSource.defaultMaxzoom)
+    assertNotNull("defaultPromoteId should not be null", VectorSource.defaultPromoteId)
     assertNotNull("defaultVolatile should not be null", VectorSource.defaultVolatile)
     assertNotNull("defaultPrefetchZoomDelta should not be null", VectorSource.defaultPrefetchZoomDelta)
     assertNotNull("defaultMinimumTileUpdateInterval should not be null", VectorSource.defaultMinimumTileUpdateInterval)

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -16,6 +16,7 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.sources.OnGeoJsonParsed
 import com.mapbox.maps.extension.style.sources.Source
+import com.mapbox.maps.extension.style.types.PromoteId
 import com.mapbox.maps.extension.style.types.SourceDsl
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import com.mapbox.maps.extension.style.utils.silentUnwrap
@@ -253,6 +254,24 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return Boolean
      */
     get() = getPropertyValue("generateId")
+
+  /**
+   * A property to use as a feature id (for feature state). Either a property name, or
+   * an object of the form `{<sourceLayer>: <propertyName>}`.
+   */
+  val promoteId: PromoteId?
+    /**
+     * Get the PromoteId property
+     *
+     * @return PromoteId
+     */
+    get() {
+      val propertyValue = getPropertyValue<Any>("promoteId")
+      propertyValue?.let {
+        return PromoteId.fromProperty(it)
+      }
+      return null
+    }
 
   /**
    * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
@@ -561,6 +580,15 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
+     * A property to use as a feature id (for feature state). Either a property name, or
+     * an object of the form `{<sourceLayer>: <propertyName>}`.
+     */
+    fun promoteId(value: PromoteId) = apply {
+      val propertyValue = PropertyValue("promoteId", value.toValue())
+      properties[propertyValue.propertyName] = propertyValue
+    }
+
+    /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that
      * the zoom level is multiple of delta, in an attempt to display a full map at
@@ -735,6 +763,24 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        * @return Boolean
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId").silentUnwrap()
+
+    /**
+     * A property to use as a feature id (for feature state). Either a property name, or
+     * an object of the form `{<sourceLayer>: <propertyName>}`.
+     */
+    val defaultPromoteId: PromoteId?
+      /**
+       * Get the PromoteId property
+       *
+       * @return PromoteId
+       */
+      get() {
+        val propertyValue = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "promoteId").silentUnwrap<Any>()
+        propertyValue?.let {
+          return PromoteId.fromProperty(it)
+        }
+        return null
+      }
 
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -6,6 +6,7 @@ import com.mapbox.maps.StyleManager
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
 import com.mapbox.maps.extension.style.sources.Source
 import com.mapbox.maps.extension.style.sources.TileSet
+import com.mapbox.maps.extension.style.types.PromoteId
 import com.mapbox.maps.extension.style.types.SourceDsl
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import com.mapbox.maps.extension.style.utils.silentUnwrap
@@ -144,6 +145,25 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
      * @return String
      */
     get() = getPropertyValue("attribution")
+
+  /**
+   * A property to use as a feature id (for feature state). Either a property name, or
+   * an object of the form `{<sourceLayer>: <propertyName>}`. If specified as a string for a vector tile
+   * source, the same property is used across all its source layers.
+   */
+  val promoteId: PromoteId?
+    /**
+     * Get the PromoteId property
+     *
+     * @return PromoteId
+     */
+    get() {
+      val propertyValue = getPropertyValue<Any>("promoteId")
+      propertyValue?.let {
+        return PromoteId.fromProperty(it)
+      }
+      return null
+    }
 
   /**
    * A setting to determine whether a source's tiles are cached locally.
@@ -302,6 +322,16 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
+     * A property to use as a feature id (for feature state). Either a property name, or
+     * an object of the form `{<sourceLayer>: <propertyName>}`. If specified as a string for a vector tile
+     * source, the same property is used across all its source layers.
+     */
+    fun promoteId(value: PromoteId) = apply {
+      val propertyValue = PropertyValue("promoteId", value.toValue())
+      properties[propertyValue.propertyName] = propertyValue
+    }
+
+    /**
      * A setting to determine whether a source's tiles are cached locally.
      */
     fun volatile(value: Boolean = false) = apply {
@@ -417,6 +447,25 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
        * @return Long
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "maxzoom").silentUnwrap()
+
+    /**
+     * A property to use as a feature id (for feature state). Either a property name, or
+     * an object of the form `{<sourceLayer>: <propertyName>}`. If specified as a string for a vector tile
+     * source, the same property is used across all its source layers.
+     */
+    val defaultPromoteId: PromoteId?
+      /**
+       * Get the PromoteId property
+       *
+       * @return PromoteId
+       */
+      get() {
+        val propertyValue = StyleManager.getStyleSourcePropertyDefaultValue("vector", "promoteId").silentUnwrap<Any>()
+        propertyValue?.let {
+          return PromoteId.fromProperty(it)
+        }
+        return null
+      }
 
     /**
      * A setting to determine whether a source's tiles are cached locally.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/types/PromoteId.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/types/PromoteId.kt
@@ -1,0 +1,61 @@
+package com.mapbox.maps.extension.style.types
+
+import androidx.annotation.Keep
+import com.mapbox.bindgen.Value
+import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
+import com.mapbox.maps.extension.style.sources.generated.VectorSource
+import java.lang.UnsupportedOperationException
+
+/**
+ * Holds a property type to promote a specific feature for feature state API.
+ *
+ * @param sourceId source layer id of the feature, either source [GeoJsonSource] or [VectorSource].
+ * @param propertyName feature property name.
+ *
+ * For more information see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/types/#promoteId).
+ */
+@Keep
+data class PromoteId @JvmOverloads constructor(
+  val propertyName: String,
+  val sourceId: String? = null
+) {
+  internal fun toValue(): Value {
+    sourceId?.let {
+      return Value(hashMapOf(sourceId to Value(propertyName)))
+    }
+    return Value(propertyName)
+  }
+
+  /**
+   * Static variables and methods.
+   */
+  companion object {
+    /**
+     * Construct a [PromoteId] object from a Property returned from the core.
+     *
+     * @param propertyName feature property name.
+     * Can be either of type [String] or [HashMap] of <String,String>
+     * Throws [RuntimeException] exception if couldn't construct to [PromoteId].
+     */
+    internal fun fromProperty(propertyName: Any) = when (propertyName) {
+      is String -> {
+        PromoteId(propertyName)
+      }
+      is HashMap<*, *> -> {
+        @Suppress("UNCHECKED_CAST")
+        try {
+          val propertyMap = propertyName as HashMap<String, String>
+          if (!propertyMap.keys.isNullOrEmpty()) {
+            val key = propertyMap.keys.iterator().next()
+            PromoteId(propertyMap[key] ?: "", key)
+          } else {
+            PromoteId("")
+          }
+        } catch (e: RuntimeException) {
+          throw RuntimeException("$propertyName must be in the format HashMap<String,String>")
+        }
+      }
+      else -> throw UnsupportedOperationException("Wrapping ${propertyName::class.java.simpleName} to PromoteId is not supported.")
+    }
+  }
+}

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSourceTest.kt
@@ -16,6 +16,7 @@ import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.expressions.dsl.generated.get
 import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
 import com.mapbox.maps.extension.style.expressions.dsl.generated.sum
+import com.mapbox.maps.extension.style.types.PromoteId
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import io.mockk.*
 import org.junit.Assert.*
@@ -383,6 +384,27 @@ class GeoJsonSourceTest {
   }
 
   @Test
+  fun promoteIdSet() {
+    val testSource = geoJsonSource("testId") {
+      promoteId(PromoteId(propertyName = "abc"))
+    }
+    testSource.bindTo(style)
+
+    verify { style.addStyleSource("testId", capture(valueSlot)) }
+    assertTrue(valueSlot.captured.toString().contains("promoteId=abc"))
+  }
+
+  @Test
+  fun promoteIdGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
+    val testSource = geoJsonSource("testId") {}
+    testSource.bindTo(style)
+
+    assertEquals(PromoteId(propertyName = "abc"), testSource.promoteId)
+    verify { style.getStyleSourceProperty("testId", "promoteId") }
+  }
+
+  @Test
   fun prefetchZoomDeltaSet() {
     val testSource = geoJsonSource("testId") {
       prefetchZoomDelta(1L)
@@ -645,6 +667,15 @@ class GeoJsonSourceTest {
 
     assertEquals(true.toString(), GeoJsonSource.defaultGenerateId?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId") }
+  }
+
+  @Test
+  fun defaultPromoteIdGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
+
+    val expectedValue = PromoteId(propertyName = "abc")
+    assertEquals(expectedValue.toValue().toString(), GeoJsonSource.defaultPromoteId?.toValue().toString())
+    verify { StyleManager.getStyleSourcePropertyDefaultValue("geojson", "promoteId") }
   }
 
   @Test

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/VectorSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/VectorSourceTest.kt
@@ -11,6 +11,7 @@ import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.ShadowStyleManager
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.sources.TileSet
+import com.mapbox.maps.extension.style.types.PromoteId
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import io.mockk.*
 import org.junit.Assert.*
@@ -237,6 +238,27 @@ class VectorSourceTest {
   }
 
   @Test
+  fun promoteIdSet() {
+    val testSource = vectorSource("testId") {
+      promoteId(PromoteId(propertyName = "abc"))
+    }
+    testSource.bindTo(style)
+
+    verify { style.addStyleSource("testId", capture(valueSlot)) }
+    assertTrue(valueSlot.captured.toString().contains("promoteId=abc"))
+  }
+
+  @Test
+  fun promoteIdGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
+    val testSource = vectorSource("testId") {}
+    testSource.bindTo(style)
+
+    assertEquals(PromoteId(propertyName = "abc"), testSource.promoteId)
+    verify { style.getStyleSourceProperty("testId", "promoteId") }
+  }
+
+  @Test
   fun volatileSet() {
     val testSource = vectorSource("testId") {
       volatile(true)
@@ -415,6 +437,15 @@ class VectorSourceTest {
 
     assertEquals(1L.toString(), VectorSource.defaultMaxzoom?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "maxzoom") }
+  }
+
+  @Test
+  fun defaultPromoteIdGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue("abc")
+
+    val expectedValue = PromoteId(propertyName = "abc")
+    assertEquals(expectedValue.toValue().toString(), VectorSource.defaultPromoteId?.toValue().toString())
+    verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "promoteId") }
   }
 
   @Test

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/utils/PromoteIdTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/utils/PromoteIdTest.kt
@@ -1,0 +1,64 @@
+package com.mapbox.maps.extension.style.utils
+
+import com.mapbox.maps.extension.style.types.PromoteId
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PromoteIdTest {
+
+  @Test
+  fun fromProperty_String() {
+    val expected = PromoteId("property")
+    assertEquals(expected, PromoteId.fromProperty("property"))
+  }
+
+  @Test
+  fun fromProperty_EmptyString() {
+    val expected = PromoteId("")
+    assertEquals(expected, PromoteId.fromProperty(""))
+  }
+
+  @Test
+  fun fromProperty_HashMap() {
+    val expected = PromoteId("abc", "source")
+    val actual = PromoteId.fromProperty(hashMapOf("source" to "abc"))
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun fromProperty_EmptyHashMap() {
+    val expected = PromoteId("")
+    val actual = PromoteId.fromProperty(hashMapOf<String, String>())
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun fromProperty_NullSource() {
+    val expected = PromoteId("abc", null)
+    assertEquals(expected, PromoteId.fromProperty("abc"))
+  }
+
+  @Test
+  fun fromProperty_EmptyPropertyAndValidSource() {
+    val expected = PromoteId("", "source")
+    val actual = PromoteId.fromProperty(hashMapOf("source" to ""))
+    assertEquals(expected, actual)
+  }
+
+  @Test(expected = UnsupportedOperationException::class)
+  fun fromProperty_UnsupportedType() {
+    PromoteId.fromProperty(intArrayOf(1, 2, 3))
+  }
+
+  @Test(expected = UnsupportedOperationException::class)
+  fun fromProperty_UnsupportedDataClassType() {
+    PromoteId.fromProperty(MockType("source", "abc"))
+  }
+
+  @Test(expected = RuntimeException::class)
+  fun fromProperty_InvalidHashMapType() {
+    PromoteId.fromProperty(hashMapOf(1 to 2))
+  }
+
+  private data class MockType(val a: String, val b: String)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Add support for PromoteId to be used with Feature state API.</changelog>`.

### Summary of changes

This PR adds support for `promoteId` which allows a developer to promote a particular string / source-property to be the feature state id in features.

'promoteId' is a feature for geojson and vector sources. The feature allows to promote feature's property to a feature id, so that promoted id can be used with FeatureState API.
