### PR TITLE
[observable-extension] Update map events data models.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ commands:
                 --device model=AOP_sprout,version=28,locale=en,orientation=portrait \
                 --device model=harpia,version=23,locale=en,orientation=portrait \
                 --device model=Pixel2,version=30,locale=en,orientation=portrait \
-                --device model=mata,version=25,locale=en,orientation=portrait \
+                --device model=G8142,version=25,locale=en,orientation=portrait \
                 --timeout 90s
             fi
 

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/LoadStyleCallbackTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/LoadStyleCallbackTest.kt
@@ -8,6 +8,7 @@ import androidx.test.filters.LargeTest
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
+import com.mapbox.maps.plugin.delegates.listeners.eventdata.TileID
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,7 +39,12 @@ class LoadStyleCallbackTest {
           latch.countDown()
         },
         onMapLoadErrorListener = object : OnMapLoadErrorListener {
-          override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
+          override fun onMapLoadError(
+            mapLoadErrorType: MapLoadErrorType,
+            message: String,
+            sourceId: String?,
+            tileId: TileID?
+          ) {
             throw AssertionError("Load $mapLoadErrorType failed with $message")
           }
         }
@@ -66,7 +72,12 @@ class LoadStyleCallbackTest {
           latch.countDown()
         },
         onMapLoadErrorListener = object : OnMapLoadErrorListener {
-          override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
+          override fun onMapLoadError(
+            mapLoadErrorType: MapLoadErrorType,
+            message: String,
+            sourceId: String?,
+            tileId: TileID?
+          ) {
             throw AssertionError("Load $mapLoadErrorType failed with $message")
           }
         }
@@ -110,7 +121,12 @@ class LoadStyleCallbackTest {
           latch.countDown()
         },
         onMapLoadErrorListener = object : OnMapLoadErrorListener {
-          override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
+          override fun onMapLoadError(
+            mapLoadErrorType: MapLoadErrorType,
+            message: String,
+            sourceId: String?,
+            tileId: TileID?
+          ) {
             throw AssertionError("Load $mapLoadErrorType failed with $message")
           }
         }

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/LoadStyleCallbackTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/LoadStyleCallbackTest.kt
@@ -45,7 +45,7 @@ class LoadStyleCallbackTest {
             sourceId: String?,
             tileId: TileID?
           ) {
-            throw AssertionError("Load $mapLoadErrorType failed with $message")
+            throw AssertionError("Load $mapLoadErrorType failed with $message, sourceId: $sourceId, tileId: $tileId")
           }
         }
       )
@@ -78,7 +78,7 @@ class LoadStyleCallbackTest {
             sourceId: String?,
             tileId: TileID?
           ) {
-            throw AssertionError("Load $mapLoadErrorType failed with $message")
+            throw AssertionError("Load $mapLoadErrorType failed with $message, sourceId: $sourceId, tileId: $tileId")
           }
         }
       )
@@ -127,7 +127,7 @@ class LoadStyleCallbackTest {
             sourceId: String?,
             tileId: TileID?
           ) {
-            throw AssertionError("Load $mapLoadErrorType failed with $message")
+            throw AssertionError("Load $mapLoadErrorType failed with $message, sourceId: $sourceId, tileId: $tileId")
           }
         }
       )

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
@@ -12,6 +12,7 @@ import com.mapbox.maps.extension.observable.unsubscribeResourceRequest
 import com.mapbox.maps.plugin.compass.compass
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
+import com.mapbox.maps.plugin.delegates.listeners.eventdata.TileID
 import com.mapbox.maps.testapp.R
 import com.mapbox.maps.testapp.databinding.ActivityDebugBinding
 
@@ -78,7 +79,12 @@ class DebugModeActivity : AppCompatActivity() {
       Logger.i(TAG, "OnMapIdleListener")
     }
     mapboxMap.addOnMapLoadErrorListener(object : OnMapLoadErrorListener {
-      override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
+      override fun onMapLoadError(
+        mapLoadErrorType: MapLoadErrorType,
+        message: String,
+        sourceId: String?,
+        tileId: TileID?
+      ) {
         Logger.i(TAG, "OnMapLoadErrorListener: $mapLoadErrorType, $message")
       }
     })

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
@@ -85,7 +85,7 @@ class DebugModeActivity : AppCompatActivity() {
         sourceId: String?,
         tileId: TileID?
       ) {
-        Logger.i(TAG, "OnMapLoadErrorListener: $mapLoadErrorType, $message")
+        Logger.i(TAG, "OnMapLoadErrorListener: $mapLoadErrorType, $message, sourceId: $sourceId, tileId: $tileId")
       }
     })
     mapboxMap.addOnMapLoadedListener {

--- a/extension-androidauto/build.gradle.kts
+++ b/extension-androidauto/build.gradle.kts
@@ -50,6 +50,6 @@ project.apply {
   from("$rootDir/gradle/ktlint.gradle")
   from("$rootDir/gradle/lint.gradle")
   from("$rootDir/gradle/jacoco.gradle")
-  from("$rootDir/gradle/sdk-registry.gradle")
+//  from("$rootDir/gradle/sdk-registry.gradle")
   from("$rootDir/gradle/track-public-apis.gradle")
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.plugin.delegates.listeners
 
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
+import com.mapbox.maps.plugin.delegates.listeners.eventdata.TileID
 
 /**
  * Definition for listener invoked whenever the map load errors out.
@@ -12,6 +13,13 @@ interface OnMapLoadErrorListener {
    *
    * @param mapLoadErrorType the [MapLoadErrorType]
    * @param message the error message string
+   * @param sourceId optional, in case of `source` or `tile` loading errors, `source-id` will contain the id of the source failing.
+   * @param tileId optional, in case of `tile` loading errors, `tile-id` will contain the id of the tile
    */
-  fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String)
+  fun onMapLoadError(
+    mapLoadErrorType: MapLoadErrorType,
+    message: String,
+    sourceId: String?,
+    tileId: TileID?
+  )
 }

--- a/sdk/src/main/java/com/mapbox/maps/MapboxConfigurationException.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxConfigurationException.kt
@@ -11,7 +11,10 @@ class MapboxConfigurationException : RuntimeException {
   constructor() : super(
     """
       Using MapView requires providing a valid access token when inflating or creating the view.
-      Provide the token by creating a $MAPBOX_ACCESS_TOKEN_RESOURCE_NAME string resource or by passing it using MapView's 'mapbox_accessToken' XML attribute.
+      Provide the token by either:
+        1. Initialising the MapView programmatically using 'MapInitOptions' and configure the token using 'MapInitOptions.resourceOptions.accessToken'.
+        2. Or by passing it using MapView's 'mapbox_resourcesAccessToken' XML attribute.
+        3. Or by creating a $MAPBOX_ACCESS_TOKEN_RESOURCE_NAME string resource.
       The access token parameter is required when using a Mapbox service.
       Please see https://www.mapbox.com/help/create-api-access-token/ to learn how to create one.
       More information in this guide https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens.

--- a/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
@@ -43,7 +43,12 @@ internal class NativeObserver(
       MapEvents.MAP_LOADING_ERROR -> if (onMapLoadErrorListeners.isNotEmpty()) {
         val loadingError = event.getMapLoadingErrorEventData()
         onMapLoadErrorListeners.forEach {
-          it.onMapLoadError(loadingError.type, loadingError.message)
+          it.onMapLoadError(
+            loadingError.type,
+            loadingError.message,
+            loadingError.sourceId,
+            loadingError.tileId
+          )
         }
       }
       MapEvents.MAP_LOADED -> onMapLoadedListeners.forEach { it.onMapLoaded() }

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -4,6 +4,7 @@ import com.mapbox.common.Logger
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.OnStyleLoadedListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
+import com.mapbox.maps.plugin.delegates.listeners.eventdata.TileID
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -28,7 +29,10 @@ internal class StyleObserver(
   /**
    * Clears previous added listeners and setup to receive callback for new style loaded or error events.
    */
-  fun onNewStyleLoad(loadedListener: Style.OnStyleLoaded?, onMapLoadErrorListener: OnMapLoadErrorListener?) {
+  fun onNewStyleLoad(
+    loadedListener: Style.OnStyleLoaded?,
+    onMapLoadErrorListener: OnMapLoadErrorListener?
+  ) {
     awaitingStyleLoadListeners.clear()
     loadedListener?.let {
       awaitingStyleLoadListeners.add(loadedListener)
@@ -57,9 +61,14 @@ internal class StyleObserver(
     }
   }
 
-  override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, message: String) {
+  override fun onMapLoadError(
+    mapLoadErrorType: MapLoadErrorType,
+    message: String,
+    sourceId: String?,
+    tileId: TileID?
+  ) {
     Logger.e(TAG, "OnMapLoadError: $mapLoadErrorType: $message")
-    awaitingStyleErrorListener?.onMapLoadError(mapLoadErrorType, message)
+    awaitingStyleErrorListener?.onMapLoadError(mapLoadErrorType, message, sourceId, tileId)
   }
 
   fun onDestroy() {

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/model/MapLoadingErrorEventData.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/model/MapLoadingErrorEventData.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps.extension.observable.model
 
 import com.google.gson.annotations.SerializedName
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
+import com.mapbox.maps.plugin.delegates.listeners.eventdata.TileID
 
 /**
  *The data class for Map Loading Error event data in Observer
@@ -14,5 +15,13 @@ data class MapLoadingErrorEventData(
   /**
    * The descriptive error message of the error.
    */
-  @SerializedName("message") val message: String
+  @SerializedName("message") val message: String,
+  /**
+   * In case of `source` or `tile` loading errors, `source-id` will contain the id of the source failing.
+   */
+  @SerializedName("source-id") val sourceId: String?,
+  /**
+   * In case of `tile` loading errors, `tile-id` will contain the id of the tile.
+   */
+  @SerializedName("tile-id") val tileId: TileID?,
 )

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/Error.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/Error.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.extension.observable.resourcerequest
 
 import com.google.gson.annotations.SerializedName
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.ResponseErrorType
 
 /**
  *The data class for error in Observer
@@ -9,7 +10,7 @@ data class Error(
   /**
    * "reason" property
    */
-  @SerializedName("reason") val reason: String,
+  @SerializedName("reason") val reason: ResponseErrorType,
   /**
    * "message" property
    */

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/Request.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/Request.kt
@@ -1,6 +1,8 @@
 package com.mapbox.maps.extension.observable.resourcerequest
 
 import com.google.gson.annotations.SerializedName
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.RequestPriority
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.RequestType
 
 /**
  * The request data class that included in EventData
@@ -17,9 +19,9 @@ data class Request(
   /**
    * "kind" property
    */
-  @SerializedName("kind") val kind: String,
+  @SerializedName("kind") val kind: RequestType,
   /**
    * "priority" property
    */
-  @SerializedName("priority") val priority: String
+  @SerializedName("priority") val priority: RequestPriority
 )

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/ResourceEventData.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/ResourceEventData.kt
@@ -17,7 +17,7 @@ data class ResourceEventData(
   /**
    * "response" property
    */
-  @SerializedName("response") val response: Response,
+  @SerializedName("response") val response: Response?,
   /**
    * "cancelled" property
    */

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/ResourceEventData.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/ResourceEventData.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.extension.observable.resourcerequest
 
 import com.google.gson.annotations.SerializedName
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.RequestDataSourceType
 
 /**
  *The data class for event data in Observer
@@ -9,7 +10,7 @@ data class ResourceEventData(
   /**
    * "data-source" property
    */
-  @SerializedName("data-source") val dataSource: String,
+  @SerializedName("data-source") val dataSource: RequestDataSourceType,
   /**
    * "request" property
    */

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/Response.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/Response.kt
@@ -9,7 +9,7 @@ data class Response(
   /**
    * "etag" property
    */
-  @SerializedName("etag") val eTag: String,
+  @SerializedName("etag") val eTag: String?,
   /**
    * "must-revalidate" property
    */
@@ -21,7 +21,7 @@ data class Response(
   /**
    * "modified" property
    */
-  @SerializedName("modified") val modified: String,
+  @SerializedName("modified") val modified: String?,
   /**
    * "source" property
    */
@@ -33,7 +33,7 @@ data class Response(
   /**
    * "expires" property
    */
-  @SerializedName("expires") val expires: String,
+  @SerializedName("expires") val expires: String?,
   /**
    * "size" property
    */

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/Response.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/Response.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.extension.observable.resourcerequest
 
 import com.google.gson.annotations.SerializedName
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.ResponseSourceType
 
 /**
  * The response data class that included in EventData
@@ -25,7 +26,7 @@ data class Response(
   /**
    * "source" property
    */
-  @SerializedName("source") val source: String,
+  @SerializedName("source") val source: ResponseSourceType,
   /**
    * "not-modified" property
    */

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/RequestDataSourceType.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/RequestDataSourceType.kt
@@ -1,0 +1,38 @@
+package com.mapbox.maps.extension.observable.resourcerequest.eventdata
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Describes data source of request for resource-request event.
+ */
+enum class RequestDataSourceType {
+  /**
+   * data source as resource-loader.
+   */
+  @SerializedName("resource-loader")
+  RESOURCE_LOADER,
+
+  /**
+   * data source as network.
+   */
+  @SerializedName("network")
+  NETWORK,
+
+  /**
+   * data source as database.
+   */
+  @SerializedName("database")
+  DATABASE,
+
+  /**
+   * data source as asset.
+   */
+  @SerializedName("asset")
+  ASSET,
+
+  /**
+   * data source as file-system.
+   */
+  @SerializedName("file-system")
+  FILE_SYSTEM,
+}

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/RequestPriority.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/RequestPriority.kt
@@ -1,0 +1,16 @@
+package com.mapbox.maps.extension.observable.resourcerequest.eventdata
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Describes priority for request object.
+ */
+enum class RequestPriority {
+  /** Regular priority. */
+  @SerializedName("regular")
+  REGULAR,
+
+  /** low priority. */
+  @SerializedName("low")
+  LOW
+}

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/RequestType.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/RequestType.kt
@@ -1,0 +1,56 @@
+package com.mapbox.maps.extension.observable.resourcerequest.eventdata
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Describes type for request object.
+ */
+enum class RequestType {
+  /**
+   * Request type unknown.
+   */
+  @SerializedName("unknown")
+  UNKNOWN,
+
+  /**
+   * Request type style.
+   */
+  @SerializedName("style")
+  STYLE,
+
+  /**
+   * Request type source.
+   */
+  @SerializedName("source")
+  SOURCE,
+
+  /**
+   * Request type tile.
+   */
+  @SerializedName("tile")
+  TILE,
+
+  /**
+   * Request type glyphs.
+   */
+  @SerializedName("glyphs")
+  GLYPHS,
+
+  /**
+   * Request type sprite-image.
+   */
+  @SerializedName("sprite-image")
+  SPRITE_IMAGE,
+
+  /**
+   * Request type sprite-json.
+   */
+  @SerializedName("sprite-json")
+  SPRITE_JSON,
+
+  /**
+   * Request type image.
+   */
+  @SerializedName("image")
+  IMAGE,
+}

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/ResponseErrorType.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/ResponseErrorType.kt
@@ -1,0 +1,44 @@
+package com.mapbox.maps.extension.observable.resourcerequest.eventdata
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Describes type of Error for response object.
+ */
+enum class ResponseErrorType {
+  /**
+   * Error type server.
+   */
+  @SerializedName("server")
+  SERVER,
+
+  /**
+   * Error type connection.
+   */
+  @SerializedName("connection")
+  CONNECTION,
+
+  /**
+   * Error type rate-limit.
+   */
+  @SerializedName("rate-limit")
+  RATE_LIMIT,
+
+  /**
+   * Error type not-found.
+   */
+  @SerializedName("not-found")
+  NOT_FOUND,
+
+  /**
+   * Error type other.
+   */
+  @SerializedName("other")
+  OTHER,
+
+  /**
+   * Error type success.
+   */
+  @SerializedName("success")
+  SUCCESS,
+}

--- a/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/ResponseSourceType.kt
+++ b/sdk/src/main/java/com/mapbox/maps/extension/observable/resourcerequest/eventdata/ResponseSourceType.kt
@@ -1,0 +1,32 @@
+package com.mapbox.maps.extension.observable.resourcerequest.eventdata
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Describes source data type for response in resource-request event.
+ */
+enum class ResponseSourceType {
+  /**
+   * source type as network.
+   */
+  @SerializedName("network")
+  NETWORK,
+
+  /**
+   * source type as cache.
+   */
+  @SerializedName("cache")
+  CACHE,
+
+  /**
+   * source type as tile-store.
+   */
+  @SerializedName("tile-store")
+  TILE_STORE,
+
+  /**
+   * source type as local-file.
+   */
+  @SerializedName("local-file")
+  LOCAL_FILE,
+}

--- a/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
@@ -106,7 +106,7 @@ class NativeObserverTest {
     verify { observableInterface.subscribe(any(), listOf(MapEvents.MAP_LOADING_ERROR)) }
     assertTrue(nativeObserver.observedEvents.contains(MapEvents.MAP_LOADING_ERROR))
     notifyEvents(MapEvents.MAP_LOADING_ERROR)
-    verify { listener.onMapLoadError(any(), any()) }
+    verify { listener.onMapLoadError(any(), any(), any(), any()) }
 
     val listener2 = mockk<OnMapLoadErrorListener>(relaxUnitFun = true)
     nativeObserver.addOnMapLoadErrorListener(listener2)
@@ -118,7 +118,7 @@ class NativeObserverTest {
       )
     }
     notifyEvents(MapEvents.MAP_LOADING_ERROR)
-    verify { listener2.onMapLoadError(any(), any()) }
+    verify { listener2.onMapLoadError(any(), any(), any(), any()) }
   }
 
   @Test
@@ -141,8 +141,8 @@ class NativeObserverTest {
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.MAP_LOADING_ERROR))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.MAP_LOADING_ERROR)) }
     notifyEvents(MapEvents.MAP_IDLE)
-    verify(exactly = 0) { listener.onMapLoadError(any(), any()) }
-    verify(exactly = 0) { listener2.onMapLoadError(any(), any()) }
+    verify(exactly = 0) { listener.onMapLoadError(any(), any(), any(), any()) }
+    verify(exactly = 0) { listener2.onMapLoadError(any(), any(), any(), any()) }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -99,8 +99,8 @@ class StyleObserverTest {
     val styleObserver = StyleObserver(mockk(relaxed = true), mockk(relaxed = true), 1.0f)
     val errorListener = mockk<OnMapLoadErrorListener>(relaxed = true)
     styleObserver.onNewStyleLoad(mockk(relaxed = true), errorListener)
-    styleObserver.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar")
-    verify { errorListener.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar") }
+    styleObserver.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar", null, null)
+    verify { errorListener.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar", null, null) }
   }
 
   /**
@@ -113,8 +113,8 @@ class StyleObserverTest {
     styleObserver.onNewStyleLoad(mockk(relaxed = true), errorListenerFail)
     val errorListenerSuccess = mockk<OnMapLoadErrorListener>(relaxed = true)
     styleObserver.onNewStyleLoad(mockk(relaxed = true), errorListenerSuccess)
-    styleObserver.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar")
-    verify(exactly = 0) { errorListenerFail.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar") }
-    verify { errorListenerSuccess.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar") }
+    styleObserver.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar", null, null)
+    verify(exactly = 0) { errorListenerFail.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar", null, null) }
+    verify { errorListenerSuccess.onMapLoadError(MapLoadErrorType.GLYPHS, "foobar", null, null) }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/extension/observable/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/extension/observable/MapboxMapTest.kt
@@ -5,6 +5,10 @@ import com.mapbox.maps.Event
 import com.mapbox.maps.ObservableInterface
 import com.mapbox.maps.Observer
 import com.mapbox.maps.extension.observable.resourcerequest.*
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.RequestPriority
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.RequestType
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.ResponseErrorType
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.ResponseSourceType
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -32,17 +36,17 @@ class MapboxMapTest {
 
   @Test
   fun getEventData() {
-    val request = Request(listOf("network"), "https://api.mapbox.com", "tile", "regular")
+    val request = Request(listOf("network"), "https://api.mapbox.com", RequestType.TILE, RequestPriority.REGULAR)
     val response = Response(
       eTag = "d8abd8d10bee6b45b4dbf5c05496587a",
       mustRevalidate = false,
       noContent = false,
       modified = "Mon, 05 Oct 2020 14:23:52 GMT",
-      source = "network",
+      source = ResponseSourceType.NETWORK,
       notModified = false,
       expires = "Thu, 15 Oct 2020 14:32:23 GMT",
       size = 181576,
-      error = Error("not-found", "error message")
+      error = Error(ResponseErrorType.NOT_FOUND, "error message")
     )
     val requestMap = hashMapOf(
       Pair("loading-method", Value(listOf(Value("network")))),
@@ -94,7 +98,7 @@ class MapboxMapTest {
     assertEquals(false, response.notModified)
     assertEquals("Thu, 15 Oct 2020 14:32:23 GMT", response.expires)
     assertEquals(181576, response.size)
-    assertEquals(Error("not-found", "error message"), response.error)
+    assertEquals(Error(ResponseErrorType.NOT_FOUND, "error message"), response.error)
 
     assertEquals("not-found", response.error!!.reason)
     assertEquals("error message", response.error!!.message)

--- a/sdk/src/test/java/com/mapbox/maps/extension/observable/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/extension/observable/MapboxMapTest.kt
@@ -5,10 +5,7 @@ import com.mapbox.maps.Event
 import com.mapbox.maps.ObservableInterface
 import com.mapbox.maps.Observer
 import com.mapbox.maps.extension.observable.resourcerequest.*
-import com.mapbox.maps.extension.observable.resourcerequest.eventdata.RequestPriority
-import com.mapbox.maps.extension.observable.resourcerequest.eventdata.RequestType
-import com.mapbox.maps.extension.observable.resourcerequest.eventdata.ResponseErrorType
-import com.mapbox.maps.extension.observable.resourcerequest.eventdata.ResponseSourceType
+import com.mapbox.maps.extension.observable.resourcerequest.eventdata.*
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -81,26 +78,26 @@ class MapboxMapTest {
     val event = Event("resource-request", Value.valueOf(map))
 
     val eventData = event.getResourceEventData()
-    assertEquals("network", eventData.dataSource)
+    assertEquals(DataSourceType.NETWORK, eventData.dataSource)
     assertEquals(false, eventData.cancelled)
     assertEquals(request, eventData.request)
     assertEquals(response, eventData.response)
 
     assertEquals(listOf("network"), request.loadingMethod)
     assertEquals("https://api.mapbox.com", request.url)
-    assertEquals("tile", request.kind)
-    assertEquals("regular", request.priority)
+    assertEquals(RequestType.TILE, request.kind)
+    assertEquals(RequestPriority.REGULAR, request.priority)
 
     assertEquals("d8abd8d10bee6b45b4dbf5c05496587a", response.eTag)
     assertEquals(false, response.mustRevalidate)
     assertEquals(false, response.noContent)
-    assertEquals("network", response.source)
+    assertEquals(ResponseSourceType.NETWORK, response.source)
     assertEquals(false, response.notModified)
     assertEquals("Thu, 15 Oct 2020 14:32:23 GMT", response.expires)
     assertEquals(181576, response.size)
     assertEquals(Error(ResponseErrorType.NOT_FOUND, "error message"), response.error)
 
-    assertEquals("not-found", response.error!!.reason)
+    assertEquals(ResponseErrorType.NOT_FOUND, response.error!!.reason)
     assertEquals("error message", response.error!!.message)
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Update map events data models.</changelog>`.

### Summary of changes

This PR updates the map events data models, so they match the gl-native MapEvents.

List of changes:

* add optional `sourceId` and `tileId` in the `MapLoadingErrorEventData` and `OnMapLoadErrorListener`.
* make `response` in `ResourceEventData` optional.
* make `etag`, `modified`, `expires` inside resource request's `Response` optional.
* add `DataSourceType` , `RequestPriority` , `RequestType` ,`ResponseErrorType` , `ResponseSourceType` enum for `resource-request` event which conform to java docs from gl-native.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->