### PR TITLE
Apply annotation manager properties to drag layer

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
@@ -175,6 +175,7 @@ class CircleAnnotationManager(
     set(value) {
       value?.let {
         layer?.circlePitchAlignment(it)
+        dragLayer?.circlePitchAlignment(it)
       }
     }
 
@@ -199,6 +200,7 @@ class CircleAnnotationManager(
     set(value) {
       value?.let {
         layer?.circlePitchScale(it)
+        dragLayer?.circlePitchScale(it)
       }
     }
 
@@ -223,6 +225,7 @@ class CircleAnnotationManager(
     set(value) {
       value?.let {
         layer?.circleTranslate(it)
+        dragLayer?.circleTranslate(it)
       }
     }
 
@@ -247,6 +250,7 @@ class CircleAnnotationManager(
     set(value) {
       value?.let {
         layer?.circleTranslateAnchor(it)
+        dragLayer?.circleTranslateAnchor(it)
       }
     }
 
@@ -279,7 +283,10 @@ class CircleAnnotationManager(
      * @param expression expression
      */
     set(value) {
-      value?.let { layer?.filter(it) }
+      value?.let {
+        layer?.filter(it)
+        dragLayer?.filter(it)
+      }
     }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
@@ -306,6 +306,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconAllowOverlap(it)
+        dragLayer?.iconAllowOverlap(it)
       }
     }
 
@@ -330,6 +331,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconIgnorePlacement(it)
+        dragLayer?.iconIgnorePlacement(it)
       }
     }
 
@@ -354,6 +356,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconKeepUpright(it)
+        dragLayer?.iconKeepUpright(it)
       }
     }
 
@@ -378,6 +381,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconOptional(it)
+        dragLayer?.iconOptional(it)
       }
     }
 
@@ -402,6 +406,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconPadding(it)
+        dragLayer?.iconPadding(it)
       }
     }
 
@@ -426,6 +431,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconPitchAlignment(it)
+        dragLayer?.iconPitchAlignment(it)
       }
     }
 
@@ -450,6 +456,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconRotationAlignment(it)
+        dragLayer?.iconRotationAlignment(it)
       }
     }
 
@@ -474,6 +481,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconTextFit(it)
+        dragLayer?.iconTextFit(it)
       }
     }
 
@@ -498,6 +506,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconTextFitPadding(it)
+        dragLayer?.iconTextFitPadding(it)
       }
     }
 
@@ -522,6 +531,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.symbolAvoidEdges(it)
+        dragLayer?.symbolAvoidEdges(it)
       }
     }
 
@@ -546,6 +556,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.symbolPlacement(it)
+        dragLayer?.symbolPlacement(it)
       }
     }
 
@@ -570,6 +581,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.symbolSpacing(it)
+        dragLayer?.symbolSpacing(it)
       }
     }
 
@@ -594,6 +606,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textAllowOverlap(it)
+        dragLayer?.textAllowOverlap(it)
       }
     }
 
@@ -618,6 +631,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textFont(it)
+        dragLayer?.textFont(it)
       }
     }
 
@@ -642,6 +656,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textIgnorePlacement(it)
+        dragLayer?.textIgnorePlacement(it)
       }
     }
 
@@ -666,6 +681,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textKeepUpright(it)
+        dragLayer?.textKeepUpright(it)
       }
     }
 
@@ -690,6 +706,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textLineHeight(it)
+        dragLayer?.textLineHeight(it)
       }
     }
 
@@ -714,6 +731,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textMaxAngle(it)
+        dragLayer?.textMaxAngle(it)
       }
     }
 
@@ -738,6 +756,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textOptional(it)
+        dragLayer?.textOptional(it)
       }
     }
 
@@ -762,6 +781,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textPadding(it)
+        dragLayer?.textPadding(it)
       }
     }
 
@@ -786,6 +806,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textPitchAlignment(it)
+        dragLayer?.textPitchAlignment(it)
       }
     }
 
@@ -810,6 +831,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textRotationAlignment(it)
+        dragLayer?.textRotationAlignment(it)
       }
     }
 
@@ -834,6 +856,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textVariableAnchor(it)
+        dragLayer?.textVariableAnchor(it)
       }
     }
 
@@ -858,6 +881,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textWritingMode(it)
+        dragLayer?.textWritingMode(it)
       }
     }
 
@@ -882,6 +906,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconTranslate(it)
+        dragLayer?.iconTranslate(it)
       }
     }
 
@@ -906,6 +931,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.iconTranslateAnchor(it)
+        dragLayer?.iconTranslateAnchor(it)
       }
     }
 
@@ -930,6 +956,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textTranslate(it)
+        dragLayer?.textTranslate(it)
       }
     }
 
@@ -954,6 +981,7 @@ class PointAnnotationManager(
     set(value) {
       value?.let {
         layer?.textTranslateAnchor(it)
+        dragLayer?.textTranslateAnchor(it)
       }
     }
 
@@ -986,7 +1014,10 @@ class PointAnnotationManager(
      * @param expression expression
      */
     set(value) {
-      value?.let { layer?.filter(it) }
+      value?.let {
+        layer?.filter(it)
+        dragLayer?.filter(it)
+      }
     }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
@@ -154,6 +154,7 @@ class PolygonAnnotationManager(
     set(value) {
       value?.let {
         layer?.fillAntialias(it)
+        dragLayer?.fillAntialias(it)
       }
     }
 
@@ -178,6 +179,7 @@ class PolygonAnnotationManager(
     set(value) {
       value?.let {
         layer?.fillTranslate(it)
+        dragLayer?.fillTranslate(it)
       }
     }
 
@@ -202,6 +204,7 @@ class PolygonAnnotationManager(
     set(value) {
       value?.let {
         layer?.fillTranslateAnchor(it)
+        dragLayer?.fillTranslateAnchor(it)
       }
     }
 
@@ -234,7 +237,10 @@ class PolygonAnnotationManager(
      * @param expression expression
      */
     set(value) {
-      value?.let { layer?.filter(it) }
+      value?.let {
+        layer?.filter(it)
+        dragLayer?.filter(it)
+      }
     }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
@@ -182,6 +182,7 @@ class PolylineAnnotationManager(
     set(value) {
       value?.let {
         layer?.lineCap(it)
+        dragLayer?.lineCap(it)
       }
     }
 
@@ -206,6 +207,7 @@ class PolylineAnnotationManager(
     set(value) {
       value?.let {
         layer?.lineMiterLimit(it)
+        dragLayer?.lineMiterLimit(it)
       }
     }
 
@@ -230,6 +232,7 @@ class PolylineAnnotationManager(
     set(value) {
       value?.let {
         layer?.lineRoundLimit(it)
+        dragLayer?.lineRoundLimit(it)
       }
     }
 
@@ -254,6 +257,7 @@ class PolylineAnnotationManager(
     set(value) {
       value?.let {
         layer?.lineDasharray(it)
+        dragLayer?.lineDasharray(it)
       }
     }
 
@@ -278,6 +282,7 @@ class PolylineAnnotationManager(
     set(value) {
       value?.let {
         layer?.lineTranslate(it)
+        dragLayer?.lineTranslate(it)
       }
     }
 
@@ -302,6 +307,7 @@ class PolylineAnnotationManager(
     set(value) {
       value?.let {
         layer?.lineTranslateAnchor(it)
+        dragLayer?.lineTranslateAnchor(it)
       }
     }
 
@@ -334,7 +340,10 @@ class PolylineAnnotationManager(
      * @param expression expression
      */
     set(value) {
-      value?.let { layer?.filter(it) }
+      value?.let {
+        layer?.filter(it)
+        dragLayer?.filter(it)
+      }
     }
 
   /**

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -46,9 +46,12 @@ class CircleAnnotationManagerTest {
   private val style: StyleInterface = mockk()
   private val mapCameraManagerDelegate: MapCameraManagerDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
+  private val mapListenerDelegate: MapListenerDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
   private val layer: CircleLayer = mockk()
   private val source: GeoJsonSource = mockk()
+  private val dragLayer: CircleLayer = mockk()
+  private val dragSource: GeoJsonSource = mockk()
   private val mapView: View = mockk()
   private val queriedFeatures = mockk<Expected<String, List<QueriedFeature>>>()
   private val queriedFeature = mockk<QueriedFeature>()
@@ -92,6 +95,8 @@ class CircleAnnotationManagerTest {
     every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
+    every { delegateProvider.mapListenerDelegate } returns mapListenerDelegate
+    every { mapListenerDelegate.addOnMapIdleListener(any()) } just Runs
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
     every { mapCameraManagerDelegate.pixelForCoordinate(any()) } returns ScreenCoordinate(1.0, 1.0)
     every { mapView.scrollX } returns 0
@@ -119,14 +124,24 @@ class CircleAnnotationManagerTest {
     manager = CircleAnnotationManager(mapView, delegateProvider)
     manager.layer = layer
     manager.source = source
+    manager.dragLayer = dragLayer
+    manager.dragSource = dragSource
     every { layer.circleSortKey(any<Expression>()) } answers { layer }
+    every { dragLayer.circleSortKey(any<Expression>()) } answers { dragLayer }
     every { layer.circleBlur(any<Expression>()) } answers { layer }
+    every { dragLayer.circleBlur(any<Expression>()) } answers { dragLayer }
     every { layer.circleColor(any<Expression>()) } answers { layer }
+    every { dragLayer.circleColor(any<Expression>()) } answers { dragLayer }
     every { layer.circleOpacity(any<Expression>()) } answers { layer }
+    every { dragLayer.circleOpacity(any<Expression>()) } answers { dragLayer }
     every { layer.circleRadius(any<Expression>()) } answers { layer }
+    every { dragLayer.circleRadius(any<Expression>()) } answers { dragLayer }
     every { layer.circleStrokeColor(any<Expression>()) } answers { layer }
+    every { dragLayer.circleStrokeColor(any<Expression>()) } answers { dragLayer }
     every { layer.circleStrokeOpacity(any<Expression>()) } answers { layer }
+    every { dragLayer.circleStrokeOpacity(any<Expression>()) } answers { dragLayer }
     every { layer.circleStrokeWidth(any<Expression>()) } answers { layer }
+    every { dragLayer.circleStrokeWidth(any<Expression>()) } answers { dragLayer }
   }
 
   @Test
@@ -399,8 +414,10 @@ class CircleAnnotationManagerTest {
       .withCircleSortKey(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleSortKey(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY)) }
+    verify(exactly = 1) { manager.dragLayer?.circleSortKey(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleSortKey(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY)) }
+    verify(exactly = 1) { manager.dragLayer?.circleSortKey(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY)) }
   }
 
   @Test
@@ -412,8 +429,10 @@ class CircleAnnotationManagerTest {
       .withCircleBlur(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleBlur(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR)) }
+    verify(exactly = 1) { manager.dragLayer?.circleBlur(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleBlur(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR)) }
+    verify(exactly = 1) { manager.dragLayer?.circleBlur(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR)) }
   }
 
   @Test
@@ -438,8 +457,10 @@ class CircleAnnotationManagerTest {
       .withCircleColor("rgba(0, 0, 0, 1)")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.circleColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.circleColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR)) }
   }
 
   @Test
@@ -451,8 +472,10 @@ class CircleAnnotationManagerTest {
       .withCircleOpacity(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.circleOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.circleOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY)) }
   }
 
   @Test
@@ -464,8 +487,10 @@ class CircleAnnotationManagerTest {
       .withCircleRadius(5.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleRadius(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS)) }
+    verify(exactly = 1) { manager.dragLayer?.circleRadius(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleRadius(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS)) }
+    verify(exactly = 1) { manager.dragLayer?.circleRadius(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS)) }
   }
 
   @Test
@@ -490,8 +515,10 @@ class CircleAnnotationManagerTest {
       .withCircleStrokeColor("rgba(0, 0, 0, 1)")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleStrokeColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.circleStrokeColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleStrokeColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.circleStrokeColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR)) }
   }
 
   @Test
@@ -503,8 +530,10 @@ class CircleAnnotationManagerTest {
       .withCircleStrokeOpacity(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleStrokeOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.circleStrokeOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleStrokeOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.circleStrokeOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY)) }
   }
 
   @Test
@@ -516,7 +545,9 @@ class CircleAnnotationManagerTest {
       .withCircleStrokeWidth(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleStrokeWidth(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.circleStrokeWidth(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.circleStrokeWidth(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.circleStrokeWidth(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH)) }
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -49,9 +49,12 @@ class PointAnnotationManagerTest {
   private val style: StyleInterface = mockk()
   private val mapCameraManagerDelegate: MapCameraManagerDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
+  private val mapListenerDelegate: MapListenerDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
   private val layer: SymbolLayer = mockk()
   private val source: GeoJsonSource = mockk()
+  private val dragLayer: SymbolLayer = mockk()
+  private val dragSource: GeoJsonSource = mockk()
   private val mapView: View = mockk()
   private val queriedFeatures = mockk<Expected<String, List<QueriedFeature>>>()
   private val queriedFeature = mockk<QueriedFeature>()
@@ -96,6 +99,8 @@ class PointAnnotationManagerTest {
     every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
+    every { delegateProvider.mapListenerDelegate } returns mapListenerDelegate
+    every { mapListenerDelegate.addOnMapIdleListener(any()) } just Runs
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
     every { mapCameraManagerDelegate.pixelForCoordinate(any()) } returns ScreenCoordinate(1.0, 1.0)
     every { mapView.scrollX } returns 0
@@ -123,35 +128,63 @@ class PointAnnotationManagerTest {
     manager = PointAnnotationManager(mapView, delegateProvider)
     manager.layer = layer
     manager.source = source
+    manager.dragLayer = dragLayer
+    manager.dragSource = dragSource
     val expected = mockk<Expected<String, None>>(relaxUnitFun = true, relaxed = true)
     every { style.addStyleImage(any(), any(), any(), any(), any(), any(), any()) } returns expected
     every { expected.error } returns null
     every { layer.iconAnchor(any<Expression>()) } answers { layer }
+    every { dragLayer.iconAnchor(any<Expression>()) } answers { dragLayer }
     every { layer.iconImage(any<Expression>()) } answers { layer }
+    every { dragLayer.iconImage(any<Expression>()) } answers { dragLayer }
     every { layer.iconOffset(any<Expression>()) } answers { layer }
+    every { dragLayer.iconOffset(any<Expression>()) } answers { dragLayer }
     every { layer.iconRotate(any<Expression>()) } answers { layer }
+    every { dragLayer.iconRotate(any<Expression>()) } answers { dragLayer }
     every { layer.iconSize(any<Expression>()) } answers { layer }
+    every { dragLayer.iconSize(any<Expression>()) } answers { dragLayer }
     every { layer.symbolSortKey(any<Expression>()) } answers { layer }
+    every { dragLayer.symbolSortKey(any<Expression>()) } answers { dragLayer }
     every { layer.textAnchor(any<Expression>()) } answers { layer }
+    every { dragLayer.textAnchor(any<Expression>()) } answers { dragLayer }
     every { layer.textField(any<Expression>()) } answers { layer }
+    every { dragLayer.textField(any<Expression>()) } answers { dragLayer }
     every { layer.textJustify(any<Expression>()) } answers { layer }
+    every { dragLayer.textJustify(any<Expression>()) } answers { dragLayer }
     every { layer.textLetterSpacing(any<Expression>()) } answers { layer }
+    every { dragLayer.textLetterSpacing(any<Expression>()) } answers { dragLayer }
     every { layer.textMaxWidth(any<Expression>()) } answers { layer }
+    every { dragLayer.textMaxWidth(any<Expression>()) } answers { dragLayer }
     every { layer.textOffset(any<Expression>()) } answers { layer }
+    every { dragLayer.textOffset(any<Expression>()) } answers { dragLayer }
     every { layer.textRadialOffset(any<Expression>()) } answers { layer }
+    every { dragLayer.textRadialOffset(any<Expression>()) } answers { dragLayer }
     every { layer.textRotate(any<Expression>()) } answers { layer }
+    every { dragLayer.textRotate(any<Expression>()) } answers { dragLayer }
     every { layer.textSize(any<Expression>()) } answers { layer }
+    every { dragLayer.textSize(any<Expression>()) } answers { dragLayer }
     every { layer.textTransform(any<Expression>()) } answers { layer }
+    every { dragLayer.textTransform(any<Expression>()) } answers { dragLayer }
     every { layer.iconColor(any<Expression>()) } answers { layer }
+    every { dragLayer.iconColor(any<Expression>()) } answers { dragLayer }
     every { layer.iconHaloBlur(any<Expression>()) } answers { layer }
+    every { dragLayer.iconHaloBlur(any<Expression>()) } answers { dragLayer }
     every { layer.iconHaloColor(any<Expression>()) } answers { layer }
+    every { dragLayer.iconHaloColor(any<Expression>()) } answers { dragLayer }
     every { layer.iconHaloWidth(any<Expression>()) } answers { layer }
+    every { dragLayer.iconHaloWidth(any<Expression>()) } answers { dragLayer }
     every { layer.iconOpacity(any<Expression>()) } answers { layer }
+    every { dragLayer.iconOpacity(any<Expression>()) } answers { dragLayer }
     every { layer.textColor(any<Expression>()) } answers { layer }
+    every { dragLayer.textColor(any<Expression>()) } answers { dragLayer }
     every { layer.textHaloBlur(any<Expression>()) } answers { layer }
+    every { dragLayer.textHaloBlur(any<Expression>()) } answers { dragLayer }
     every { layer.textHaloColor(any<Expression>()) } answers { layer }
+    every { dragLayer.textHaloColor(any<Expression>()) } answers { dragLayer }
     every { layer.textHaloWidth(any<Expression>()) } answers { layer }
+    every { dragLayer.textHaloWidth(any<Expression>()) } answers { dragLayer }
     every { layer.textOpacity(any<Expression>()) } answers { layer }
+    every { dragLayer.textOpacity(any<Expression>()) } answers { dragLayer }
   }
 
   @Test
@@ -511,8 +544,10 @@ class PointAnnotationManagerTest {
       .withIconAnchor(IconAnchor.CENTER)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconAnchor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR)) }
+    verify(exactly = 1) { manager.dragLayer?.iconAnchor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconAnchor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR)) }
+    verify(exactly = 1) { manager.dragLayer?.iconAnchor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR)) }
   }
 
   @Test
@@ -524,8 +559,10 @@ class PointAnnotationManagerTest {
       .withIconImage("")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconImage(Expression.get(PointAnnotationOptions.PROPERTY_ICON_IMAGE)) }
+    verify(exactly = 1) { manager.dragLayer?.iconImage(Expression.get(PointAnnotationOptions.PROPERTY_ICON_IMAGE)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconImage(Expression.get(PointAnnotationOptions.PROPERTY_ICON_IMAGE)) }
+    verify(exactly = 1) { manager.dragLayer?.iconImage(Expression.get(PointAnnotationOptions.PROPERTY_ICON_IMAGE)) }
   }
 
   @Test
@@ -537,8 +574,10 @@ class PointAnnotationManagerTest {
       .withIconOffset(listOf(0.0, 0.0))
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconOffset(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OFFSET)) }
+    verify(exactly = 1) { manager.dragLayer?.iconOffset(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OFFSET)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconOffset(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OFFSET)) }
+    verify(exactly = 1) { manager.dragLayer?.iconOffset(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OFFSET)) }
   }
 
   @Test
@@ -550,8 +589,10 @@ class PointAnnotationManagerTest {
       .withIconRotate(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconRotate(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ROTATE)) }
+    verify(exactly = 1) { manager.dragLayer?.iconRotate(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ROTATE)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconRotate(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ROTATE)) }
+    verify(exactly = 1) { manager.dragLayer?.iconRotate(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ROTATE)) }
   }
 
   @Test
@@ -563,8 +604,10 @@ class PointAnnotationManagerTest {
       .withIconSize(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconSize(Expression.get(PointAnnotationOptions.PROPERTY_ICON_SIZE)) }
+    verify(exactly = 1) { manager.dragLayer?.iconSize(Expression.get(PointAnnotationOptions.PROPERTY_ICON_SIZE)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconSize(Expression.get(PointAnnotationOptions.PROPERTY_ICON_SIZE)) }
+    verify(exactly = 1) { manager.dragLayer?.iconSize(Expression.get(PointAnnotationOptions.PROPERTY_ICON_SIZE)) }
   }
 
   @Test
@@ -576,8 +619,10 @@ class PointAnnotationManagerTest {
       .withSymbolSortKey(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.symbolSortKey(Expression.get(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY)) }
+    verify(exactly = 1) { manager.dragLayer?.symbolSortKey(Expression.get(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.symbolSortKey(Expression.get(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY)) }
+    verify(exactly = 1) { manager.dragLayer?.symbolSortKey(Expression.get(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY)) }
   }
 
   @Test
@@ -589,8 +634,10 @@ class PointAnnotationManagerTest {
       .withTextAnchor(TextAnchor.CENTER)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textAnchor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR)) }
+    verify(exactly = 1) { manager.dragLayer?.textAnchor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textAnchor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR)) }
+    verify(exactly = 1) { manager.dragLayer?.textAnchor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR)) }
   }
 
   @Test
@@ -602,8 +649,10 @@ class PointAnnotationManagerTest {
       .withTextField("")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textField(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FIELD)) }
+    verify(exactly = 1) { manager.dragLayer?.textField(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FIELD)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textField(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FIELD)) }
+    verify(exactly = 1) { manager.dragLayer?.textField(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FIELD)) }
   }
 
   @Test
@@ -615,8 +664,10 @@ class PointAnnotationManagerTest {
       .withTextJustify(TextJustify.CENTER)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textJustify(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)) }
+    verify(exactly = 1) { manager.dragLayer?.textJustify(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textJustify(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)) }
+    verify(exactly = 1) { manager.dragLayer?.textJustify(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)) }
   }
 
   @Test
@@ -628,8 +679,10 @@ class PointAnnotationManagerTest {
       .withTextLetterSpacing(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textLetterSpacing(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING)) }
+    verify(exactly = 1) { manager.dragLayer?.textLetterSpacing(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textLetterSpacing(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING)) }
+    verify(exactly = 1) { manager.dragLayer?.textLetterSpacing(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING)) }
   }
 
   @Test
@@ -641,8 +694,10 @@ class PointAnnotationManagerTest {
       .withTextMaxWidth(10.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textMaxWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.textMaxWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textMaxWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.textMaxWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH)) }
   }
 
   @Test
@@ -654,8 +709,10 @@ class PointAnnotationManagerTest {
       .withTextOffset(listOf(0.0, 0.0))
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OFFSET)) }
+    verify(exactly = 1) { manager.dragLayer?.textOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OFFSET)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OFFSET)) }
+    verify(exactly = 1) { manager.dragLayer?.textOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OFFSET)) }
   }
 
   @Test
@@ -667,8 +724,10 @@ class PointAnnotationManagerTest {
       .withTextRadialOffset(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textRadialOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET)) }
+    verify(exactly = 1) { manager.dragLayer?.textRadialOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textRadialOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET)) }
+    verify(exactly = 1) { manager.dragLayer?.textRadialOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET)) }
   }
 
   @Test
@@ -680,8 +739,10 @@ class PointAnnotationManagerTest {
       .withTextRotate(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textRotate(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ROTATE)) }
+    verify(exactly = 1) { manager.dragLayer?.textRotate(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ROTATE)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textRotate(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ROTATE)) }
+    verify(exactly = 1) { manager.dragLayer?.textRotate(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ROTATE)) }
   }
 
   @Test
@@ -693,8 +754,10 @@ class PointAnnotationManagerTest {
       .withTextSize(16.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textSize(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_SIZE)) }
+    verify(exactly = 1) { manager.dragLayer?.textSize(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_SIZE)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textSize(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_SIZE)) }
+    verify(exactly = 1) { manager.dragLayer?.textSize(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_SIZE)) }
   }
 
   @Test
@@ -706,8 +769,10 @@ class PointAnnotationManagerTest {
       .withTextTransform(TextTransform.NONE)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textTransform(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM)) }
+    verify(exactly = 1) { manager.dragLayer?.textTransform(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textTransform(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM)) }
+    verify(exactly = 1) { manager.dragLayer?.textTransform(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM)) }
   }
 
   @Test
@@ -732,8 +797,10 @@ class PointAnnotationManagerTest {
       .withIconColor("rgba(0, 0, 0, 1)")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.iconColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_COLOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.iconColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_COLOR)) }
   }
 
   @Test
@@ -745,8 +812,10 @@ class PointAnnotationManagerTest {
       .withIconHaloBlur(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR)) }
+    verify(exactly = 1) { manager.dragLayer?.iconHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR)) }
+    verify(exactly = 1) { manager.dragLayer?.iconHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR)) }
   }
 
   @Test
@@ -771,8 +840,10 @@ class PointAnnotationManagerTest {
       .withIconHaloColor("rgba(0, 0, 0, 1)")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.iconHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.iconHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR)) }
   }
 
   @Test
@@ -784,8 +855,10 @@ class PointAnnotationManagerTest {
       .withIconHaloWidth(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.iconHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.iconHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH)) }
   }
 
   @Test
@@ -797,8 +870,10 @@ class PointAnnotationManagerTest {
       .withIconOpacity(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconOpacity(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.iconOpacity(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OPACITY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.iconOpacity(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.iconOpacity(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OPACITY)) }
   }
 
   @Test
@@ -823,8 +898,10 @@ class PointAnnotationManagerTest {
       .withTextColor("rgba(0, 0, 0, 1)")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.textColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_COLOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.textColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_COLOR)) }
   }
 
   @Test
@@ -836,8 +913,10 @@ class PointAnnotationManagerTest {
       .withTextHaloBlur(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR)) }
+    verify(exactly = 1) { manager.dragLayer?.textHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR)) }
+    verify(exactly = 1) { manager.dragLayer?.textHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR)) }
   }
 
   @Test
@@ -862,8 +941,10 @@ class PointAnnotationManagerTest {
       .withTextHaloColor("rgba(0, 0, 0, 1)")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.textHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.textHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR)) }
   }
 
   @Test
@@ -875,8 +956,10 @@ class PointAnnotationManagerTest {
       .withTextHaloWidth(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.textHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.textHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH)) }
   }
 
   @Test
@@ -888,7 +971,9 @@ class PointAnnotationManagerTest {
       .withTextOpacity(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textOpacity(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.textOpacity(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OPACITY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.textOpacity(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.textOpacity(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OPACITY)) }
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -47,9 +47,12 @@ class PolygonAnnotationManagerTest {
   private val style: StyleInterface = mockk()
   private val mapCameraManagerDelegate: MapCameraManagerDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
+  private val mapListenerDelegate: MapListenerDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
   private val layer: FillLayer = mockk()
   private val source: GeoJsonSource = mockk()
+  private val dragLayer: FillLayer = mockk()
+  private val dragSource: GeoJsonSource = mockk()
   private val mapView: View = mockk()
   private val queriedFeatures = mockk<Expected<String, List<QueriedFeature>>>()
   private val queriedFeature = mockk<QueriedFeature>()
@@ -93,6 +96,8 @@ class PolygonAnnotationManagerTest {
     every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
+    every { delegateProvider.mapListenerDelegate } returns mapListenerDelegate
+    every { mapListenerDelegate.addOnMapIdleListener(any()) } just Runs
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
     every { mapCameraManagerDelegate.pixelForCoordinate(any()) } returns ScreenCoordinate(1.0, 1.0)
     every { mapView.scrollX } returns 0
@@ -120,11 +125,18 @@ class PolygonAnnotationManagerTest {
     manager = PolygonAnnotationManager(mapView, delegateProvider)
     manager.layer = layer
     manager.source = source
+    manager.dragLayer = dragLayer
+    manager.dragSource = dragSource
     every { layer.fillSortKey(any<Expression>()) } answers { layer }
+    every { dragLayer.fillSortKey(any<Expression>()) } answers { dragLayer }
     every { layer.fillColor(any<Expression>()) } answers { layer }
+    every { dragLayer.fillColor(any<Expression>()) } answers { dragLayer }
     every { layer.fillOpacity(any<Expression>()) } answers { layer }
+    every { dragLayer.fillOpacity(any<Expression>()) } answers { dragLayer }
     every { layer.fillOutlineColor(any<Expression>()) } answers { layer }
+    every { dragLayer.fillOutlineColor(any<Expression>()) } answers { dragLayer }
     every { layer.fillPattern(any<Expression>()) } answers { layer }
+    every { dragLayer.fillPattern(any<Expression>()) } answers { dragLayer }
   }
 
   @Test
@@ -397,8 +409,10 @@ class PolygonAnnotationManagerTest {
       .withFillSortKey(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillSortKey(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY)) }
+    verify(exactly = 1) { manager.dragLayer?.fillSortKey(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillSortKey(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY)) }
+    verify(exactly = 1) { manager.dragLayer?.fillSortKey(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY)) }
   }
 
   @Test
@@ -423,8 +437,10 @@ class PolygonAnnotationManagerTest {
       .withFillColor("rgba(0, 0, 0, 1)")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.fillColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_COLOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.fillColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_COLOR)) }
   }
 
   @Test
@@ -436,8 +452,10 @@ class PolygonAnnotationManagerTest {
       .withFillOpacity(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillOpacity(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.fillOpacity(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillOpacity(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.fillOpacity(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY)) }
   }
 
   @Test
@@ -462,8 +480,10 @@ class PolygonAnnotationManagerTest {
       .withFillOutlineColor("rgba(0, 0, 0, 1)")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillOutlineColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.fillOutlineColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillOutlineColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.fillOutlineColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR)) }
   }
 
   @Test
@@ -475,7 +495,9 @@ class PolygonAnnotationManagerTest {
       .withFillPattern("pedestrian-polygon")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillPattern(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN)) }
+    verify(exactly = 1) { manager.dragLayer?.fillPattern(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.fillPattern(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN)) }
+    verify(exactly = 1) { manager.dragLayer?.fillPattern(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN)) }
   }
 }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -48,9 +48,12 @@ class PolylineAnnotationManagerTest {
   private val style: StyleInterface = mockk()
   private val mapCameraManagerDelegate: MapCameraManagerDelegate = mockk()
   private val mapFeatureQueryDelegate: MapFeatureQueryDelegate = mockk()
+  private val mapListenerDelegate: MapListenerDelegate = mockk()
   private val gesturesPlugin: GesturesPlugin = mockk()
   private val layer: LineLayer = mockk()
   private val source: GeoJsonSource = mockk()
+  private val dragLayer: LineLayer = mockk()
+  private val dragSource: GeoJsonSource = mockk()
   private val mapView: View = mockk()
   private val queriedFeatures = mockk<Expected<String, List<QueriedFeature>>>()
   private val queriedFeature = mockk<QueriedFeature>()
@@ -94,6 +97,8 @@ class PolylineAnnotationManagerTest {
     every { delegateProvider.mapPluginProviderDelegate.getPlugin<GesturesPlugin>(any()) } returns gesturesPlugin
     every { delegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { delegateProvider.mapFeatureQueryDelegate } returns mapFeatureQueryDelegate
+    every { delegateProvider.mapListenerDelegate } returns mapListenerDelegate
+    every { mapListenerDelegate.addOnMapIdleListener(any()) } just Runs
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
     every { mapCameraManagerDelegate.pixelForCoordinate(any()) } returns ScreenCoordinate(1.0, 1.0)
     every { mapView.scrollX } returns 0
@@ -121,15 +126,26 @@ class PolylineAnnotationManagerTest {
     manager = PolylineAnnotationManager(mapView, delegateProvider)
     manager.layer = layer
     manager.source = source
+    manager.dragLayer = dragLayer
+    manager.dragSource = dragSource
     every { layer.lineJoin(any<Expression>()) } answers { layer }
+    every { dragLayer.lineJoin(any<Expression>()) } answers { dragLayer }
     every { layer.lineSortKey(any<Expression>()) } answers { layer }
+    every { dragLayer.lineSortKey(any<Expression>()) } answers { dragLayer }
     every { layer.lineBlur(any<Expression>()) } answers { layer }
+    every { dragLayer.lineBlur(any<Expression>()) } answers { dragLayer }
     every { layer.lineColor(any<Expression>()) } answers { layer }
+    every { dragLayer.lineColor(any<Expression>()) } answers { dragLayer }
     every { layer.lineGapWidth(any<Expression>()) } answers { layer }
+    every { dragLayer.lineGapWidth(any<Expression>()) } answers { dragLayer }
     every { layer.lineOffset(any<Expression>()) } answers { layer }
+    every { dragLayer.lineOffset(any<Expression>()) } answers { dragLayer }
     every { layer.lineOpacity(any<Expression>()) } answers { layer }
+    every { dragLayer.lineOpacity(any<Expression>()) } answers { dragLayer }
     every { layer.linePattern(any<Expression>()) } answers { layer }
+    every { dragLayer.linePattern(any<Expression>()) } answers { dragLayer }
     every { layer.lineWidth(any<Expression>()) } answers { layer }
+    every { dragLayer.lineWidth(any<Expression>()) } answers { dragLayer }
   }
 
   @Test
@@ -402,8 +418,10 @@ class PolylineAnnotationManagerTest {
       .withLineJoin(LineJoin.MITER)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineJoin(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_JOIN)) }
+    verify(exactly = 1) { manager.dragLayer?.lineJoin(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_JOIN)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineJoin(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_JOIN)) }
+    verify(exactly = 1) { manager.dragLayer?.lineJoin(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_JOIN)) }
   }
 
   @Test
@@ -415,8 +433,10 @@ class PolylineAnnotationManagerTest {
       .withLineSortKey(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineSortKey(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY)) }
+    verify(exactly = 1) { manager.dragLayer?.lineSortKey(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineSortKey(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY)) }
+    verify(exactly = 1) { manager.dragLayer?.lineSortKey(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY)) }
   }
 
   @Test
@@ -428,8 +448,10 @@ class PolylineAnnotationManagerTest {
       .withLineBlur(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineBlur(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_BLUR)) }
+    verify(exactly = 1) { manager.dragLayer?.lineBlur(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_BLUR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineBlur(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_BLUR)) }
+    verify(exactly = 1) { manager.dragLayer?.lineBlur(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_BLUR)) }
   }
 
   @Test
@@ -454,8 +476,10 @@ class PolylineAnnotationManagerTest {
       .withLineColor("rgba(0, 0, 0, 1)")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineColor(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.lineColor(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_COLOR)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineColor(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_COLOR)) }
+    verify(exactly = 1) { manager.dragLayer?.lineColor(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_COLOR)) }
   }
 
   @Test
@@ -467,8 +491,10 @@ class PolylineAnnotationManagerTest {
       .withLineGapWidth(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineGapWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.lineGapWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineGapWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.lineGapWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH)) }
   }
 
   @Test
@@ -480,8 +506,10 @@ class PolylineAnnotationManagerTest {
       .withLineOffset(0.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineOffset(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET)) }
+    verify(exactly = 1) { manager.dragLayer?.lineOffset(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineOffset(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET)) }
+    verify(exactly = 1) { manager.dragLayer?.lineOffset(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET)) }
   }
 
   @Test
@@ -493,8 +521,10 @@ class PolylineAnnotationManagerTest {
       .withLineOpacity(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineOpacity(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.lineOpacity(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineOpacity(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY)) }
+    verify(exactly = 1) { manager.dragLayer?.lineOpacity(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY)) }
   }
 
   @Test
@@ -506,8 +536,10 @@ class PolylineAnnotationManagerTest {
       .withLinePattern("pedestrian-polygon")
     manager.create(options)
     verify(exactly = 1) { manager.layer?.linePattern(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN)) }
+    verify(exactly = 1) { manager.dragLayer?.linePattern(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.linePattern(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN)) }
+    verify(exactly = 1) { manager.dragLayer?.linePattern(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN)) }
   }
 
   @Test
@@ -519,7 +551,9 @@ class PolylineAnnotationManagerTest {
       .withLineWidth(1.0)
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.lineWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH)) }
     manager.create(options)
     verify(exactly = 1) { manager.layer?.lineWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH)) }
+    verify(exactly = 1) { manager.dragLayer?.lineWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH)) }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Apply annotation manager properties to drag layer to keep annotations the same while dragging</changelog>`.

### Summary of changes
In the past, we haven't applied the properties to drag layer, so when dragging an annotation, the properties like test font will not keep the same as the original.
This pr applies all the properties to the drag layer to keep annotations the same while dragging.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->