### PR TITLE
Move EGL no current context to surface creation

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
@@ -74,10 +74,7 @@ internal class EGLCore(
     if (eglDisplay != EGL10.EGL_NO_DISPLAY) {
       // Android is unusual in that it uses a reference-counted EGLDisplay.  So for
       // every eglInitialize() we need an eglTerminate().
-      egl.eglMakeCurrent(
-        eglDisplay, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_SURFACE,
-        EGL10.EGL_NO_CONTEXT
-      )
+      makeNothingCurrent()
       egl.eglDestroyContext(eglDisplay, eglContext)
       egl.eglTerminate(eglDisplay)
     }
@@ -91,14 +88,6 @@ internal class EGLCore(
    */
   fun releaseSurface(eglSurface: EGLSurface) {
     if (eglSurface != EGL10.EGL_NO_SURFACE && eglDisplay != EGL10.EGL_NO_DISPLAY) {
-      if (egl.eglGetCurrentSurface(EGL10.EGL_DRAW) == eglSurface) {
-        egl.eglMakeCurrent(
-          eglDisplay,
-          EGL10.EGL_NO_SURFACE,
-          EGL10.EGL_NO_SURFACE,
-          EGL10.EGL_NO_CONTEXT
-        )
-      }
       egl.eglDestroySurface(eglDisplay, eglSurface)
     }
   }
@@ -124,22 +113,12 @@ internal class EGLCore(
   }
 
   /**
-   * Creates an EGL surface associated with an offscreen buffer.
+   * Makes no context current.
    */
-  fun createOffscreenSurface(width: Int, height: Int): EGLSurface? {
-    val surfaceAttribs =
-      intArrayOf(EGL10.EGL_WIDTH, width, EGL10.EGL_HEIGHT, height, EGL10.EGL_NONE)
-    val eglSurface = egl.eglCreatePbufferSurface(
-      eglDisplay,
-      eglConfig,
-      surfaceAttribs
-    )
-    checkEglErrorNoException("eglCreatePbufferSurface")
-    if (eglSurface == null) {
-      Logger.e(TAG, "surface was null")
-      eglStatusSuccess = false
+  fun makeNothingCurrent() {
+    if (!egl.eglMakeCurrent(eglDisplay, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_CONTEXT)) {
+      checkEglErrorNoException("eglMakeNothingCurrent")
     }
-    return eglSurface
   }
 
   /**

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -62,6 +62,7 @@ class MapboxRenderThreadTest {
     }
     verify {
       mapboxRenderer.onSurfaceCreated()
+      eglCore.makeNothingCurrent()
       mapboxRenderer.onSurfaceChanged(1, 1)
     }
   }
@@ -242,6 +243,10 @@ class MapboxRenderThreadTest {
     // one swap buffer for surface creation, two for not squashed render requests
     verify(exactly = 3) {
       eglCore.swapBuffers(any())
+    }
+    // make EGL context current only once when creating surface
+    verify(exactly = 1) {
+      eglCore.makeNothingCurrent()
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

Revisiting fix introduced in https://github.com/mapbox/mapbox-maps-android/pull/671.
Moved explicit setting `EGL10.NO_CONTEXT` from surface destroy to surface creation as surface destroy may be followed up by complete render thread destruction and in this case we still need valid EGL context to perform cleanup of GPU buffers / textures.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->