### PR TITLE
Fix memory leak in renderer destroy

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/terrain3D/SantaCatalinaActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/terrain3D/SantaCatalinaActivity.kt
@@ -132,14 +132,15 @@ class SantaCatalinaActivity : AppCompatActivity() {
         response: Response<DirectionsResponse>
       ) {
         response.body()?.let { body ->
-          body.routes()[0].geometry()?.let {
-            animateRoute(
-              LineString.fromPolyline(it, PRECISION_6)
-            )
-            return
+          if (body.routes().isNotEmpty()) {
+            body.routes()[0].geometry()?.let {
+              animateRoute(
+                LineString.fromPolyline(it, PRECISION_6)
+              )
+              return
+            }
           }
-        }
-        throw RuntimeException("Not able to retrieve a directions route")
+        } ?: throw RuntimeException("Not able to retrieve a directions route")
       }
 
       override fun onFailure(call: Call<DirectionsResponse>, t: Throwable) {}

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -30,8 +30,6 @@ internal abstract class MapboxRenderer : MapClient() {
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var pixelReader: PixelReader? = null
 
-  internal var needDestroy = false
-
   // in order to prevent snapshots being black we capture first moment
   // when map is rendered fully
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -49,8 +47,7 @@ internal abstract class MapboxRenderer : MapClient() {
 
   @UiThread
   fun onDestroy() {
-    // we destroy and stop thread after surface or texture is destroyed
-    needDestroy = true
+    renderThread.destroy()
     renderThread.fpsChangedListener = null
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/WorkerHandlerThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/WorkerHandlerThread.kt
@@ -12,6 +12,9 @@ internal class WorkerHandlerThread {
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var handler: Handler? = null
 
+  internal var started = false
+    private set
+
   fun post(task: () -> Unit) {
     handler?.let {
       it.post { task.invoke() }
@@ -24,6 +27,7 @@ internal class WorkerHandlerThread {
       start()
       handler = Handler(this.looper)
     }
+    started = true
   }
 
   fun stop() {
@@ -33,6 +37,7 @@ internal class WorkerHandlerThread {
     } catch (e: InterruptedException) {
     } finally {
       handler = null
+      started = false
     }
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/WorkerHandlerThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/WorkerHandlerThread.kt
@@ -12,8 +12,8 @@ internal class WorkerHandlerThread {
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var handler: Handler? = null
 
-  internal var started = false
-    private set
+  internal val started
+    get() = handlerThread.isAlive
 
   fun post(task: () -> Unit) {
     handler?.let {
@@ -27,7 +27,6 @@ internal class WorkerHandlerThread {
       start()
       handler = Handler(this.looper)
     }
-    started = true
   }
 
   fun stop() {
@@ -37,7 +36,6 @@ internal class WorkerHandlerThread {
     } catch (e: InterruptedException) {
     } finally {
       handler = null
-      started = false
     }
   }
 

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -140,7 +140,7 @@ class MapboxRenderThreadTest {
     }
     assert(!mapboxRenderThread.eglPrepared)
     verify { mapboxRenderer.onSurfaceDestroyed() }
-    assert(!workerThread.handlerThread.isAlive)
+    assert(!workerThread.started)
   }
 
   @Test
@@ -159,7 +159,7 @@ class MapboxRenderThreadTest {
     }
     assert(!mapboxRenderThread.eglPrepared)
     verify { mapboxRenderer.onSurfaceDestroyed() }
-    assert(!workerThread.handlerThread.isAlive)
+    assert(!workerThread.started)
   }
 
   @Test
@@ -347,7 +347,7 @@ class MapboxRenderThreadTest {
   @Test
   fun destroyTest() {
     mapboxRenderThread.destroy()
-    assert(!workerThread.handlerThread.isAlive)
+    assert(!workerThread.started)
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -125,32 +125,20 @@ class MapboxRenderThreadTest {
   }
 
   @Test
-  fun onSurfaceOnlyDestroyedTest() {
-    every { mapboxRenderer.needDestroy } returns false
-    val surface = mockk<Surface>(relaxUnitFun = true)
-    every { surface.isValid } returns true
-    every { eglCore.eglStatusSuccess } returns true
-    every { eglCore.createWindowSurface(any()) } returns mockk(relaxed = true)
-    mapboxRenderThread.onSurfaceCreated(surface, 1, 1)
-    mapboxRenderThread.onSurfaceDestroyed()
-    verify(exactly = 0) { mapboxRenderer.onSurfaceDestroyed() }
-    assert(workerThread.handlerThread.isAlive)
-  }
-
-  @Test
   fun onSurfaceWithActivityDestroyedTest() {
     val latch = CountDownLatch(1)
     every { mapboxRenderer.onSurfaceDestroyed() } answers { latch.countDown() }
-    every { mapboxRenderer.needDestroy } returns true
     val surface = mockk<Surface>(relaxUnitFun = true)
     every { surface.isValid } returns true
     every { eglCore.eglStatusSuccess } returns true
     every { eglCore.createWindowSurface(any()) } returns mockk(relaxed = true)
     mapboxRenderThread.onSurfaceCreated(surface, 1, 1)
     mapboxRenderThread.onSurfaceDestroyed()
+    mapboxRenderThread.destroy()
     if (!latch.await(waitTime, TimeUnit.MILLISECONDS)) {
       throw TimeoutException()
     }
+    assert(!mapboxRenderThread.eglPrepared)
     verify { mapboxRenderer.onSurfaceDestroyed() }
     assert(!workerThread.handlerThread.isAlive)
   }
@@ -165,7 +153,6 @@ class MapboxRenderThreadTest {
     ).apply {
       workerThread.start()
     }
-    every { mapboxRenderer.needDestroy } returns false
     val surface = mockk<Surface>(relaxUnitFun = true)
     every { surface.isValid } returns true
     every { eglCore.eglStatusSuccess } returns true
@@ -195,7 +182,6 @@ class MapboxRenderThreadTest {
     ).apply {
       workerThread.start()
     }
-    every { mapboxRenderer.needDestroy } returns false
     val latch = CountDownLatch(1)
     every { mapboxRenderer.onSurfaceDestroyed() } answers { latch.countDown() }
     val surface = mockk<Surface>(relaxUnitFun = true)

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -233,7 +233,7 @@ internal abstract class MapboxRendererTest {
     every { renderThread.fpsChangedListener } returns listener
     mapboxRenderer.setOnFpsChangedListener(listener)
     mapboxRenderer.onDestroy()
-    Assert.assertEquals(true, mapboxRenderer.needDestroy)
+    verify { renderThread.destroy() }
     verify { renderThread.fpsChangedListener = null }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix memory leak in renderer destroy.</changelog>`.

### Summary of changes

Fix memory leak in renderer destroy.
Previously in surface mode we did not call releasing native renderer as `Activity.onDestroy` call is happening after Android system was sending `SurfaceHolder.Callback.surfaceDestroyed` when we have already stopped render thread.

Diagram from the profiler after the fix and several opening / closing activity with `MapView`

![image](https://user-images.githubusercontent.com/15800566/134319537-09556b77-671f-400b-95f3-6863b89af5c8.png)

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->