### PR TITLE
Fix drag annotation blink issue

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -1,6 +1,8 @@
 package com.mapbox.maps.plugin.annotation
 
 import android.graphics.PointF
+import android.os.Handler
+import android.os.Looper
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import com.mapbox.android.gestures.MoveGestureDetector
@@ -34,10 +36,8 @@ import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
 import com.mapbox.maps.plugin.InvalidPluginConfigurationException
 import com.mapbox.maps.plugin.Plugin.Companion.MAPBOX_GESTURES_PLUGIN_ID
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
-import com.mapbox.maps.plugin.delegates.MapCameraManagerDelegate
-import com.mapbox.maps.plugin.delegates.MapDelegateProvider
-import com.mapbox.maps.plugin.delegates.MapFeatureQueryDelegate
-import com.mapbox.maps.plugin.delegates.MapStyleStateDelegate
+import com.mapbox.maps.plugin.delegates.*
+import com.mapbox.maps.plugin.delegates.listeners.OnMapIdleListener
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
@@ -61,6 +61,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   private var mapFeatureQueryDelegate: MapFeatureQueryDelegate =
     delegateProvider.mapFeatureQueryDelegate
   private var styleStateDelegate: MapStyleStateDelegate = delegateProvider.styleStateDelegate
+  private var mapListenerDelegate: MapListenerDelegate = delegateProvider.mapListenerDelegate
   protected val dataDrivenPropertyUsageMap: MutableMap<String, Boolean> = HashMap()
   private var currentId = 0L
   private var width = 0
@@ -76,6 +77,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   protected abstract val sourceId: String
   protected abstract val dragLayerId: String
   protected abstract val dragSourceId: String
+  private val handler = Handler(Looper.getMainLooper())
 
   @Suppress("UNCHECKED_CAST")
   private var gesturesPlugin: GesturesPlugin = delegateProvider.mapPluginProviderDelegate.getPlugin(
@@ -663,15 +665,28 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
       return false
     }
 
+    private val onMapIdleListener: OnMapIdleListener = object : OnMapIdleListener {
+      override fun onMapIdle() {
+        mapListenerDelegate.removeOnMapIdleListener(this)
+        // Remove dragging annotation from drag layer
+        handler.postDelayed(
+          {
+            // Delay 1 second to avoid blink issue.
+            delegateProvider.getStyle { style ->
+              updateDragSource(style)
+            }
+          },
+          UPDATE_DELAY
+        )
+      }
+    }
+
     private fun stopDragging() {
       draggingAnnotation?.let { annotation ->
         dragListeners.forEach { it.onAnnotationDragFinished(annotation) }
         draggingAnnotation = null
+        mapListenerDelegate.addOnMapIdleListener(onMapIdleListener)
         addAnnotation(annotation)
-      }
-      // Remove dragging annotation from drag layer
-      delegateProvider.getStyle { style ->
-        updateDragSource(style)
       }
     }
   }
@@ -763,5 +778,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     private const val QUERY_WAIT_TIME = 2L
     private const val CLUSTER_TEXT_LAYER_ID = "mapbox-android-cluster-text-layer"
     private val DEFAULT_TEXT_FIELD = get("point_count")
+    /** The delay time when updating drag source */
+    private const val UPDATE_DELAY = 1000L
   }
 }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -490,6 +490,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
    * Invoked when Mapview or Annotation manager is destroyed.
    */
   override fun onDestroy() {
+    handler.removeCallbacksAndMessages(null)
     delegateProvider.getStyle { style ->
       layer?.let {
         if (style.styleLayerExists(it.layerId)) {
@@ -676,7 +677,7 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
               updateDragSource(style)
             }
           },
-          UPDATE_DELAY
+          UPDATE_DELAY_MS
         )
       }
     }
@@ -779,6 +780,6 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
     private const val CLUSTER_TEXT_LAYER_ID = "mapbox-android-cluster-text-layer"
     private val DEFAULT_TEXT_FIELD = get("point_count")
     /** The delay time when updating drag source */
-    private const val UPDATE_DELAY = 1000L
+    private const val UPDATE_DELAY_MS = 1000L
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -46,6 +46,7 @@ class CircleAnnotationManagerTest {
   private val style: StyleInterface = mockk()
   private val mapCameraManagerDelegate: MapCameraManagerDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
+  private val mapListenerDelegate: MapListenerDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
   private val layer: CircleLayer = mockk()
   private val source: GeoJsonSource = mockk()
@@ -92,6 +93,8 @@ class CircleAnnotationManagerTest {
     every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
+    every { delegateProvider.mapListenerDelegate } returns mapListenerDelegate
+    every { mapListenerDelegate.addOnMapIdleListener(any()) } just Runs
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
     every { mapCameraManagerDelegate.pixelForCoordinate(any()) } returns ScreenCoordinate(1.0, 1.0)
     every { mapView.scrollX } returns 0

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -49,6 +49,7 @@ class PointAnnotationManagerTest {
   private val style: StyleInterface = mockk()
   private val mapCameraManagerDelegate: MapCameraManagerDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
+  private val mapListenerDelegate: MapListenerDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
   private val layer: SymbolLayer = mockk()
   private val source: GeoJsonSource = mockk()
@@ -96,6 +97,8 @@ class PointAnnotationManagerTest {
     every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
+    every { delegateProvider.mapListenerDelegate } returns mapListenerDelegate
+    every { mapListenerDelegate.addOnMapIdleListener(any()) } just Runs
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
     every { mapCameraManagerDelegate.pixelForCoordinate(any()) } returns ScreenCoordinate(1.0, 1.0)
     every { mapView.scrollX } returns 0

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -47,6 +47,7 @@ class PolygonAnnotationManagerTest {
   private val style: StyleInterface = mockk()
   private val mapCameraManagerDelegate: MapCameraManagerDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
+  private val mapListenerDelegate: MapListenerDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
   private val layer: FillLayer = mockk()
   private val source: GeoJsonSource = mockk()
@@ -93,6 +94,8 @@ class PolygonAnnotationManagerTest {
     every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
+    every { delegateProvider.mapListenerDelegate } returns mapListenerDelegate
+    every { mapListenerDelegate.addOnMapIdleListener(any()) } just Runs
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
     every { mapCameraManagerDelegate.pixelForCoordinate(any()) } returns ScreenCoordinate(1.0, 1.0)
     every { mapView.scrollX } returns 0

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -48,6 +48,7 @@ class PolylineAnnotationManagerTest {
   private val style: StyleInterface = mockk()
   private val mapCameraManagerDelegate: MapCameraManagerDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
+  private val mapListenerDelegate: MapListenerDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
   private val layer: LineLayer = mockk()
   private val source: GeoJsonSource = mockk()
@@ -94,6 +95,8 @@ class PolylineAnnotationManagerTest {
     every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
+    every { delegateProvider.mapListenerDelegate } returns mapListenerDelegate
+    every { mapListenerDelegate.addOnMapIdleListener(any()) } just Runs
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
     every { mapCameraManagerDelegate.pixelForCoordinate(any()) } returns ScreenCoordinate(1.0, 1.0)
     every { mapView.scrollX } returns 0


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix drag annotation blink issue</changelog>`.

### Summary of changes
In this pr, we will remove the drag annotation from the drag source only when the map is idle and 1 sec later, so there will be no blink issue after drag.

Before:

https://user-images.githubusercontent.com/8577318/130190854-a89298ce-b63d-4b77-a6d6-29d754885c5e.mp4

After:

https://user-images.githubusercontent.com/8577318/133201118-aa534c68-1026-412a-be75-d981fb66223b.mp4


<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->