### PR TITLE
Enable annotations to set null value to nullable properties.

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/CircleAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/CircleAnnotationManagerAndroidTest.kt
@@ -8,7 +8,9 @@ import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
 import com.mapbox.maps.R
+import com.mapbox.maps.StyleManager
 import com.mapbox.maps.extension.style.layers.properties.generated.*
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.CircleAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createCircleAnnotationManager
@@ -17,6 +19,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.*
 
 /**
  * Basic smoke tests for CircleAnnotationManager
@@ -39,6 +42,9 @@ class CircleAnnotationManagerAndroidTest : BaseMapTest() {
     val circleAnnotationManager = mapView.annotations.createCircleAnnotationManager(mapView)
     circleAnnotationManager.circlePitchAlignment = expectedValue
     assertEquals(expectedValue, circleAnnotationManager.circlePitchAlignment)
+    circleAnnotationManager.circlePitchAlignment = null
+    val expectedDefaultValue = CirclePitchAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("circle", "circle-pitch-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, circleAnnotationManager.circlePitchAlignment)
   }
 
   @Test
@@ -47,6 +53,9 @@ class CircleAnnotationManagerAndroidTest : BaseMapTest() {
     val circleAnnotationManager = mapView.annotations.createCircleAnnotationManager(mapView)
     circleAnnotationManager.circlePitchScale = expectedValue
     assertEquals(expectedValue, circleAnnotationManager.circlePitchScale)
+    circleAnnotationManager.circlePitchScale = null
+    val expectedDefaultValue = CirclePitchScale.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("circle", "circle-pitch-scale").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, circleAnnotationManager.circlePitchScale)
   }
 
   @Test
@@ -55,6 +64,8 @@ class CircleAnnotationManagerAndroidTest : BaseMapTest() {
     val circleAnnotationManager = mapView.annotations.createCircleAnnotationManager(mapView)
     circleAnnotationManager.circleTranslate = expectedValue
     assertEquals(expectedValue, circleAnnotationManager.circleTranslate)
+    circleAnnotationManager.circleTranslate = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("circle", "circle-translate").silentUnwrap(), circleAnnotationManager.circleTranslate)
   }
 
   @Test
@@ -63,6 +74,9 @@ class CircleAnnotationManagerAndroidTest : BaseMapTest() {
     val circleAnnotationManager = mapView.annotations.createCircleAnnotationManager(mapView)
     circleAnnotationManager.circleTranslateAnchor = expectedValue
     assertEquals(expectedValue, circleAnnotationManager.circleTranslateAnchor)
+    circleAnnotationManager.circleTranslateAnchor = null
+    val expectedDefaultValue = CircleTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("circle", "circle-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, circleAnnotationManager.circleTranslateAnchor)
   }
 
   @Test

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PointAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PointAnnotationManagerAndroidTest.kt
@@ -8,7 +8,9 @@ import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
 import com.mapbox.maps.R
+import com.mapbox.maps.StyleManager
 import com.mapbox.maps.extension.style.layers.properties.generated.*
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
@@ -17,6 +19,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.*
 
 /**
  * Basic smoke tests for PointAnnotationManager
@@ -39,6 +42,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconAllowOverlap = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconAllowOverlap)
+    pointAnnotationManager.iconAllowOverlap = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-allow-overlap").silentUnwrap(), pointAnnotationManager.iconAllowOverlap)
   }
 
   @Test
@@ -47,6 +52,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconIgnorePlacement = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconIgnorePlacement)
+    pointAnnotationManager.iconIgnorePlacement = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-ignore-placement").silentUnwrap(), pointAnnotationManager.iconIgnorePlacement)
   }
 
   @Test
@@ -55,6 +62,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconKeepUpright = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconKeepUpright)
+    pointAnnotationManager.iconKeepUpright = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-keep-upright").silentUnwrap(), pointAnnotationManager.iconKeepUpright)
   }
 
   @Test
@@ -63,6 +72,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconOptional = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconOptional)
+    pointAnnotationManager.iconOptional = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-optional").silentUnwrap(), pointAnnotationManager.iconOptional)
   }
 
   @Test
@@ -71,6 +82,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconPadding = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconPadding)
+    pointAnnotationManager.iconPadding = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-padding").silentUnwrap(), pointAnnotationManager.iconPadding)
   }
 
   @Test
@@ -79,6 +92,9 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconPitchAlignment = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconPitchAlignment)
+    pointAnnotationManager.iconPitchAlignment = null
+    val expectedDefaultValue = IconPitchAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-pitch-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, pointAnnotationManager.iconPitchAlignment)
   }
 
   @Test
@@ -87,6 +103,9 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconRotationAlignment = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconRotationAlignment)
+    pointAnnotationManager.iconRotationAlignment = null
+    val expectedDefaultValue = IconRotationAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-rotation-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, pointAnnotationManager.iconRotationAlignment)
   }
 
   @Test
@@ -95,6 +114,9 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconTextFit = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconTextFit)
+    pointAnnotationManager.iconTextFit = null
+    val expectedDefaultValue = IconTextFit.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-text-fit").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, pointAnnotationManager.iconTextFit)
   }
 
   @Test
@@ -103,6 +125,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconTextFitPadding = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconTextFitPadding)
+    pointAnnotationManager.iconTextFitPadding = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-text-fit-padding").silentUnwrap(), pointAnnotationManager.iconTextFitPadding)
   }
 
   @Test
@@ -111,6 +135,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.symbolAvoidEdges = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.symbolAvoidEdges)
+    pointAnnotationManager.symbolAvoidEdges = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "symbol-avoid-edges").silentUnwrap(), pointAnnotationManager.symbolAvoidEdges)
   }
 
   @Test
@@ -119,6 +145,9 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.symbolPlacement = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.symbolPlacement)
+    pointAnnotationManager.symbolPlacement = null
+    val expectedDefaultValue = SymbolPlacement.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "symbol-placement").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, pointAnnotationManager.symbolPlacement)
   }
 
   @Test
@@ -127,6 +156,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.symbolSpacing = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.symbolSpacing)
+    pointAnnotationManager.symbolSpacing = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "symbol-spacing").silentUnwrap(), pointAnnotationManager.symbolSpacing)
   }
 
   @Test
@@ -135,6 +166,9 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.symbolZOrder = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.symbolZOrder)
+    pointAnnotationManager.symbolZOrder = null
+    val expectedDefaultValue = SymbolZOrder.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "symbol-z-order").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, pointAnnotationManager.symbolZOrder)
   }
 
   @Test
@@ -143,6 +177,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textAllowOverlap = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textAllowOverlap)
+    pointAnnotationManager.textAllowOverlap = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-allow-overlap").silentUnwrap(), pointAnnotationManager.textAllowOverlap)
   }
 
   @Test
@@ -151,6 +187,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textFont = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textFont)
+    pointAnnotationManager.textFont = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-font").silentUnwrap(), pointAnnotationManager.textFont)
   }
 
   @Test
@@ -159,6 +197,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textIgnorePlacement = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textIgnorePlacement)
+    pointAnnotationManager.textIgnorePlacement = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-ignore-placement").silentUnwrap(), pointAnnotationManager.textIgnorePlacement)
   }
 
   @Test
@@ -167,6 +207,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textKeepUpright = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textKeepUpright)
+    pointAnnotationManager.textKeepUpright = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-keep-upright").silentUnwrap(), pointAnnotationManager.textKeepUpright)
   }
 
   @Test
@@ -175,6 +217,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textLineHeight = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textLineHeight)
+    pointAnnotationManager.textLineHeight = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-line-height").silentUnwrap(), pointAnnotationManager.textLineHeight)
   }
 
   @Test
@@ -183,6 +227,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textMaxAngle = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textMaxAngle)
+    pointAnnotationManager.textMaxAngle = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-max-angle").silentUnwrap(), pointAnnotationManager.textMaxAngle)
   }
 
   @Test
@@ -191,6 +237,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textOptional = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textOptional)
+    pointAnnotationManager.textOptional = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-optional").silentUnwrap(), pointAnnotationManager.textOptional)
   }
 
   @Test
@@ -199,6 +247,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textPadding = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textPadding)
+    pointAnnotationManager.textPadding = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-padding").silentUnwrap(), pointAnnotationManager.textPadding)
   }
 
   @Test
@@ -207,6 +257,9 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textPitchAlignment = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textPitchAlignment)
+    pointAnnotationManager.textPitchAlignment = null
+    val expectedDefaultValue = TextPitchAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-pitch-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, pointAnnotationManager.textPitchAlignment)
   }
 
   @Test
@@ -215,6 +268,9 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textRotationAlignment = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textRotationAlignment)
+    pointAnnotationManager.textRotationAlignment = null
+    val expectedDefaultValue = TextRotationAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-rotation-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, pointAnnotationManager.textRotationAlignment)
   }
 
   @Test
@@ -223,6 +279,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textVariableAnchor = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textVariableAnchor)
+    pointAnnotationManager.textVariableAnchor = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-variable-anchor").silentUnwrap(), pointAnnotationManager.textVariableAnchor)
   }
 
   @Test
@@ -231,6 +289,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textWritingMode = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textWritingMode)
+    pointAnnotationManager.textWritingMode = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-writing-mode").silentUnwrap(), pointAnnotationManager.textWritingMode)
   }
 
   @Test
@@ -239,6 +299,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconTranslate = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconTranslate)
+    pointAnnotationManager.iconTranslate = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-translate").silentUnwrap(), pointAnnotationManager.iconTranslate)
   }
 
   @Test
@@ -247,6 +309,9 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.iconTranslateAnchor = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.iconTranslateAnchor)
+    pointAnnotationManager.iconTranslateAnchor = null
+    val expectedDefaultValue = IconTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, pointAnnotationManager.iconTranslateAnchor)
   }
 
   @Test
@@ -255,6 +320,8 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textTranslate = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textTranslate)
+    pointAnnotationManager.textTranslate = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-translate").silentUnwrap(), pointAnnotationManager.textTranslate)
   }
 
   @Test
@@ -263,6 +330,9 @@ class PointAnnotationManagerAndroidTest : BaseMapTest() {
     val pointAnnotationManager = mapView.annotations.createPointAnnotationManager(mapView)
     pointAnnotationManager.textTranslateAnchor = expectedValue
     assertEquals(expectedValue, pointAnnotationManager.textTranslateAnchor)
+    pointAnnotationManager.textTranslateAnchor = null
+    val expectedDefaultValue = TextTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, pointAnnotationManager.textTranslateAnchor)
   }
 
   @Test

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolygonAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolygonAnnotationManagerAndroidTest.kt
@@ -9,7 +9,9 @@ import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.Polygon
 import com.mapbox.maps.R
+import com.mapbox.maps.StyleManager
 import com.mapbox.maps.extension.style.layers.properties.generated.*
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPolygonAnnotationManager
@@ -18,6 +20,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.*
 
 /**
  * Basic smoke tests for PolygonAnnotationManager
@@ -40,6 +43,8 @@ class PolygonAnnotationManagerAndroidTest : BaseMapTest() {
     val polygonAnnotationManager = mapView.annotations.createPolygonAnnotationManager(mapView)
     polygonAnnotationManager.fillAntialias = expectedValue
     assertEquals(expectedValue, polygonAnnotationManager.fillAntialias)
+    polygonAnnotationManager.fillAntialias = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-antialias").silentUnwrap(), polygonAnnotationManager.fillAntialias)
   }
 
   @Test
@@ -48,6 +53,8 @@ class PolygonAnnotationManagerAndroidTest : BaseMapTest() {
     val polygonAnnotationManager = mapView.annotations.createPolygonAnnotationManager(mapView)
     polygonAnnotationManager.fillTranslate = expectedValue
     assertEquals(expectedValue, polygonAnnotationManager.fillTranslate)
+    polygonAnnotationManager.fillTranslate = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-translate").silentUnwrap(), polygonAnnotationManager.fillTranslate)
   }
 
   @Test
@@ -56,6 +63,9 @@ class PolygonAnnotationManagerAndroidTest : BaseMapTest() {
     val polygonAnnotationManager = mapView.annotations.createPolygonAnnotationManager(mapView)
     polygonAnnotationManager.fillTranslateAnchor = expectedValue
     assertEquals(expectedValue, polygonAnnotationManager.fillTranslateAnchor)
+    polygonAnnotationManager.fillTranslateAnchor = null
+    val expectedDefaultValue = FillTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, polygonAnnotationManager.fillTranslateAnchor)
   }
 
   @Test

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolylineAnnotationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/generated/PolylineAnnotationManagerAndroidTest.kt
@@ -9,7 +9,9 @@ import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.maps.R
+import com.mapbox.maps.StyleManager
 import com.mapbox.maps.extension.style.layers.properties.generated.*
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPolylineAnnotationManager
@@ -18,6 +20,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.*
 
 /**
  * Basic smoke tests for PolylineAnnotationManager
@@ -40,6 +43,9 @@ class PolylineAnnotationManagerAndroidTest : BaseMapTest() {
     val polylineAnnotationManager = mapView.annotations.createPolylineAnnotationManager(mapView)
     polylineAnnotationManager.lineCap = expectedValue
     assertEquals(expectedValue, polylineAnnotationManager.lineCap)
+    polylineAnnotationManager.lineCap = null
+    val expectedDefaultValue = LineCap.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("line", "line-cap").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, polylineAnnotationManager.lineCap)
   }
 
   @Test
@@ -48,6 +54,8 @@ class PolylineAnnotationManagerAndroidTest : BaseMapTest() {
     val polylineAnnotationManager = mapView.annotations.createPolylineAnnotationManager(mapView)
     polylineAnnotationManager.lineMiterLimit = expectedValue
     assertEquals(expectedValue, polylineAnnotationManager.lineMiterLimit)
+    polylineAnnotationManager.lineMiterLimit = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("line", "line-miter-limit").silentUnwrap(), polylineAnnotationManager.lineMiterLimit)
   }
 
   @Test
@@ -56,6 +64,8 @@ class PolylineAnnotationManagerAndroidTest : BaseMapTest() {
     val polylineAnnotationManager = mapView.annotations.createPolylineAnnotationManager(mapView)
     polylineAnnotationManager.lineRoundLimit = expectedValue
     assertEquals(expectedValue, polylineAnnotationManager.lineRoundLimit)
+    polylineAnnotationManager.lineRoundLimit = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("line", "line-round-limit").silentUnwrap(), polylineAnnotationManager.lineRoundLimit)
   }
 
   @Test
@@ -64,6 +74,8 @@ class PolylineAnnotationManagerAndroidTest : BaseMapTest() {
     val polylineAnnotationManager = mapView.annotations.createPolylineAnnotationManager(mapView)
     polylineAnnotationManager.lineDasharray = expectedValue
     assertEquals(expectedValue, polylineAnnotationManager.lineDasharray)
+    polylineAnnotationManager.lineDasharray = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("line", "line-dasharray").silentUnwrap(), polylineAnnotationManager.lineDasharray)
   }
 
   @Test
@@ -72,6 +84,8 @@ class PolylineAnnotationManagerAndroidTest : BaseMapTest() {
     val polylineAnnotationManager = mapView.annotations.createPolylineAnnotationManager(mapView)
     polylineAnnotationManager.lineTranslate = expectedValue
     assertEquals(expectedValue, polylineAnnotationManager.lineTranslate)
+    polylineAnnotationManager.lineTranslate = null
+    assertEquals(StyleManager.getStyleLayerPropertyDefaultValue("line", "line-translate").silentUnwrap(), polylineAnnotationManager.lineTranslate)
   }
 
   @Test
@@ -80,6 +94,9 @@ class PolylineAnnotationManagerAndroidTest : BaseMapTest() {
     val polylineAnnotationManager = mapView.annotations.createPolylineAnnotationManager(mapView)
     polylineAnnotationManager.lineTranslateAnchor = expectedValue
     assertEquals(expectedValue, polylineAnnotationManager.lineTranslateAnchor)
+    polylineAnnotationManager.lineTranslateAnchor = null
+    val expectedDefaultValue = LineTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("line", "line-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+    assertEquals(expectedDefaultValue, polylineAnnotationManager.lineTranslateAnchor)
   }
 
   @Test

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotation.kt
@@ -76,8 +76,10 @@ class CircleAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY, it)
+      if (value != null) {
+        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY, value)
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY)
       }
     }
 
@@ -107,8 +109,10 @@ class CircleAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR, it)
+      if (value != null) {
+        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR, value)
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR)
       }
     }
 
@@ -138,10 +142,12 @@ class CircleAnnotation(
      * @param color value for String
      */
     set(@ColorInt value) {
-      value?.let {
+      if (value != null) {
         jsonObject.addProperty(
           CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR, ColorUtils.colorToRgbaString(value)
         )
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR)
       }
     }
 
@@ -169,7 +175,11 @@ class CircleAnnotation(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR, value)
+      if (value != null) {
+        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR, value)
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR)
+      }
     }
 
   /**
@@ -198,8 +208,10 @@ class CircleAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY, it)
+      if (value != null) {
+        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY, value)
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY)
       }
     }
 
@@ -229,8 +241,10 @@ class CircleAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS, it)
+      if (value != null) {
+        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS, value)
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS)
       }
     }
 
@@ -260,10 +274,12 @@ class CircleAnnotation(
      * @param color value for String
      */
     set(@ColorInt value) {
-      value?.let {
+      if (value != null) {
         jsonObject.addProperty(
           CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR, ColorUtils.colorToRgbaString(value)
         )
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR)
       }
     }
 
@@ -291,7 +307,11 @@ class CircleAnnotation(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR, value)
+      if (value != null) {
+        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR, value)
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR)
+      }
     }
 
   /**
@@ -320,8 +340,10 @@ class CircleAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY, it)
+      if (value != null) {
+        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY, value)
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY)
       }
     }
 
@@ -351,8 +373,10 @@ class CircleAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH, it)
+      if (value != null) {
+        jsonObject.addProperty(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH, value)
+      } else {
+        jsonObject.remove(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH)
       }
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManager.kt
@@ -4,16 +4,19 @@ package com.mapbox.maps.plugin.annotation.generated
 
 import android.view.View
 import com.mapbox.geojson.*
+import com.mapbox.maps.StyleManager
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.get
 import com.mapbox.maps.extension.style.layers.generated.CircleLayer
 import com.mapbox.maps.extension.style.layers.generated.circleLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.AnnotationManagerImpl
 import com.mapbox.maps.plugin.annotation.AnnotationPlugin
 import com.mapbox.maps.plugin.annotation.AnnotationType
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
+import java.util.*
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -173,7 +176,8 @@ class CircleAnnotationManager(
      * @param value property wrapper value around CirclePitchAlignment
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: CirclePitchAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("circle", "circle-pitch-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.circlePitchAlignment(it)
         dragLayer?.circlePitchAlignment(it)
       }
@@ -198,7 +202,8 @@ class CircleAnnotationManager(
      * @param value property wrapper value around CirclePitchScale
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: CirclePitchScale.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("circle", "circle-pitch-scale").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.circlePitchScale(it)
         dragLayer?.circlePitchScale(it)
       }
@@ -223,7 +228,8 @@ class CircleAnnotationManager(
      * @param value property wrapper value around List<Double>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("circle", "circle-translate").silentUnwrap()
+      newValue?.let {
         layer?.circleTranslate(it)
         dragLayer?.circleTranslate(it)
       }
@@ -248,7 +254,8 @@ class CircleAnnotationManager(
      * @param value property wrapper value around CircleTranslateAnchor
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: CircleTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("circle", "circle-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.circleTranslateAnchor(it)
         dragLayer?.circleTranslateAnchor(it)
       }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotation.kt
@@ -63,12 +63,14 @@ class PointAnnotation(
      * @param value the iconBitmap
      */
     set(value) {
-      value?.let {
-        field = it
+      if (value != null) {
+        field = value
         if (iconImage == null || iconImage!!.startsWith(ICON_DEFAULT_NAME_PREFIX)) {
           // User does not set iconImage, update iconImage to this new bitmap
-          iconImage = ICON_DEFAULT_NAME_PREFIX + it.hashCode()
+          iconImage = ICON_DEFAULT_NAME_PREFIX + value.hashCode()
         }
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_IMAGE)
       }
     }
   // Property accessors
@@ -98,8 +100,10 @@ class PointAnnotation(
      * @param value constant property value for IconAnchor
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_ANCHOR, it.value)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_ANCHOR, value.value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_ANCHOR)
       }
     }
 
@@ -129,8 +133,10 @@ class PointAnnotation(
      * @param value constant property value for String
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_IMAGE, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_IMAGE, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_IMAGE)
       }
     }
 
@@ -157,10 +163,12 @@ class PointAnnotation(
      * To update the pointAnnotation on the map use {@link PointAnnotationManager#update(Annotation)}.
      */
     set(value) {
-      val jsonArray = JsonArray()
-      value?.let {
-        it.forEach { jsonArray.add(it) }
+      if (value != null) {
+        val jsonArray = JsonArray()
+        value.forEach { jsonArray.add(it) }
         jsonObject.add(PointAnnotationOptions.PROPERTY_ICON_OFFSET, jsonArray)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_OFFSET)
       }
     }
 
@@ -190,8 +198,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_ROTATE, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_ROTATE, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_ROTATE)
       }
     }
 
@@ -221,8 +231,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_SIZE, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_SIZE, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_SIZE)
       }
     }
 
@@ -252,8 +264,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY)
       }
     }
 
@@ -283,8 +297,10 @@ class PointAnnotation(
      * @param value constant property value for TextAnchor
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR, it.value)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR, value.value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR)
       }
     }
 
@@ -314,8 +330,10 @@ class PointAnnotation(
      * @param value constant property value for String
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_FIELD, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_FIELD, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_FIELD)
       }
     }
 
@@ -345,8 +363,10 @@ class PointAnnotation(
      * @param value constant property value for TextJustify
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY, it.value)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY, value.value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)
       }
     }
 
@@ -376,8 +396,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING)
       }
     }
 
@@ -407,8 +429,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH)
       }
     }
 
@@ -435,10 +459,12 @@ class PointAnnotation(
      * To update the pointAnnotation on the map use {@link PointAnnotationManager#update(Annotation)}.
      */
     set(value) {
-      val jsonArray = JsonArray()
-      value?.let {
-        it.forEach { jsonArray.add(it) }
+      if (value != null) {
+        val jsonArray = JsonArray()
+        value.forEach { jsonArray.add(it) }
         jsonObject.add(PointAnnotationOptions.PROPERTY_TEXT_OFFSET, jsonArray)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_OFFSET)
       }
     }
 
@@ -468,8 +494,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET)
       }
     }
 
@@ -499,8 +527,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_ROTATE, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_ROTATE, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_ROTATE)
       }
     }
 
@@ -530,8 +560,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_SIZE, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_SIZE, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_SIZE)
       }
     }
 
@@ -561,8 +593,10 @@ class PointAnnotation(
      * @param value constant property value for TextTransform
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM, it.value)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM, value.value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM)
       }
     }
 
@@ -592,10 +626,12 @@ class PointAnnotation(
      * @param color value for String
      */
     set(@ColorInt value) {
-      value?.let {
+      if (value != null) {
         jsonObject.addProperty(
           PointAnnotationOptions.PROPERTY_ICON_COLOR, ColorUtils.colorToRgbaString(value)
         )
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_COLOR)
       }
     }
 
@@ -623,7 +659,11 @@ class PointAnnotation(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_COLOR, value)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_COLOR, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_COLOR)
+      }
     }
 
   /**
@@ -652,8 +692,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR)
       }
     }
 
@@ -683,10 +725,12 @@ class PointAnnotation(
      * @param color value for String
      */
     set(@ColorInt value) {
-      value?.let {
+      if (value != null) {
         jsonObject.addProperty(
           PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR, ColorUtils.colorToRgbaString(value)
         )
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR)
       }
     }
 
@@ -714,7 +758,11 @@ class PointAnnotation(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR, value)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR)
+      }
     }
 
   /**
@@ -743,8 +791,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH)
       }
     }
 
@@ -774,8 +824,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_OPACITY, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_ICON_OPACITY, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_ICON_OPACITY)
       }
     }
 
@@ -805,10 +857,12 @@ class PointAnnotation(
      * @param color value for String
      */
     set(@ColorInt value) {
-      value?.let {
+      if (value != null) {
         jsonObject.addProperty(
           PointAnnotationOptions.PROPERTY_TEXT_COLOR, ColorUtils.colorToRgbaString(value)
         )
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_COLOR)
       }
     }
 
@@ -836,7 +890,11 @@ class PointAnnotation(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_COLOR, value)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_COLOR, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_COLOR)
+      }
     }
 
   /**
@@ -865,8 +923,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR)
       }
     }
 
@@ -896,10 +956,12 @@ class PointAnnotation(
      * @param color value for String
      */
     set(@ColorInt value) {
-      value?.let {
+      if (value != null) {
         jsonObject.addProperty(
           PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR, ColorUtils.colorToRgbaString(value)
         )
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR)
       }
     }
 
@@ -927,7 +989,11 @@ class PointAnnotation(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR, value)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR)
+      }
     }
 
   /**
@@ -956,8 +1022,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH)
       }
     }
 
@@ -987,8 +1055,10 @@ class PointAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_OPACITY, it)
+      if (value != null) {
+        jsonObject.addProperty(PointAnnotationOptions.PROPERTY_TEXT_OPACITY, value)
+      } else {
+        jsonObject.remove(PointAnnotationOptions.PROPERTY_TEXT_OPACITY)
       }
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManager.kt
@@ -4,16 +4,19 @@ package com.mapbox.maps.plugin.annotation.generated
 
 import android.view.View
 import com.mapbox.geojson.*
+import com.mapbox.maps.StyleManager
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.get
 import com.mapbox.maps.extension.style.layers.generated.SymbolLayer
 import com.mapbox.maps.extension.style.layers.generated.symbolLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.AnnotationManagerImpl
 import com.mapbox.maps.plugin.annotation.AnnotationPlugin
 import com.mapbox.maps.plugin.annotation.AnnotationType
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
+import java.util.*
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -304,7 +307,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-allow-overlap").silentUnwrap()
+      newValue?.let {
         layer?.iconAllowOverlap(it)
         dragLayer?.iconAllowOverlap(it)
       }
@@ -329,7 +333,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-ignore-placement").silentUnwrap()
+      newValue?.let {
         layer?.iconIgnorePlacement(it)
         dragLayer?.iconIgnorePlacement(it)
       }
@@ -354,7 +359,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-keep-upright").silentUnwrap()
+      newValue?.let {
         layer?.iconKeepUpright(it)
         dragLayer?.iconKeepUpright(it)
       }
@@ -379,7 +385,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-optional").silentUnwrap()
+      newValue?.let {
         layer?.iconOptional(it)
         dragLayer?.iconOptional(it)
       }
@@ -404,7 +411,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Double
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-padding").silentUnwrap()
+      newValue?.let {
         layer?.iconPadding(it)
         dragLayer?.iconPadding(it)
       }
@@ -429,7 +437,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around IconPitchAlignment
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: IconPitchAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-pitch-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.iconPitchAlignment(it)
         dragLayer?.iconPitchAlignment(it)
       }
@@ -454,7 +463,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around IconRotationAlignment
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: IconRotationAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-rotation-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.iconRotationAlignment(it)
         dragLayer?.iconRotationAlignment(it)
       }
@@ -479,7 +489,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around IconTextFit
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: IconTextFit.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-text-fit").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.iconTextFit(it)
         dragLayer?.iconTextFit(it)
       }
@@ -504,7 +515,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around List<Double>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-text-fit-padding").silentUnwrap()
+      newValue?.let {
         layer?.iconTextFitPadding(it)
         dragLayer?.iconTextFitPadding(it)
       }
@@ -529,7 +541,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "symbol-avoid-edges").silentUnwrap()
+      newValue?.let {
         layer?.symbolAvoidEdges(it)
         dragLayer?.symbolAvoidEdges(it)
       }
@@ -554,7 +567,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around SymbolPlacement
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: SymbolPlacement.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "symbol-placement").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.symbolPlacement(it)
         dragLayer?.symbolPlacement(it)
       }
@@ -579,7 +593,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Double
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "symbol-spacing").silentUnwrap()
+      newValue?.let {
         layer?.symbolSpacing(it)
         dragLayer?.symbolSpacing(it)
       }
@@ -604,7 +619,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around SymbolZOrder
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: SymbolZOrder.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "symbol-z-order").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.symbolZOrder(it)
         dragLayer?.symbolZOrder(it)
       }
@@ -629,7 +645,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-allow-overlap").silentUnwrap()
+      newValue?.let {
         layer?.textAllowOverlap(it)
         dragLayer?.textAllowOverlap(it)
       }
@@ -654,7 +671,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around List<String>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-font").silentUnwrap()
+      newValue?.let {
         layer?.textFont(it)
         dragLayer?.textFont(it)
       }
@@ -679,7 +697,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-ignore-placement").silentUnwrap()
+      newValue?.let {
         layer?.textIgnorePlacement(it)
         dragLayer?.textIgnorePlacement(it)
       }
@@ -704,7 +723,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-keep-upright").silentUnwrap()
+      newValue?.let {
         layer?.textKeepUpright(it)
         dragLayer?.textKeepUpright(it)
       }
@@ -729,7 +749,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Double
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-line-height").silentUnwrap()
+      newValue?.let {
         layer?.textLineHeight(it)
         dragLayer?.textLineHeight(it)
       }
@@ -754,7 +775,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Double
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-max-angle").silentUnwrap()
+      newValue?.let {
         layer?.textMaxAngle(it)
         dragLayer?.textMaxAngle(it)
       }
@@ -779,7 +801,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-optional").silentUnwrap()
+      newValue?.let {
         layer?.textOptional(it)
         dragLayer?.textOptional(it)
       }
@@ -804,7 +827,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around Double
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-padding").silentUnwrap()
+      newValue?.let {
         layer?.textPadding(it)
         dragLayer?.textPadding(it)
       }
@@ -829,7 +853,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around TextPitchAlignment
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: TextPitchAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-pitch-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.textPitchAlignment(it)
         dragLayer?.textPitchAlignment(it)
       }
@@ -854,7 +879,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around TextRotationAlignment
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: TextRotationAlignment.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-rotation-alignment").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.textRotationAlignment(it)
         dragLayer?.textRotationAlignment(it)
       }
@@ -879,7 +905,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around List<String>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-variable-anchor").silentUnwrap()
+      newValue?.let {
         layer?.textVariableAnchor(it)
         dragLayer?.textVariableAnchor(it)
       }
@@ -904,7 +931,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around List<String>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-writing-mode").silentUnwrap()
+      newValue?.let {
         layer?.textWritingMode(it)
         dragLayer?.textWritingMode(it)
       }
@@ -929,7 +957,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around List<Double>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-translate").silentUnwrap()
+      newValue?.let {
         layer?.iconTranslate(it)
         dragLayer?.iconTranslate(it)
       }
@@ -954,7 +983,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around IconTranslateAnchor
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: IconTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "icon-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.iconTranslateAnchor(it)
         dragLayer?.iconTranslateAnchor(it)
       }
@@ -979,7 +1009,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around List<Double>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-translate").silentUnwrap()
+      newValue?.let {
         layer?.textTranslate(it)
         dragLayer?.textTranslate(it)
       }
@@ -1004,7 +1035,8 @@ class PointAnnotationManager(
      * @param value property wrapper value around TextTranslateAnchor
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: TextTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("symbol", "text-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.textTranslateAnchor(it)
         dragLayer?.textTranslateAnchor(it)
       }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotation.kt
@@ -76,8 +76,10 @@ class PolygonAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY, it)
+      if (value != null) {
+        jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY, value)
+      } else {
+        jsonObject.remove(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY)
       }
     }
 
@@ -107,10 +109,12 @@ class PolygonAnnotation(
      * @param color value for String
      */
     set(@ColorInt value) {
-      value?.let {
+      if (value != null) {
         jsonObject.addProperty(
           PolygonAnnotationOptions.PROPERTY_FILL_COLOR, ColorUtils.colorToRgbaString(value)
         )
+      } else {
+        jsonObject.remove(PolygonAnnotationOptions.PROPERTY_FILL_COLOR)
       }
     }
 
@@ -138,7 +142,11 @@ class PolygonAnnotation(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_COLOR, value)
+      if (value != null) {
+        jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_COLOR, value)
+      } else {
+        jsonObject.remove(PolygonAnnotationOptions.PROPERTY_FILL_COLOR)
+      }
     }
 
   /**
@@ -167,8 +175,10 @@ class PolygonAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY, it)
+      if (value != null) {
+        jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY, value)
+      } else {
+        jsonObject.remove(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY)
       }
     }
 
@@ -198,10 +208,12 @@ class PolygonAnnotation(
      * @param color value for String
      */
     set(@ColorInt value) {
-      value?.let {
+      if (value != null) {
         jsonObject.addProperty(
           PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR, ColorUtils.colorToRgbaString(value)
         )
+      } else {
+        jsonObject.remove(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR)
       }
     }
 
@@ -229,7 +241,11 @@ class PolygonAnnotation(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR, value)
+      if (value != null) {
+        jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR, value)
+      } else {
+        jsonObject.remove(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR)
+      }
     }
 
   /**
@@ -258,8 +274,10 @@ class PolygonAnnotation(
      * @param value constant property value for String
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN, it)
+      if (value != null) {
+        jsonObject.addProperty(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN, value)
+      } else {
+        jsonObject.remove(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN)
       }
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManager.kt
@@ -4,16 +4,19 @@ package com.mapbox.maps.plugin.annotation.generated
 
 import android.view.View
 import com.mapbox.geojson.*
+import com.mapbox.maps.StyleManager
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.get
 import com.mapbox.maps.extension.style.layers.generated.FillLayer
 import com.mapbox.maps.extension.style.layers.generated.fillLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.AnnotationManagerImpl
 import com.mapbox.maps.plugin.annotation.AnnotationPlugin
 import com.mapbox.maps.plugin.annotation.AnnotationType
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
+import java.util.*
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -152,7 +155,8 @@ class PolygonAnnotationManager(
      * @param value property wrapper value around Boolean
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-antialias").silentUnwrap()
+      newValue?.let {
         layer?.fillAntialias(it)
         dragLayer?.fillAntialias(it)
       }
@@ -177,7 +181,8 @@ class PolygonAnnotationManager(
      * @param value property wrapper value around List<Double>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-translate").silentUnwrap()
+      newValue?.let {
         layer?.fillTranslate(it)
         dragLayer?.fillTranslate(it)
       }
@@ -202,7 +207,8 @@ class PolygonAnnotationManager(
      * @param value property wrapper value around FillTranslateAnchor
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: FillTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.fillTranslateAnchor(it)
         dragLayer?.fillTranslateAnchor(it)
       }

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotation.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotation.kt
@@ -77,8 +77,10 @@ class PolylineAnnotation(
      * @param value constant property value for LineJoin
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_JOIN, it.value)
+      if (value != null) {
+        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_JOIN, value.value)
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_JOIN)
       }
     }
 
@@ -108,8 +110,10 @@ class PolylineAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY, it)
+      if (value != null) {
+        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY, value)
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY)
       }
     }
 
@@ -139,8 +143,10 @@ class PolylineAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_BLUR, it)
+      if (value != null) {
+        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_BLUR, value)
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_BLUR)
       }
     }
 
@@ -170,10 +176,12 @@ class PolylineAnnotation(
      * @param color value for String
      */
     set(@ColorInt value) {
-      value?.let {
+      if (value != null) {
         jsonObject.addProperty(
           PolylineAnnotationOptions.PROPERTY_LINE_COLOR, ColorUtils.colorToRgbaString(value)
         )
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_COLOR)
       }
     }
 
@@ -201,7 +209,11 @@ class PolylineAnnotation(
      * @param color value for String
      */
     set(value) {
-      jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_COLOR, value)
+      if (value != null) {
+        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_COLOR, value)
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_COLOR)
+      }
     }
 
   /**
@@ -230,8 +242,10 @@ class PolylineAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH, it)
+      if (value != null) {
+        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH, value)
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH)
       }
     }
 
@@ -261,8 +275,10 @@ class PolylineAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET, it)
+      if (value != null) {
+        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET, value)
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET)
       }
     }
 
@@ -292,8 +308,10 @@ class PolylineAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY, it)
+      if (value != null) {
+        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY, value)
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY)
       }
     }
 
@@ -323,8 +341,10 @@ class PolylineAnnotation(
      * @param value constant property value for String
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN, it)
+      if (value != null) {
+        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN, value)
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN)
       }
     }
 
@@ -354,8 +374,10 @@ class PolylineAnnotation(
      * @param value constant property value for Double
      */
     set(value) {
-      value?.let {
-        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH, it)
+      if (value != null) {
+        jsonObject.addProperty(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH, value)
+      } else {
+        jsonObject.remove(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH)
       }
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManager.kt
@@ -4,16 +4,19 @@ package com.mapbox.maps.plugin.annotation.generated
 
 import android.view.View
 import com.mapbox.geojson.*
+import com.mapbox.maps.StyleManager
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.get
 import com.mapbox.maps.extension.style.layers.generated.LineLayer
 import com.mapbox.maps.extension.style.layers.generated.lineLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.*
+import com.mapbox.maps.extension.style.utils.silentUnwrap
 import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.AnnotationManagerImpl
 import com.mapbox.maps.plugin.annotation.AnnotationPlugin
 import com.mapbox.maps.plugin.annotation.AnnotationType
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
+import java.util.*
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -180,7 +183,8 @@ class PolylineAnnotationManager(
      * @param value property wrapper value around LineCap
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: LineCap.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("line", "line-cap").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.lineCap(it)
         dragLayer?.lineCap(it)
       }
@@ -205,7 +209,8 @@ class PolylineAnnotationManager(
      * @param value property wrapper value around Double
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("line", "line-miter-limit").silentUnwrap()
+      newValue?.let {
         layer?.lineMiterLimit(it)
         dragLayer?.lineMiterLimit(it)
       }
@@ -230,7 +235,8 @@ class PolylineAnnotationManager(
      * @param value property wrapper value around Double
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("line", "line-round-limit").silentUnwrap()
+      newValue?.let {
         layer?.lineRoundLimit(it)
         dragLayer?.lineRoundLimit(it)
       }
@@ -255,7 +261,8 @@ class PolylineAnnotationManager(
      * @param value property wrapper value around List<Double>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("line", "line-dasharray").silentUnwrap()
+      newValue?.let {
         layer?.lineDasharray(it)
         dragLayer?.lineDasharray(it)
       }
@@ -280,7 +287,8 @@ class PolylineAnnotationManager(
      * @param value property wrapper value around List<Double>
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: StyleManager.getStyleLayerPropertyDefaultValue("line", "line-translate").silentUnwrap()
+      newValue?.let {
         layer?.lineTranslate(it)
         dragLayer?.lineTranslate(it)
       }
@@ -305,7 +313,8 @@ class PolylineAnnotationManager(
      * @param value property wrapper value around LineTranslateAnchor
      */
     set(value) {
-      value?.let {
+      val newValue = value ?: LineTranslateAnchor.valueOf(StyleManager.getStyleLayerPropertyDefaultValue("line", "line-translate-anchor").silentUnwrap<String>()!!.toUpperCase(Locale.US).replace('-', '_'))
+      newValue?.let {
         layer?.lineTranslateAnchor(it)
         dragLayer?.lineTranslateAnchor(it)
       }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -24,6 +24,7 @@ import com.mapbox.maps.extension.style.layers.generated.CircleLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.getSource
+import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.*
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
@@ -31,8 +32,7 @@ import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import io.mockk.*
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -249,6 +249,61 @@ class CircleAnnotationManagerTest {
     annotation.point = Point.fromLngLat(1.0, 1.0)
     manager.update(annotation)
     assertEquals(annotation, manager.annotations[0])
+  }
+
+  @Test
+  fun annotationPropertiesUpdate() {
+    val annotation = manager.create(CircleAnnotationOptions().withPoint(Point.fromLngLat(0.0, 0.0)))
+
+    annotation.circleSortKey = 1.0
+    assertEquals(1.0, annotation.circleSortKey)
+    annotation.circleSortKey = null
+    assertNull(annotation.circleSortKey)
+
+    annotation.circleBlur = 0.0
+    assertEquals(0.0, annotation.circleBlur)
+    annotation.circleBlur = null
+    assertNull(annotation.circleBlur)
+
+    annotation.circleColorInt = Color.BLACK
+    assertEquals(Color.BLACK, annotation.circleColorInt)
+    annotation.circleColorInt = null
+    assertNull(annotation.circleColorInt)
+
+    annotation.circleColorString = ColorUtils.colorToRgbaString(Color.YELLOW)
+    assertEquals(ColorUtils.colorToRgbaString(Color.YELLOW), annotation.circleColorString)
+    annotation.circleColorString = null
+    assertNull(annotation.circleColorString)
+
+    annotation.circleOpacity = 1.0
+    assertEquals(1.0, annotation.circleOpacity)
+    annotation.circleOpacity = null
+    assertNull(annotation.circleOpacity)
+
+    annotation.circleRadius = 5.0
+    assertEquals(5.0, annotation.circleRadius)
+    annotation.circleRadius = null
+    assertNull(annotation.circleRadius)
+
+    annotation.circleStrokeColorInt = Color.BLACK
+    assertEquals(Color.BLACK, annotation.circleStrokeColorInt)
+    annotation.circleStrokeColorInt = null
+    assertNull(annotation.circleStrokeColorInt)
+
+    annotation.circleStrokeColorString = ColorUtils.colorToRgbaString(Color.YELLOW)
+    assertEquals(ColorUtils.colorToRgbaString(Color.YELLOW), annotation.circleStrokeColorString)
+    annotation.circleStrokeColorString = null
+    assertNull(annotation.circleStrokeColorString)
+
+    annotation.circleStrokeOpacity = 1.0
+    assertEquals(1.0, annotation.circleStrokeOpacity)
+    annotation.circleStrokeOpacity = null
+    assertNull(annotation.circleStrokeOpacity)
+
+    annotation.circleStrokeWidth = 0.0
+    assertEquals(0.0, annotation.circleStrokeWidth)
+    annotation.circleStrokeWidth = null
+    assertNull(annotation.circleStrokeWidth)
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -27,6 +27,7 @@ import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.getSource
+import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.*
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
@@ -34,8 +35,7 @@ import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import io.mockk.*
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -382,6 +382,166 @@ class PointAnnotationManagerTest {
     annotation.point = Point.fromLngLat(1.0, 1.0)
     manager.update(annotation)
     assertEquals(annotation, manager.annotations[0])
+  }
+
+  @Test
+  fun annotationPropertiesUpdate() {
+    val annotation = manager.create(PointAnnotationOptions().withPoint(Point.fromLngLat(0.0, 0.0)))
+
+    annotation.iconImageBitmap = bitmap
+    assertEquals(PointAnnotation.ICON_DEFAULT_NAME_PREFIX + bitmap.hashCode(), annotation.iconImage)
+    annotation.iconImageBitmap = null
+    assertNull(annotation.iconImage)
+
+    annotation.iconAnchor = IconAnchor.CENTER
+    assertEquals(IconAnchor.CENTER, annotation.iconAnchor)
+    annotation.iconAnchor = null
+    assertNull(annotation.iconAnchor)
+
+    annotation.iconImage = ""
+    assertEquals("", annotation.iconImage)
+    annotation.iconImage = null
+    assertNull(annotation.iconImage)
+
+    annotation.iconOffset = listOf(0.0, 0.0)
+    assertEquals(listOf(0.0, 0.0), annotation.iconOffset)
+    annotation.iconOffset = null
+    assertNull(annotation.iconOffset)
+
+    annotation.iconRotate = 0.0
+    assertEquals(0.0, annotation.iconRotate)
+    annotation.iconRotate = null
+    assertNull(annotation.iconRotate)
+
+    annotation.iconSize = 1.0
+    assertEquals(1.0, annotation.iconSize)
+    annotation.iconSize = null
+    assertNull(annotation.iconSize)
+
+    annotation.symbolSortKey = 1.0
+    assertEquals(1.0, annotation.symbolSortKey)
+    annotation.symbolSortKey = null
+    assertNull(annotation.symbolSortKey)
+
+    annotation.textAnchor = TextAnchor.CENTER
+    assertEquals(TextAnchor.CENTER, annotation.textAnchor)
+    annotation.textAnchor = null
+    assertNull(annotation.textAnchor)
+
+    annotation.textField = ""
+    assertEquals("", annotation.textField)
+    annotation.textField = null
+    assertNull(annotation.textField)
+
+    annotation.textJustify = TextJustify.AUTO
+    assertEquals(TextJustify.AUTO, annotation.textJustify)
+    annotation.textJustify = null
+    assertNull(annotation.textJustify)
+
+    annotation.textLetterSpacing = 0.0
+    assertEquals(0.0, annotation.textLetterSpacing)
+    annotation.textLetterSpacing = null
+    assertNull(annotation.textLetterSpacing)
+
+    annotation.textMaxWidth = 10.0
+    assertEquals(10.0, annotation.textMaxWidth)
+    annotation.textMaxWidth = null
+    assertNull(annotation.textMaxWidth)
+
+    annotation.textOffset = listOf(0.0, 0.0)
+    assertEquals(listOf(0.0, 0.0), annotation.textOffset)
+    annotation.textOffset = null
+    assertNull(annotation.textOffset)
+
+    annotation.textRadialOffset = 0.0
+    assertEquals(0.0, annotation.textRadialOffset)
+    annotation.textRadialOffset = null
+    assertNull(annotation.textRadialOffset)
+
+    annotation.textRotate = 0.0
+    assertEquals(0.0, annotation.textRotate)
+    annotation.textRotate = null
+    assertNull(annotation.textRotate)
+
+    annotation.textSize = 16.0
+    assertEquals(16.0, annotation.textSize)
+    annotation.textSize = null
+    assertNull(annotation.textSize)
+
+    annotation.textTransform = TextTransform.NONE
+    assertEquals(TextTransform.NONE, annotation.textTransform)
+    annotation.textTransform = null
+    assertNull(annotation.textTransform)
+
+    annotation.iconColorInt = Color.BLACK
+    assertEquals(Color.BLACK, annotation.iconColorInt)
+    annotation.iconColorInt = null
+    assertNull(annotation.iconColorInt)
+
+    annotation.iconColorString = ColorUtils.colorToRgbaString(Color.YELLOW)
+    assertEquals(ColorUtils.colorToRgbaString(Color.YELLOW), annotation.iconColorString)
+    annotation.iconColorString = null
+    assertNull(annotation.iconColorString)
+
+    annotation.iconHaloBlur = 0.0
+    assertEquals(0.0, annotation.iconHaloBlur)
+    annotation.iconHaloBlur = null
+    assertNull(annotation.iconHaloBlur)
+
+    annotation.iconHaloColorInt = Color.BLACK
+    assertEquals(Color.BLACK, annotation.iconHaloColorInt)
+    annotation.iconHaloColorInt = null
+    assertNull(annotation.iconHaloColorInt)
+
+    annotation.iconHaloColorString = ColorUtils.colorToRgbaString(Color.YELLOW)
+    assertEquals(ColorUtils.colorToRgbaString(Color.YELLOW), annotation.iconHaloColorString)
+    annotation.iconHaloColorString = null
+    assertNull(annotation.iconHaloColorString)
+
+    annotation.iconHaloWidth = 0.0
+    assertEquals(0.0, annotation.iconHaloWidth)
+    annotation.iconHaloWidth = null
+    assertNull(annotation.iconHaloWidth)
+
+    annotation.iconOpacity = 1.0
+    assertEquals(1.0, annotation.iconOpacity)
+    annotation.iconOpacity = null
+    assertNull(annotation.iconOpacity)
+
+    annotation.textColorInt = Color.BLACK
+    assertEquals(Color.BLACK, annotation.textColorInt)
+    annotation.textColorInt = null
+    assertNull(annotation.textColorInt)
+
+    annotation.textColorString = ColorUtils.colorToRgbaString(Color.YELLOW)
+    assertEquals(ColorUtils.colorToRgbaString(Color.YELLOW), annotation.textColorString)
+    annotation.textColorString = null
+    assertNull(annotation.textColorString)
+
+    annotation.textHaloBlur = 0.0
+    assertEquals(0.0, annotation.textHaloBlur)
+    annotation.textHaloBlur = null
+    assertNull(annotation.textHaloBlur)
+
+    annotation.textHaloColorInt = Color.BLACK
+    assertEquals(Color.BLACK, annotation.textHaloColorInt)
+    annotation.textHaloColorInt = null
+    assertNull(annotation.textHaloColorInt)
+
+    annotation.textHaloColorString = ColorUtils.colorToRgbaString(Color.YELLOW)
+    assertEquals(ColorUtils.colorToRgbaString(Color.YELLOW), annotation.textHaloColorString)
+    annotation.textHaloColorString = null
+    assertNull(annotation.textHaloColorString)
+
+    annotation.textHaloWidth = 0.0
+    assertEquals(0.0, annotation.textHaloWidth)
+    annotation.textHaloWidth = null
+    assertNull(annotation.textHaloWidth)
+
+    annotation.textOpacity = 1.0
+    assertEquals(1.0, annotation.textOpacity)
+    annotation.textOpacity = null
+    assertNull(annotation.textOpacity)
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -25,6 +25,7 @@ import com.mapbox.maps.extension.style.layers.generated.FillLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.getSource
+import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.*
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
@@ -32,8 +33,7 @@ import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import io.mockk.*
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -244,6 +244,46 @@ class PolygonAnnotationManagerTest {
     annotation.points = listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))
     manager.update(annotation)
     assertEquals(annotation, manager.annotations[0])
+  }
+
+  @Test
+  fun annotationPropertiesUpdate() {
+    val annotation = manager.create(PolygonAnnotationOptions().withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0)))))
+
+    annotation.fillSortKey = 1.0
+    assertEquals(1.0, annotation.fillSortKey)
+    annotation.fillSortKey = null
+    assertNull(annotation.fillSortKey)
+
+    annotation.fillColorInt = Color.BLACK
+    assertEquals(Color.BLACK, annotation.fillColorInt)
+    annotation.fillColorInt = null
+    assertNull(annotation.fillColorInt)
+
+    annotation.fillColorString = ColorUtils.colorToRgbaString(Color.YELLOW)
+    assertEquals(ColorUtils.colorToRgbaString(Color.YELLOW), annotation.fillColorString)
+    annotation.fillColorString = null
+    assertNull(annotation.fillColorString)
+
+    annotation.fillOpacity = 1.0
+    assertEquals(1.0, annotation.fillOpacity)
+    annotation.fillOpacity = null
+    assertNull(annotation.fillOpacity)
+
+    annotation.fillOutlineColorInt = Color.BLACK
+    assertEquals(Color.BLACK, annotation.fillOutlineColorInt)
+    annotation.fillOutlineColorInt = null
+    assertNull(annotation.fillOutlineColorInt)
+
+    annotation.fillOutlineColorString = ColorUtils.colorToRgbaString(Color.YELLOW)
+    assertEquals(ColorUtils.colorToRgbaString(Color.YELLOW), annotation.fillOutlineColorString)
+    annotation.fillOutlineColorString = null
+    assertNull(annotation.fillOutlineColorString)
+
+    annotation.fillPattern = "pedestrian-polygon"
+    assertEquals("pedestrian-polygon", annotation.fillPattern)
+    annotation.fillPattern = null
+    assertNull(annotation.fillPattern)
   }
 
   @Test

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -26,6 +26,7 @@ import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.getSource
+import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.*
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
@@ -33,8 +34,7 @@ import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import io.mockk.*
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -253,6 +253,61 @@ class PolylineAnnotationManagerTest {
     annotation.points = listOf(Point.fromLngLat(1.0, 1.0), Point.fromLngLat(1.0, 1.0))
     manager.update(annotation)
     assertEquals(annotation, manager.annotations[0])
+  }
+
+  @Test
+  fun annotationPropertiesUpdate() {
+    val annotation = manager.create(PolylineAnnotationOptions().withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0))))
+
+    annotation.lineJoin = LineJoin.BEVEL
+    assertEquals(LineJoin.BEVEL, annotation.lineJoin)
+    annotation.lineJoin = null
+    assertNull(annotation.lineJoin)
+
+    annotation.lineSortKey = 1.0
+    assertEquals(1.0, annotation.lineSortKey)
+    annotation.lineSortKey = null
+    assertNull(annotation.lineSortKey)
+
+    annotation.lineBlur = 0.0
+    assertEquals(0.0, annotation.lineBlur)
+    annotation.lineBlur = null
+    assertNull(annotation.lineBlur)
+
+    annotation.lineColorInt = Color.BLACK
+    assertEquals(Color.BLACK, annotation.lineColorInt)
+    annotation.lineColorInt = null
+    assertNull(annotation.lineColorInt)
+
+    annotation.lineColorString = ColorUtils.colorToRgbaString(Color.YELLOW)
+    assertEquals(ColorUtils.colorToRgbaString(Color.YELLOW), annotation.lineColorString)
+    annotation.lineColorString = null
+    assertNull(annotation.lineColorString)
+
+    annotation.lineGapWidth = 0.0
+    assertEquals(0.0, annotation.lineGapWidth)
+    annotation.lineGapWidth = null
+    assertNull(annotation.lineGapWidth)
+
+    annotation.lineOffset = 0.0
+    assertEquals(0.0, annotation.lineOffset)
+    annotation.lineOffset = null
+    assertNull(annotation.lineOffset)
+
+    annotation.lineOpacity = 1.0
+    assertEquals(1.0, annotation.lineOpacity)
+    annotation.lineOpacity = null
+    assertNull(annotation.lineOpacity)
+
+    annotation.linePattern = "pedestrian-polygon"
+    assertEquals("pedestrian-polygon", annotation.linePattern)
+    annotation.linePattern = null
+    assertNull(annotation.linePattern)
+
+    annotation.lineWidth = 1.0
+    assertEquals(1.0, annotation.lineWidth)
+    annotation.lineWidth = null
+    assertNull(annotation.lineWidth)
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Enable annotations to set null value to nullable properties.</changelog>`.

### Summary of changes
In the past, we ignore null values while users set them to annotation nullable properties so that users are not able to remove previously set properties.
In this pr, the properties will be removed from annotation if users set null value.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->