### PR TITLE
Fix map render deadlock on Android 8 on power on button

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -53,7 +53,8 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal val awaitingNextVsync = AtomicBoolean(false)
   private var sizeChanged = false
-  private var paused = false
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  internal var paused = false
   private var shouldExit = false
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var eglPrepared = false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/684

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix map render deadlock on Android 8 on power on button.</changelog>`.

### Summary of changes

It seems that at least on Android 8 system sends `SurfaceHolder.Callback.surfaceCreated` __earlier__ than even `Activity#onStart()` if stopping / resuming the map with a power button. That is leading to the deadlock in our renderer as we release lock when trying prepare EGL as we don't call it because thread is in paused state. Now this issue is fixed because we will be always trying to create EGL if we schedule `prepareRenderFrame` from surface creation (but not from other places).

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->