### PR TITLE
fix getLayerAs return optional Layer type.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/terrain3D/SantaCatalinaActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/terrain3D/SantaCatalinaActivity.kt
@@ -101,7 +101,7 @@ class SantaCatalinaActivity : AppCompatActivity() {
       }
     ) { style ->
       // hide road labels
-      style.getLayerAs<SymbolLayer>(LAYER_ROAD_ID).visibility(Visibility.NONE)
+      style.getLayerAs<SymbolLayer>(LAYER_ROAD_ID)?.visibility(Visibility.NONE)
 
       // execute direction request
       executeDirectionsRequestForRoute {
@@ -209,7 +209,7 @@ class SantaCatalinaActivity : AppCompatActivity() {
           val elevation = (ELEVATION_MAX * phase) + ELEVATION_MIN
 
           // Update location indicator
-          locationLayer.location(
+          locationLayer?.location(
             listOf(
               cameraLookingAt.latitude(),
               cameraLookingAt.longitude(),

--- a/extension-localization/src/main/java/com/mapbox/maps/extension/localization/Localization.kt
+++ b/extension-localization/src/main/java/com/mapbox/maps/extension/localization/Localization.kt
@@ -29,13 +29,15 @@ internal fun setMapLanguage(locale: Locale, style: StyleInterface, layerIds: Lis
         }
         .forEach { layer ->
           val symbolLayer = style.getLayerAs<SymbolLayer>(layer.id)
-          symbolLayer.textFieldAsExpression?.let { textFieldExpression ->
-            if (BuildConfig.DEBUG) {
-              Logger.i(TAG, "Localize layer id: ${symbolLayer.layerId}")
+          symbolLayer?.let {
+            it.textFieldAsExpression?.let { textFieldExpression ->
+              if (BuildConfig.DEBUG) {
+                Logger.i(TAG, "Localize layer id: ${it.layerId}")
+              }
+              val language = if (sourceIsStreetsV8(style, source)) getLanguageNameV8(locale)
+              else getLanguageNameV7(locale)
+              convertExpression(language, it, textFieldExpression)
             }
-            val language = if (sourceIsStreetsV8(style, source)) getLanguageNameV8(locale)
-            else getLanguageNameV7(locale)
-            convertExpression(language, symbolLayer, textFieldExpression)
           }
         }
     }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
@@ -40,14 +40,18 @@ fun StyleManagerInterface.getLayer(layerId: String): Layer? {
 }
 
 /**
- * Tries to cast the Layer to T, throws ClassCastException if it's another type.
+ * Tries to cast the Layer to T.
  *
  * @param layerId the layer id
- * @return T
+ * @return T if layer is T, otherwise null
  */
-fun <T : Layer> StyleManagerInterface.getLayerAs(layerId: String): T {
-  @Suppress("UNCHECKED_CAST")
-  return getLayer(layerId) as T
+inline fun <reified T : Layer> StyleManagerInterface.getLayerAs(layerId: String): T? {
+  val layer = getLayer(layerId)
+  if (layer !is T) {
+    Logger.e("StyleLayerPlugin", "Given layerId = $layerId is not requested type in Layer")
+    return null
+  }
+  return layer
 }
 
 /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
@@ -32,7 +32,7 @@ fun StyleManagerInterface.getLayer(layerId: String): Layer? {
       "raster" -> RasterLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
       "symbol" -> SymbolLayer(layerId, this.getStyleLayerProperty(layerId, "source").unwrap()).also { it.delegate = this }
       else -> {
-        Logger.e("StyleLayerPlugin", "Layer type: $type unknown.")
+        Logger.e(TAG, "Layer type: $type unknown.")
         null
       }
     }
@@ -46,9 +46,9 @@ fun StyleManagerInterface.getLayer(layerId: String): Layer? {
  * @return T if layer is T, otherwise null
  */
 inline fun <reified T : Layer> StyleManagerInterface.getLayerAs(layerId: String): T? {
-  val layer = getLayer(layerId)
-  if (layer !is T) {
-    Logger.e("StyleLayerPlugin", "Given layerId = $layerId is not requested type in Layer")
+  val layer = getLayer(layerId) as? T
+  if (layer == null) {
+    Logger.e(TAG, "Given layerId = $layerId is not requested type in Layer")
     return null
   }
   return layer
@@ -150,3 +150,6 @@ fun StyleInterface.addPersistentLayer(layer: Layer, position: LayerPosition? = n
 fun Layer.isPersistent(): Boolean? {
   return delegate?.isStyleLayerPersistent(layerId)?.value
 }
+
+@PublishedApi
+internal const val TAG = "Mbgl-LayerUtils"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Update getLayerAs function to return nullable Layer type.</changelog>`.

### Summary of changes

Currently `StyleMangerInterface.getLayerAs` has return type which is non-nullable.
It should be a nullable type.

### User impact (optional)
Breaking change to get layer from style using `getLayerAs` function.

```
fun <T : Layer> StyleManagerInterface.getLayerAs(layerId: String): T {
  @Suppress("UNCHECKED_CAST")
  return getLayer(layerId) as T
}
```

Changed to 
```
inline fun <reified T : Layer> StyleManagerInterface.getLayerAs(layerId: String): T? {
  val layer = getLayer(layerId)
  if (layer !is T) {
    Logger.e("StyleLayerPlugin", "Given layerId = $layerId is not requested type in Layer")
    return null
  }
  return layer
}
```