### PR TITLE
Fix getStyle returns null after adding a source

### DIFF
--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -188,7 +188,7 @@ class MapboxMapTest {
   fun getStyleLoadedCallback() {
     val style = mockk<Style>()
     mapboxMap.style = style
-    every { style.isStyleLoaded } returns true
+    mapboxMap.styleLoaded = true
     val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     mapboxMap.getStyle(styleLoadCallback)
     verify { styleLoadCallback.onStyleLoaded(style) }
@@ -198,7 +198,7 @@ class MapboxMapTest {
   fun getStyleSynchronously() {
     val style = mockk<Style>()
     mapboxMap.style = style
-    every { style.isStyleLoaded } returns true
+    mapboxMap.styleLoaded = true
     assertNotNull(mapboxMap.getStyle())
   }
 
@@ -206,7 +206,7 @@ class MapboxMapTest {
   fun getStyleSynchronouslyNull() {
     val style = mockk<Style>()
     mapboxMap.style = style
-    every { style.isStyleLoaded } returns false
+    mapboxMap.styleLoaded = false
     assertNull(mapboxMap.getStyle())
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #634 
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/583

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix getStyle returns null after adding a source</changelog>`.

### Summary of changes
`onStyleLoaded` will only be triggered once for one style, so if users add a new source to style after style loaded, `onStyleLoaded` will never be invoked. And during the loading time for this new source, `getStyle` will return null because `style.isStyleLoaded` will be false.
This pr add a property `styleLoaded` to record wheter the style is loaded or not no matter how many sources or layers are added after style loaded.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->