### PR TITLE
Throw exception when camera plugin is missing

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsExt.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsExt.kt
@@ -3,6 +3,7 @@ package com.mapbox.maps.plugin.animation
 
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.ScreenCoordinate
+import com.mapbox.maps.plugin.Plugin
 import com.mapbox.maps.plugin.Plugin.Companion.MAPBOX_CAMERA_PLUGIN_ID
 import com.mapbox.maps.plugin.delegates.MapPluginExtensionsDelegate
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
@@ -16,12 +17,18 @@ val MapPluginProviderDelegate.camera: CameraAnimationsPlugin
 
 /**
  * Extension easeTo() for [MapPluginExtensionsDelegate]
- * Ease the map camera to a given camera options and animation options.
+ * Ease the map camera to a given camera options and animation options
+ *
+ * Camera plugin with id = [Plugin.MAPBOX_CAMERA_PLUGIN_ID] must be added while constructing
+ * [com.mapbox.maps.MapView] as part of [com.mapbox.maps.MapInitOptions.plugins].
  *
  * @param cameraOptions The camera options to ease to
  * @param animationOptions Transition options (animation duration, listeners etc)
  *
  * @return [Cancelable] animator set object or null if associated map object was garbage collected.
+ *
+ * @throws IllegalStateException if gestures plugin was not added.
+ * @see [com.mapbox.maps.MapInitOptions]
  */
 fun MapPluginExtensionsDelegate.easeTo(
   cameraOptions: CameraOptions,
@@ -32,10 +39,16 @@ fun MapPluginExtensionsDelegate.easeTo(
  * Extension flyTo() function for [MapPluginExtensionsDelegate]
  * Fly the map camera to a given camera options.
  *
+ * Camera plugin with id = [Plugin.MAPBOX_CAMERA_PLUGIN_ID] must be added while constructing
+ * [com.mapbox.maps.MapView] as part of [com.mapbox.maps.MapInitOptions.plugins].
+ *
  * @param cameraOptions The camera options to fly to
  * @param animationOptions Transition options (animation duration, listeners etc)
  *
  * @return [Cancelable] animator set object or null if associated map object was garbage collected.
+ *
+ * @throws IllegalStateException if gestures plugin was not added.
+ * @see [com.mapbox.maps.MapInitOptions]
  */
 fun MapPluginExtensionsDelegate.flyTo(
   cameraOptions: CameraOptions,
@@ -46,10 +59,16 @@ fun MapPluginExtensionsDelegate.flyTo(
  * Extension pitchBy() function for [MapPluginExtensionsDelegate]
  * Pitch the map by with optional animation.
  *
+ * Camera plugin with id = [Plugin.MAPBOX_CAMERA_PLUGIN_ID] must be added while constructing
+ * [com.mapbox.maps.MapView] as part of [com.mapbox.maps.MapInitOptions.plugins].
+ *
  * @param pitch The amount to pitch by
  * @param animationOptions Transition options (animation duration, listeners etc)
  *
  * @return [Cancelable] animator set object or null if associated map object was garbage collected.
+ *
+ * @throws IllegalStateException if gestures plugin was not added.
+ * @see [com.mapbox.maps.MapInitOptions]
  */
 fun MapPluginExtensionsDelegate.pitchBy(
   pitch: Double,
@@ -60,11 +79,17 @@ fun MapPluginExtensionsDelegate.pitchBy(
  * Extension scaleBy() function for [MapPluginExtensionsDelegate]
  * Scale the map by with optional animation.
  *
+ * Camera plugin with id = [Plugin.MAPBOX_CAMERA_PLUGIN_ID] must be added while constructing
+ * [com.mapbox.maps.MapView] as part of [com.mapbox.maps.MapInitOptions.plugins].
+ *
  * @param amount The amount to scale by
  * @param screenCoordinate The optional focal point to scale on
  * @param animationOptions Transition options (animation duration, listeners etc)
  *
  * @return [Cancelable] animator set object or null if associated map object was garbage collected.
+ *
+ * @throws IllegalStateException if gestures plugin was not added.
+ * @see [com.mapbox.maps.MapInitOptions]
  */
 fun MapPluginExtensionsDelegate.scaleBy(
   amount: Double,
@@ -76,10 +101,16 @@ fun MapPluginExtensionsDelegate.scaleBy(
  * Extension moveBy() function for [MapPluginExtensionsDelegate]
  * Move the map by a given screen coordinate with optional animation.
  *
+ * Camera plugin with id = [Plugin.MAPBOX_CAMERA_PLUGIN_ID] must be added while constructing
+ * [com.mapbox.maps.MapView] as part of [com.mapbox.maps.MapInitOptions.plugins].
+ *
  * @param screenCoordinate The screen coordinate distance to move by
  * @param animationOptions Transition options (animation duration, listeners etc)
  *
  * @return [Cancelable] animator set object or null if associated map object was garbage collected.
+ *
+ * @throws IllegalStateException if gestures plugin was not added.
+ * @see [com.mapbox.maps.MapInitOptions]
  */
 fun MapPluginExtensionsDelegate.moveBy(
   screenCoordinate: ScreenCoordinate,
@@ -90,11 +121,17 @@ fun MapPluginExtensionsDelegate.moveBy(
  * Extension rotateBy() function for [MapPluginExtensionsDelegate]
  * Rotate the map by with optional animation.
  *
+ * Camera plugin with id = [Plugin.MAPBOX_CAMERA_PLUGIN_ID] must be added while constructing
+ * [com.mapbox.maps.MapView] as part of [com.mapbox.maps.MapInitOptions.plugins].
+ *
  * @param first The first pointer to rotate on
  * @param second The second pointer to rotate on
  * @param animationOptions Transition options (animation duration, listeners etc)
  *
  * @return [Cancelable] animator set object or null if associated map object was garbage collected.
+ *
+ * @throws IllegalStateException if gestures plugin was not added.
+ * @see [com.mapbox.maps.MapInitOptions]
  */
 fun MapPluginExtensionsDelegate.rotateBy(
   first: ScreenCoordinate,

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -1263,10 +1263,11 @@ class MapboxMap internal constructor(
    * In most cases should not be called directly.
    */
   override fun cameraAnimationsPlugin(function: (CameraAnimationsPlugin.() -> Any?)): Any? {
-    cameraAnimationsPlugin?.get()?.let {
+    checkNotNull(cameraAnimationsPlugin?.get()) {
+      "Camera plugin is not added as the part of MapInitOptions for given MapView."
+    }.let {
       return function.invoke(it)
     }
-    return null
   }
 
   internal fun setGesturesAnimationPlugin(gesturesPlugin: GesturesPlugin?) {

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -868,7 +868,13 @@ class MapboxMapTest {
     mapboxMap.cameraAnimationsPlugin = WeakReference(animations)
     val options = CameraOptions.Builder().build()
     mapboxMap.cameraAnimationsPlugin?.clear()
-    mapboxMap.cameraAnimationsPlugin { easeTo(options) }
+    val exception = assertThrows(IllegalStateException::class.java) {
+      mapboxMap.cameraAnimationsPlugin { easeTo(options) }
+    }
+    assertEquals(
+      "Camera plugin is not added as the part of MapInitOptions for given MapView.",
+      exception.message
+    )
     verify(exactly = 0) {
       animations.easeTo(options, null)
     }


### PR DESCRIPTION


<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Throw exception when camera plugin was not created and used camera functionality</changelog>`.

### Summary of changes
Exception will be thrown when camera functionality trying to use but plugin was not added to MapView. Reported in #1118

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->