### PR TITLE
Init asset file thread only once

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -56,7 +56,10 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   ) {
     this.renderer = renderer
     this.mapInitOptions = mapInitOptions
-    AssetManagerProvider().initialize(mapInitOptions.context.assets)
+    if (assetsManagerNeedInit) {
+      assetsManagerNeedInit = false
+      AssetManagerProvider().initialize(mapInitOptions.context.applicationContext.assets)
+    }
     this.nativeMap = MapProvider.getNativeMap(
       mapInitOptions,
       renderer,
@@ -325,6 +328,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       "Add %s plugin dependency to the classpath take automatically load the plugin implementation."
     private const val VIEW_HIERARCHY_MISSING_TEMPLATE =
       "%s plugin requires a View hierarchy to be injected, plugin is ignored."
+    private var assetsManagerNeedInit = true
 
     init {
       MapboxMapStaticInitializer.loadMapboxMapNativeLib()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix spawning multiple assert file threads by initing asset file thread only once per application lifecycle.</changelog>`.

### Summary of changes

Fix spawning multiple assert file threads by initing asset file thread only once per application lifecycle.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->