### PR TITLE
Update the logic to invoke dragStart

### DIFF
--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
@@ -463,8 +463,11 @@ class GesturePluginTest {
     every {
       moveGestureDetector.focalPoint
     } returns PointF(0.0f, 0.0f)
-
-    val handled = presenter.handleMove(moveGestureDetector, 50.0f, 50.0f)
+    every { moveGestureDetector.pointersCount } returns 2
+    var handled = presenter.handleMove(moveGestureDetector, 50.0f, 50.0f)
+    assertFalse(handled)
+    every { moveGestureDetector.pointersCount } returns 1
+    handled = presenter.handleMove(moveGestureDetector, 50.0f, 50.0f)
     assert(handled)
     verify { listener.onMove(any()) }
     verify {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #564 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Update the logic to invoke dragStart to fix map move speed faster or slower issue</changelog>`.

### Summary of changes
In the past, we invoke the `dragStart` method while scale gesture starts, which can make the map move speed faster or slower than normal. In this pr, `dragStart` method  will only be invoked when a real drag event starts, so will not have the upper issue.

Before


https://user-images.githubusercontent.com/8577318/136907352-98a29dde-ae4e-4518-ba89-2f3fb26b4f92.mp4


After

https://user-images.githubusercontent.com/8577318/136906722-73cbb262-f29b-4b59-aa62-72b6def05be3.mp4

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->