### PR TITLE
Fix ornaments margin not update issue

### DIFF
--- a/plugin-attribution/src/main/java/com/mapbox/maps/plugin/attribution/AttributionViewImpl.kt
+++ b/plugin-attribution/src/main/java/com/mapbox/maps/plugin/attribution/AttributionViewImpl.kt
@@ -72,10 +72,10 @@ class AttributionViewImpl @JvmOverloads constructor(
    */
   override fun setAttributionMargins(left: Int, top: Int, right: Int, bottom: Int) {
     (layoutParams as FrameLayout.LayoutParams).apply {
+      setMargins(left, top, right, bottom)
+      // Support RTL
       marginStart = left
-      topMargin = top
       marginEnd = right
-      bottomMargin = bottom
     }
   }
 

--- a/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewImpl.kt
+++ b/plugin-logo/src/main/java/com/mapbox/maps/plugin/logo/LogoViewImpl.kt
@@ -92,10 +92,10 @@ class LogoViewImpl : LogoView, AppCompatImageView {
    */
   override fun setLogoMargins(left: Int, top: Int, right: Int, bottom: Int) {
     (layoutParams as FrameLayout.LayoutParams).apply {
+      setMargins(left, top, right, bottom)
+      // Support RTL
       marginStart = left
-      topMargin = top
       marginEnd = right
-      bottomMargin = bottom
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix ornaments margin not update issue</changelog>`.
 
### Summary of changes

`marginStart`  and `marginEnd`  not work as expected while update the margins of logo and attribution.
This pr revert to `setMargins`

Normally

https://user-images.githubusercontent.com/8577318/137078505-c22f1346-f63d-472c-9a0b-81e12afd7302.mp4

With RTL

https://user-images.githubusercontent.com/8577318/137078616-4d21c6c1-ce4c-4244-bebd-7231507df145.mp4


<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->