### PR TITLE
WaitForIdle before perform flaky instrumentation test

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/integration/surface/SurfaceViewOrientationChangeTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/integration/surface/SurfaceViewOrientationChangeTest.kt
@@ -13,26 +13,20 @@ import org.junit.runner.RunWith
 class SurfaceViewOrientationChangeTest : BaseIntegrationTest() {
 
   @get:Rule
-  var activityRule: ActivityScenarioRule<SimpleMapActivity> = ActivityScenarioRule(SimpleMapActivity::class.java)
+  var activityRule: ActivityScenarioRule<SimpleMapActivity> =
+    ActivityScenarioRule(SimpleMapActivity::class.java)
 
   @Test
   @LargeTest
   fun rotateSurfaceMap() {
-    device.setOrientationLeft()
-    device.waitForIdle()
-    device.setOrientationNatural()
-    device.waitForIdle()
-    device.setOrientationRight()
-    device.waitForIdle()
-    device.setOrientationNatural()
     device.waitForIdle()
     device.setOrientationLeft()
-    device.waitForIdle()
     device.setOrientationNatural()
-    device.waitForIdle()
     device.setOrientationRight()
-    device.waitForIdle()
     device.setOrientationNatural()
-    device.waitForIdle()
+    device.setOrientationLeft()
+    device.setOrientationNatural()
+    device.setOrientationRight()
+    device.setOrientationNatural()
   }
 }

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/integration/texture/TextureViewOrientationChangeTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/integration/texture/TextureViewOrientationChangeTest.kt
@@ -19,21 +19,14 @@ class TextureViewOrientationChangeTest : BaseIntegrationTest() {
   @Test
   @LargeTest
   fun rotateTextureMap() {
-    device.setOrientationLeft()
-    device.waitForIdle()
-    device.setOrientationNatural()
-    device.waitForIdle()
-    device.setOrientationRight()
-    device.waitForIdle()
-    device.setOrientationNatural()
     device.waitForIdle()
     device.setOrientationLeft()
-    device.waitForIdle()
     device.setOrientationNatural()
-    device.waitForIdle()
     device.setOrientationRight()
-    device.waitForIdle()
     device.setOrientationNatural()
-    device.waitForIdle()
+    device.setOrientationLeft()
+    device.setOrientationNatural()
+    device.setOrientationRight()
+    device.setOrientationNatural()
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes
Added waitForIdle in flaky instrumentation test before performing rotations.
With measures on emulator this command added around 800ms before changing rotation, so luckily it should solve the problem with full initialisation of views.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->