### PR TITLE
Call plugin onStart after start loading style

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -49,7 +49,8 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   private val pluginRegistry: MapPluginRegistry
   private val onStyleDataLoadedListener: OnStyleDataLoadedListener
   private val onCameraChangedListener: OnCameraChangeListener
-  private var lifecycleState: LifecycleState = LifecycleState.STATE_STOPPED
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  internal var lifecycleState: LifecycleState = LifecycleState.STATE_STOPPED
 
   constructor(
     renderer: MapboxRenderer,
@@ -314,12 +315,8 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     pluginRegistry.onAttachedToWindow(mapView)
   }
 
-  @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-  internal fun simulateStartedState() {
-    lifecycleState = LifecycleState.STATE_STARTED
-  }
-
-  private enum class LifecycleState {
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  internal enum class LifecycleState {
     STATE_STOPPED,
     STATE_STARTED,
     STATE_DESTROYED

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps
 
 import android.content.Context
 import android.view.MotionEvent
+import androidx.annotation.VisibleForTesting
 import com.mapbox.annotation.module.MapboxModuleType
 import com.mapbox.common.Logger
 import com.mapbox.common.module.provider.MapboxModuleProvider
@@ -86,6 +87,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     }
   }
 
+  @VisibleForTesting(otherwise = VisibleForTesting.NONE)
   constructor(
     renderer: MapboxRenderer,
     nativeObserver: NativeObserver,
@@ -100,7 +102,6 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     this.mapInitOptions = mapInitOptions
     this.nativeMap = nativeMap
     this.mapboxMap = mapboxMap
-    this.mapboxMap.renderHandler = renderer.renderThread.handlerThread.handler
     this.pluginRegistry = pluginRegistry
     this.onCameraChangedListener = OnCameraChangeListener {
       pluginRegistry.onCameraMove(nativeMap.cameraState)
@@ -311,6 +312,11 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
 
   internal fun onAttachedToWindow(mapView: MapView) {
     pluginRegistry.onAttachedToWindow(mapView)
+  }
+
+  @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+  internal fun simulateStartedState() {
+    lifecycleState = LifecycleState.STATE_STARTED
   }
 
   private enum class LifecycleState {

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -123,13 +123,13 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       addOnStyleDataLoadedListener(onStyleDataLoadedListener)
     }
     renderer.onStart()
-    pluginRegistry.onStart()
     if (!mapboxMap.isStyleLoadInitiated) {
       // Load the style in mapInitOptions if no style has loaded yet.
       mapInitOptions.styleUri?.let {
         mapboxMap.loadStyleUri(it)
       }
     }
+    pluginRegistry.onStart()
   }
 
   override fun onStop() {

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -104,7 +104,7 @@ class MapControllerTest {
     every { mockNativeObserver.removeOnCameraChangeListener(any()) } just Runs
     every { mockNativeObserver.removeOnStyleDataLoadedListener(any()) } just Runs
 
-    testMapController.simulateStartedState()
+    testMapController.lifecycleState = MapController.LifecycleState.STATE_STARTED
     testMapController.onStop()
 
     verifySequence {

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -8,250 +8,310 @@ import com.mapbox.maps.loader.MapboxMapStaticInitializer
 import com.mapbox.maps.plugin.MapPlugin
 import com.mapbox.maps.plugin.MapPluginRegistry
 import com.mapbox.maps.plugin.Plugin
+import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.delegates.listeners.OnCameraChangeListener
+import com.mapbox.maps.plugin.delegates.listeners.OnStyleDataLoadedListener
 import com.mapbox.maps.renderer.MapboxRenderer
 import com.mapbox.maps.renderer.OnFpsChangedListener
 import io.mockk.*
-import org.junit.Assert
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import java.io.File
-import java.lang.ref.WeakReference
 
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowLogger::class])
 class MapControllerTest {
 
-  private val renderer: MapboxRenderer = mockk(relaxUnitFun = true)
+  private val mockRenderer: MapboxRenderer = mockk()
+  private val mockNativeObserver: NativeObserver = mockk()
+  private val mockNativeMap: MapInterface = mockk()
+  private val mockMapboxMap: MapboxMap = mockk()
+  private val mockPluginRegistry: MapPluginRegistry = mockk()
+  private val mockMapInitOptions: MapInitOptions = mockk()
+  private val mockCameraState: CameraState = mockk()
+  private val mockMotionEvent: MotionEvent = mockk()
+  private val mockContext: Context = mockk()
+  private val mockMapView: MapView = mockk()
+  private val mockOnStyleDataLoadedListener: OnStyleDataLoadedListener = mockk()
 
-  private val nativeObserver: NativeObserver = mockk(relaxUnitFun = true)
-
-  private val nativeMap: MapInterface = mockk(relaxUnitFun = true)
-
-  private lateinit var mapView: MapView
-
-  private val mapboxMap: MapboxMap = mockk(relaxUnitFun = true)
-
-  private val pluginRegistry: MapPluginRegistry = mockk(relaxed = true)
-
-  private val mapInitOptions: MapInitOptions = mockk(relaxed = true)
-
-  private val cameraState: CameraState = mockk(relaxed = true)
-
-  private val motionEvent: MotionEvent = mockk(relaxed = true)
-
-  private lateinit var mapController: MapController
-
-  private val context: Context = mockk(relaxUnitFun = true)
+  private lateinit var testMapController: MapController
 
   @Before
   fun setUp() {
     mockkStatic(MapboxMapStaticInitializer::class)
     every { MapboxMapStaticInitializer.loadMapboxMapNativeLib() } just Runs
-    every { context.getString(-1) } returns "token"
-    every {
-      context.resources.getIdentifier(
-        "mapbox_access_token",
-        "string",
-        "com.mapbox.maps"
-      )
-    } returns -1
-    every { context.packageName } returns "com.mapbox.maps"
-    every { context.filesDir } returns File("foobar")
-    ResourceOptionsManager.getDefault(context).update { accessToken("foobar") }
-    mapView = mockk(relaxUnitFun = true)
-    val token = "pk.123"
-    val resourceOptions = mockk<ResourceOptions>()
-    mockkObject(MapProvider)
-    every { mapInitOptions.resourceOptions } answers { resourceOptions }
-    every { mapInitOptions.styleUri } answers { Style.MAPBOX_STREETS }
-    every { resourceOptions.accessToken } answers { token }
-    every {
-      MapProvider.getNativeMap(
-        mapInitOptions,
-        renderer
-      )
-    } answers { nativeMap }
-    every { nativeMap.cameraState } returns cameraState
+    every { mockContext.packageName } returns "com.mapbox.maps"
 
-    every { MapProvider.getMapboxMap(WeakReference(nativeMap), nativeObserver, 1.0f) } answers { mapboxMap }
-    every { MapProvider.getMapPluginRegistry(any(), any(), any()) } returns pluginRegistry
-    every { mapboxMap.isStyleLoadInitiated } returns false
-    every { renderer.renderThread.handlerThread.handler } returns mockk()
-    mapController =
-      MapController(
-        renderer,
-        nativeObserver,
-        mapInitOptions,
-        nativeMap,
-        mapboxMap,
-        pluginRegistry,
-        mockk()
-      )
+    testMapController = MapController(
+      mockRenderer,
+      mockNativeObserver,
+      mockMapInitOptions,
+      mockNativeMap,
+      mockMapboxMap,
+      mockPluginRegistry,
+      mockOnStyleDataLoadedListener
+    )
+  }
+
+  @After
+  fun shutDown() {
+    unmockkAll()
   }
 
   @Test
   fun onStart() {
-    mapController.onStart()
-    verify { renderer.onStart() }
-    verify { pluginRegistry.onStart() }
-    verify { mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) }
+    every { mockPluginRegistry.onStart() } just Runs
+    every { mockMapboxMap.loadStyleUri(Style.MAPBOX_STREETS) } just Runs
+    every { mockNativeObserver.addOnCameraChangeListener(any()) } just Runs
+    every { mockNativeObserver.addOnStyleDataLoadedListener(any()) } just Runs
+    every { mockRenderer.onStart() } just Runs
+    every { mockMapboxMap.isStyleLoadInitiated } returns false
+    every { mockMapInitOptions.styleUri } answers { Style.MAPBOX_STREETS }
+
+    testMapController.onStart()
+
+    verifySequence {
+      mockNativeObserver.addOnCameraChangeListener(any())
+      mockNativeObserver.addOnStyleDataLoadedListener(any())
+      mockRenderer.onStart()
+      mockMapboxMap.isStyleLoadInitiated
+      mockMapboxMap.loadStyleUri(Style.MAPBOX_STREETS)
+      mockPluginRegistry.onStart()
+    }
   }
 
   @Test
   fun onStartWithStyleLoaded() {
-    every { mapboxMap.isStyleLoadInitiated } returns true
-    mapController.onStart()
-    verify(exactly = 0) { mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) }
+    every { mockMapboxMap.isStyleLoadInitiated } returns true
+    every { mockPluginRegistry.onStart() } just Runs
+    every { mockRenderer.onStart() } just Runs
+    every { mockNativeObserver.addOnCameraChangeListener(any()) } just Runs
+    every { mockNativeObserver.addOnStyleDataLoadedListener(any()) } just Runs
+
+    testMapController.onStart()
+
+    verify(exactly = 0) { mockMapboxMap.loadStyleUri(Style.MAPBOX_STREETS) }
   }
 
   @Test
   fun onStop() {
-    mapController.onStart()
-    mapController.onStop()
-    verify { renderer.onStop() }
-    verify { pluginRegistry.onStop() }
+    every { mockPluginRegistry.onStop() } just Runs
+    every { mockRenderer.onStop() } just Runs
+    every { mockNativeObserver.removeOnCameraChangeListener(any()) } just Runs
+    every { mockNativeObserver.removeOnStyleDataLoadedListener(any()) } just Runs
+
+    testMapController.simulateStartedState()
+    testMapController.onStop()
+
+    verifySequence {
+      mockNativeObserver.removeOnCameraChangeListener(any())
+      mockNativeObserver.removeOnStyleDataLoadedListener(any())
+      mockRenderer.onStop()
+      mockPluginRegistry.onStop()
+    }
   }
 
   @Test
   fun onReduceMemoryUse() {
-    mapController.onLowMemory()
-    verify { mapboxMap.reduceMemoryUse() }
+    every { mockMapboxMap.reduceMemoryUse() } just Runs
+
+    testMapController.onLowMemory()
+
+    verify { mockMapboxMap.reduceMemoryUse() }
   }
 
   @Test
   fun onDestroy() {
-    mapController.onDestroy()
-    verify { nativeObserver.onDestroy() }
+    every { mockMapboxMap.onDestroy() } just Runs
+    every { mockPluginRegistry.cleanup() } just Runs
+    every { mockNativeObserver.onDestroy() } just Runs
+    every { mockRenderer.onDestroy() } just Runs
+
+    testMapController.onDestroy()
+
+    verifySequence {
+      mockMapboxMap.onDestroy()
+      mockNativeObserver.onDestroy()
+      mockRenderer.onDestroy()
+      mockPluginRegistry.cleanup()
+    }
   }
 
   @Test
   fun onTouch() {
-    mapController.onTouchEvent(motionEvent)
-    verify { pluginRegistry.onTouch(motionEvent) }
+    every { mockPluginRegistry.onTouch(mockMotionEvent) } returns true
+
+    testMapController.onTouchEvent(mockMotionEvent)
+
+    verify { mockPluginRegistry.onTouch(mockMotionEvent) }
   }
 
   @Test
   fun onGenericMotionEvent() {
-    mapController.onGenericMotionEvent(motionEvent)
-    verify { pluginRegistry.onGenericMotionEvent(motionEvent) }
+    val expectedValue = true
+    every { mockPluginRegistry.onGenericMotionEvent(mockMotionEvent) } returns expectedValue
+
+    val actualValue = testMapController.onGenericMotionEvent(mockMotionEvent)
+
+    assertEquals(expectedValue, actualValue)
+    verify { mockPluginRegistry.onGenericMotionEvent(mockMotionEvent) }
   }
 
   @Test
   fun onSizeChanged() {
-    mapController.onSizeChanged(0, 0)
-    verify { pluginRegistry.onSizeChanged(0, 0) }
+    every { mockPluginRegistry.onSizeChanged(0, 0) } just Runs
+
+    testMapController.onSizeChanged(0, 0)
+
+    verify { mockPluginRegistry.onSizeChanged(0, 0) }
   }
 
   @Test
   fun mapboxMapRequest() {
-    Assert.assertEquals(mapboxMap, mapController.getMapboxMap())
+    assertEquals(mockMapboxMap, testMapController.getMapboxMap())
   }
 
   @Test
   fun cameraPluginNotified() {
     val onCameraChangeListenerSlot = slot<OnCameraChangeListener>()
-    every { nativeObserver.addOnCameraChangeListener(capture(onCameraChangeListenerSlot)) } answers {}
-    mapController.onStart()
-    val onCameraChangeListener = onCameraChangeListenerSlot.captured
+    every { mockNativeObserver.addOnCameraChangeListener(capture(onCameraChangeListenerSlot)) } just Runs
+    every { mockNativeObserver.addOnStyleDataLoadedListener(any()) } just Runs
+    every { mockPluginRegistry.onStart() } just Runs
+    every { mockRenderer.onStart() } just Runs
+    every { mockPluginRegistry.onCameraMove(mockCameraState) } just Runs
+    every { mockMapboxMap.loadStyleUri(Style.MAPBOX_STREETS) } just Runs
+    every { mockNativeMap.cameraState } returns mockCameraState
+    every { mockMapboxMap.isStyleLoadInitiated } returns false
+    every { mockMapInitOptions.styleUri } answers { Style.MAPBOX_STREETS }
 
+    testMapController.onStart()
+    val onCameraChangeListener = onCameraChangeListenerSlot.captured
     onCameraChangeListener.onCameraChanged()
-    verify { nativeMap.cameraState }
-    verify { pluginRegistry.onCameraMove(cameraState) }
+
+    verifySequence {
+      mockPluginRegistry.onStart()
+      mockNativeMap.cameraState
+      mockPluginRegistry.onCameraMove(mockCameraState)
+    }
   }
 
   @Test
   fun createPlugin() {
-    val plugin = Plugin.Custom("id", mockk())
-    mapController.createPlugin(mapView, plugin)
-    verify { pluginRegistry.createPlugin(mapView, mapInitOptions, plugin) }
+    val mockPlugin = mockk<Plugin.Custom>()
+    every { mockPluginRegistry.createPlugin(mockMapView, mockMapInitOptions, mockPlugin) } just Runs
+
+    testMapController.createPlugin(mockMapView, mockPlugin)
+
+    verify { mockPluginRegistry.createPlugin(mockMapView, mockMapInitOptions, mockPlugin) }
   }
 
   @Test
   fun getPlugin() {
     val plugin = mockk<MapPlugin>()
-    every { pluginRegistry.getPlugin<MapPlugin>("id") } returns plugin
-    Assert.assertEquals(plugin, mapController.getPlugin("id"))
-    verify { pluginRegistry.getPlugin<MapPlugin>("id") }
+    every { mockPluginRegistry.getPlugin<MapPlugin>("id") } returns plugin
+
+    assertEquals(plugin, testMapController.getPlugin("id"))
+    verify { mockPluginRegistry.getPlugin<MapPlugin>("id") }
   }
 
   @Test
   fun queueEvent() {
     val event = mockk<Runnable>()
-    mapController.queueEvent(event, false)
-    verify { renderer.queueEvent(event) }
-    mapController.queueEvent(event, true)
-    verify { renderer.queueRenderEvent(event) }
+    every { mockRenderer.queueEvent(event) } just Runs
+    every { mockRenderer.queueRenderEvent(event) } just Runs
+
+    testMapController.queueEvent(event, false)
+    testMapController.queueEvent(event, true)
+
+    verifySequence {
+      mockRenderer.queueEvent(event)
+      mockRenderer.queueRenderEvent(event)
+    }
   }
 
   @Test
   fun snapshotSync() {
-    every { renderer.snapshot() } answers { Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) }
-    mapController.snapshot()
-    verify { renderer.snapshot() }
+    every { mockRenderer.snapshot() } answers { Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) }
+
+    testMapController.snapshot()
+
+    verify { mockRenderer.snapshot() }
   }
 
   @Test
   fun snapshotAsync() {
     val listener = mockk<MapView.OnSnapshotReady>()
-    mapController.snapshot(listener)
-    verify { renderer.snapshot(listener) }
+    every { mockRenderer.snapshot(listener) } just Runs
+
+    testMapController.snapshot(listener)
+
+    verify { mockRenderer.snapshot(listener) }
   }
 
   @Test
   fun setMaximumFpsValid() {
-    mapController.setMaximumFps(60)
-    verify { renderer.setMaximumFps(60) }
+    every { mockRenderer.setMaximumFps(60) } just Runs
+
+    testMapController.setMaximumFps(60)
+
+    verify { mockRenderer.setMaximumFps(60) }
   }
 
   @Test
   fun setMaximumFpsInvalid() {
-    mapController.setMaximumFps(-1)
-    verify(exactly = 0) { renderer.setMaximumFps(any()) }
+    testMapController.setMaximumFps(-1)
+
+    verify(exactly = 0) { mockRenderer.setMaximumFps(any()) }
   }
 
   @Test
   fun setOnFpsChangedListener() {
     val listener = mockk<OnFpsChangedListener>()
-    mapController.setOnFpsChangedListener(listener)
-    verify { renderer.setOnFpsChangedListener(listener) }
+    every { mockRenderer.setOnFpsChangedListener(listener) } just Runs
+
+    testMapController.setOnFpsChangedListener(listener)
+
+    verifyAll { mockRenderer.setOnFpsChangedListener(listener) }
   }
 
   @Test
   fun initializePluginsEmpty() {
-    val mapController =
-      MapController(
-        renderer,
-        nativeObserver,
-        mapInitOptions,
-        nativeMap,
-        mapboxMap,
-        MapPluginRegistry(mockk()),
-        mockk()
-      )
-    val mapInitOptions = MapInitOptions(mockk(relaxed = true))
-    mapInitOptions.plugins = listOf()
-    mapController.initializePlugins(mapInitOptions)
+    every { mockMapInitOptions.plugins } answers { emptyList() }
+
+    testMapController.initializePlugins(mockMapInitOptions)
+
+    verify(exactly = 0) {
+      mockPluginRegistry.createPlugin(any(), mockMapInitOptions, any())
+      mockMapboxMap.setCameraAnimationPlugin(any())
+      mockMapboxMap.setGesturesAnimationPlugin(any())
+    }
   }
 
   @Test
   fun initializePluginsCamera() {
-    val mapController =
-      MapController(
-        renderer,
-        nativeObserver,
-        mapInitOptions,
-        nativeMap,
-        mapboxMap,
-        MapPluginRegistry(mockk(relaxed = true)),
-        mockk()
+    every { mockMapboxMap.setCameraAnimationPlugin(any()) } just Runs
+    every { mockMapInitOptions.plugins } answers { listOf(Plugin.Mapbox(Plugin.MAPBOX_CAMERA_PLUGIN_ID)) }
+    val createPluginSlot = slot<Plugin>()
+    every {
+      mockPluginRegistry.createPlugin(
+        mockMapView,
+        mockMapInitOptions,
+        capture(createPluginSlot)
       )
-    val mapInitOptions = MapInitOptions(mockk(relaxed = true))
-    mapInitOptions.plugins = listOf(Plugin.Mapbox(Plugin.MAPBOX_CAMERA_PLUGIN_ID))
-    mapController.initializePlugins(mapInitOptions)
-    verify { mapboxMap.setCameraAnimationPlugin(any()) }
+    } just Runs
+
+    testMapController.initializePlugins(mockMapInitOptions, mockMapView)
+
+    val createdPlugin = createPluginSlot.captured
+    assertEquals(Plugin.MAPBOX_CAMERA_PLUGIN_ID, createdPlugin.id)
+    verifySequence {
+      mockMapInitOptions.plugins
+      mockPluginRegistry.createPlugin(mockMapView, mockMapInitOptions, createdPlugin)
+      mockMapboxMap.setCameraAnimationPlugin(createdPlugin.instance as CameraAnimationsPlugin)
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix initialisation location puck when no style loaded from code by changing Plugin#onStart() call after style loaded</changelog>`.

### Summary of changes
In this PR has been changed order of methods called on lifecycle event onStart. Now plugins will receive onStart after style has been loaded. This reorder prevent of loosing callbacks from StyleObserver when callback were added before style starts loading.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)
User with styleUri attribute in XML will have all plugins started correctly after style has been loaded. Before in this case it was the issue reported here: #641 
<!--
If this PR introduces user-facing changes, please note them here.
-->