### PR TITLE
[ci] minimal circleci config to avoid red builds on publisher 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+
+workflows:
+  empty:
+    jobs:
+      - empty
+
+jobs:
+  empty:
+    docker:
+      - image: cimg/base:stable
+
+    steps:
+      - run:
+          name: echo
+          command: echo "hello_world"


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes
When publishing docs onto publisher-production, we get a build error due to a missing ciricleci configuration. 
This PR works around that with adding an MVP circle-ci config file. 

Example PR with red build: #725 