### PR TITLE
Fix location puck initialization with xml loading style

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/LocationTrackingActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/LocationTrackingActivity.kt
@@ -7,7 +7,6 @@ import androidx.appcompat.content.res.AppCompatResources
 import com.mapbox.android.gestures.MoveGestureDetector
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapView
-import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.expressions.dsl.generated.interpolate
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.gestures.OnMoveListener
@@ -52,9 +51,7 @@ class LocationTrackingActivity : AppCompatActivity() {
     mapView = MapView(this)
     setContentView(mapView)
     locationPermissionHelper = LocationPermissionHelper(this)
-    locationPermissionHelper.checkPermissions {
-      onMapReady()
-    }
+    locationPermissionHelper.checkPermissions(::onMapReady)
   }
 
   private fun onMapReady() {
@@ -63,12 +60,8 @@ class LocationTrackingActivity : AppCompatActivity() {
         .zoom(14.0)
         .build()
     )
-    mapView.getMapboxMap().loadStyleUri(
-      Style.MAPBOX_STREETS
-    ) {
-      initLocationComponent()
-      setupGesturesListener()
-    }
+    initLocationComponent()
+    setupGesturesListener()
   }
 
   private fun setupGesturesListener() {

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
@@ -152,36 +152,38 @@ class LocationComponentPluginImpl : LocationComponentPlugin, LocationConsumer,
 
   private fun activateLocationComponent() {
     if (internalSettings.enabled) {
-      delegateProvider.getStyle { style ->
-        if (locationPuckManager?.isLayerInitialised() == true && isLocationComponentActivated) {
-          return@getStyle
-        }
-        if (locationPuckManager == null) {
-          locationPuckManager = LocationPuckManager(
-            settings = internalSettings,
-            delegateProvider = delegateProvider,
-            positionManager = LocationComponentPositionManager(
-              style,
-              internalSettings.layerAbove,
-              internalSettings.layerBelow
-            ),
-            layerSourceProvider = LayerSourceProvider(),
-            animationManager = PuckAnimatorManager(
-              indicatorPositionChangedListener,
-              indicatorBearingChangedListener
-            )
-          )
-        }
-        locationPuckManager?.let {
-          if (!it.isLayerInitialised()) {
-            it.initialize(style)
-          }
-        }
-        locationPuckManager?.onStart()
-        locationProvider?.registerLocationConsumer(this)
-        isLocationComponentActivated = true
+      delegateProvider.getStyle(::updateStyle)
+    }
+  }
+
+  private fun updateStyle(style: StyleInterface) {
+    if (locationPuckManager?.isLayerInitialised() == true && isLocationComponentActivated) {
+      return
+    }
+    if (locationPuckManager == null) {
+      locationPuckManager = LocationPuckManager(
+        settings = internalSettings,
+        delegateProvider = delegateProvider,
+        positionManager = LocationComponentPositionManager(
+          style,
+          internalSettings.layerAbove,
+          internalSettings.layerBelow
+        ),
+        layerSourceProvider = LayerSourceProvider(),
+        animationManager = PuckAnimatorManager(
+          indicatorPositionChangedListener,
+          indicatorBearingChangedListener
+        )
+      )
+    }
+    locationPuckManager?.let {
+      if (!it.isLayerInitialised()) {
+        it.initialize(style)
       }
     }
+    locationPuckManager?.onStart()
+    locationProvider?.registerLocationConsumer(this)
+    isLocationComponentActivated = true
   }
 
   /**
@@ -283,9 +285,7 @@ class LocationComponentPluginImpl : LocationComponentPlugin, LocationConsumer,
    *
    * @param styleDelegate
    */
-  override fun onStyleChanged(styleDelegate: StyleInterface) {
-    // no-ops
-  }
+  override fun onStyleChanged(styleDelegate: StyleInterface) = updateStyle(styleDelegate)
 
   override lateinit var internalSettings: LocationComponentSettings
 

--- a/sdk/src/main/java/com/mapbox/maps/plugin/MapDelegateProviderImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/plugin/MapDelegateProviderImpl.kt
@@ -17,7 +17,5 @@ internal class MapDelegateProviderImpl constructor(val mapboxMap: MapboxMap, map
   override val mapListenerDelegate: MapListenerDelegate by lazy { mapboxMap }
   override val styleStateDelegate: MapStyleStateDelegate by lazy { mapboxMap }
 
-  override fun getStyle(callback: (StyleInterface) -> Unit) {
-    mapboxMap.getStyle { style -> callback(style) }
-  }
+  override fun getStyle(callback: (StyleInterface) -> Unit) = mapboxMap.getStyle(callback)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix location puck invisibility when styles loaded from XML</changelog>`.

### Summary of changes
Before location puck didn't received callback when style is ready if style was declared in XML, but not triggered in source code, and was not initialised correctly. Reported: #641 
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)
Location component will appear if style loaded from xml.
<!--
If this PR introduces user-facing changes, please note them here.
-->