### PR TITLE
Fix attribution/logo jumble when RTL layout is configured

### DIFF
--- a/plugin-attribution/src/main/java/com/mapbox/maps/plugin/attribution/AttributionViewImpl.kt
+++ b/plugin-attribution/src/main/java/com/mapbox/maps/plugin/attribution/AttributionViewImpl.kt
@@ -71,7 +71,12 @@ class AttributionViewImpl @JvmOverloads constructor(
    * @param bottom Margin to the bottom in pixel
    */
   override fun setAttributionMargins(left: Int, top: Int, right: Int, bottom: Int) {
-    (layoutParams as FrameLayout.LayoutParams).setMargins(left, top, right, bottom)
+    (layoutParams as FrameLayout.LayoutParams).apply{
+      marginStart = left
+      setTop(top)
+      marginEnd = right
+      setBottom(bottom)
+    }
   }
 
   /**

--- a/plugin-attribution/src/main/java/com/mapbox/maps/plugin/attribution/AttributionViewImpl.kt
+++ b/plugin-attribution/src/main/java/com/mapbox/maps/plugin/attribution/AttributionViewImpl.kt
@@ -71,11 +71,11 @@ class AttributionViewImpl @JvmOverloads constructor(
    * @param bottom Margin to the bottom in pixel
    */
   override fun setAttributionMargins(left: Int, top: Int, right: Int, bottom: Int) {
-    (layoutParams as FrameLayout.LayoutParams).apply{
+    (layoutParams as FrameLayout.LayoutParams).apply {
       marginStart = left
-      setTop(top)
+      topMargin = top
       marginEnd = right
-      setBottom(bottom)
+      bottomMargin = bottom
     }
   }
 

--- a/plugin-attribution/src/test/java/com/mapbox/maps/plugin/attribution/AttributionViewImplTest.kt
+++ b/plugin-attribution/src/test/java/com/mapbox/maps/plugin/attribution/AttributionViewImplTest.kt
@@ -54,9 +54,9 @@ class AttributionViewImplTest {
   fun setMargin() {
     attributionView.setAttributionMargins(1, 2, 3, 4)
     val layoutParams = attributionView.layoutParams as FrameLayout.LayoutParams
-    assertEquals(1, layoutParams.leftMargin)
+    assertEquals(1, layoutParams.marginStart)
     assertEquals(2, layoutParams.topMargin)
-    assertEquals(3, layoutParams.rightMargin)
+    assertEquals(3, layoutParams.marginEnd)
     assertEquals(4, layoutParams.bottomMargin)
   }
 

--- a/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewImpl.kt
+++ b/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewImpl.kt
@@ -91,11 +91,11 @@ class LogoViewImpl : LogoView, AppCompatImageView {
    * @param bottom Margin to the bottom in pixel
    */
   override fun setLogoMargins(left: Int, top: Int, right: Int, bottom: Int) {
-    (layoutParams as FrameLayout.LayoutParams).apply{
+    (layoutParams as FrameLayout.LayoutParams).apply {
       marginStart = left
-      setTop(top)
+      topMargin = top
       marginEnd = right
-      setBottom(bottom)
+      bottomMargin = bottom
     }
   }
 

--- a/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewImpl.kt
+++ b/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewImpl.kt
@@ -91,7 +91,12 @@ class LogoViewImpl : LogoView, AppCompatImageView {
    * @param bottom Margin to the bottom in pixel
    */
   override fun setLogoMargins(left: Int, top: Int, right: Int, bottom: Int) {
-    (layoutParams as FrameLayout.LayoutParams).setMargins(left, top, right, bottom)
+    (layoutParams as FrameLayout.LayoutParams).apply{
+      marginStart = left
+      setTop(top)
+      marginEnd = right
+      setBottom(bottom)
+    }
   }
 
   internal fun injectPresenter(presenter: LogoPlugin) {


### PR DESCRIPTION
Created to resolve https://github.com/mapbox/mapbox-maps-android/issues/635

Before: 
<img width="362" alt="Screen Shot 2021-09-27 at 9 19 44 AM" src="https://user-images.githubusercontent.com/44972592/134916563-9eb89d0e-7b5d-4877-b62b-5040cb301b6f.png">


After:
<img width="360" alt="Screen Shot 2021-09-27 at 9 20 16 AM" src="https://user-images.githubusercontent.com/44972592/134916552-496169a9-80c5-402d-9ef9-7eb394b70acf.png">
