### PR TITLE
Remove styleStateDelegate.isFullyLoaded() for AnnotationManagerImpl.kt

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationManagerImpl.kt
@@ -399,13 +399,15 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
   private fun updateDragSource() {
     delegateProvider.getStyle { style ->
       dragSource?.let { geoJsonSource ->
-        if (!style.styleSourceExists(geoJsonSource.sourceId)) {
-          Logger.e(TAG, "Can't update dragSource: source has not been added to style.")
-          return@getStyle
+        dragLayer?.let { layer ->
+          if (!style.styleSourceExists(geoJsonSource.sourceId) || !style.styleLayerExists(layer.layerId)) {
+            Logger.e(TAG, "Can't update dragSource: drag source or layer has not been added to style.")
+            return@getStyle
+          }
+          addIconToStyle(style, dragAnnotationMap.values)
+          val features = convertAnnotationsToFeatures(dragAnnotationMap.values)
+          geoJsonSource.featureCollection(FeatureCollection.fromFeatures(features))
         }
-        addIconToStyle(style, dragAnnotationMap.values)
-        val features = convertAnnotationsToFeatures(dragAnnotationMap.values)
-        geoJsonSource.featureCollection(FeatureCollection.fromFeatures(features))
       }
     }
   }
@@ -414,22 +416,20 @@ abstract class AnnotationManagerImpl<G : Geometry, T : Annotation<G>, S : Annota
    * Trigger an update to the underlying source
    */
   private fun updateSource() {
-    if (!styleStateDelegate.isFullyLoaded()) {
-      Logger.e(TAG, "Can't update source: style is not fully loaded.")
-      return
-    }
     delegateProvider.getStyle { style ->
       if (source == null || layer == null) {
         initLayerAndSource(style)
       }
       source?.let { geoJsonSource ->
-        if (!style.styleSourceExists(geoJsonSource.sourceId)) {
-          Logger.e(TAG, "Can't update source: source has not been added to style.")
-          return@getStyle
+        layer?.let { layer ->
+          if (!style.styleSourceExists(geoJsonSource.sourceId) || !style.styleLayerExists(layer.layerId)) {
+            Logger.e(TAG, "Can't update source: source or layer has not been added to style.")
+            return@getStyle
+          }
+          addIconToStyle(style, annotationMap.values)
+          val features = convertAnnotationsToFeatures(annotationMap.values)
+          geoJsonSource.featureCollection(FeatureCollection.fromFeatures(features))
         }
-        addIconToStyle(style, annotationMap.values)
-        val features = convertAnnotationsToFeatures(annotationMap.values)
-        geoJsonSource.featureCollection(FeatureCollection.fromFeatures(features))
       }
     }
   }

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/CircleAnnotationManagerTest.kt
@@ -70,7 +70,6 @@ class CircleAnnotationManagerTest {
     }
     val styleStateDelegate = mockk<MapStyleStateDelegate>()
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate
-    every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
     every { style.getSource(any()) } returns null
     every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
@@ -481,6 +480,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleSortKeyLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleSortKey(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_SORT_KEY)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -496,6 +496,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleBlurLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleBlur(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_BLUR)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -511,6 +512,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleColorIntLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -524,6 +526,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_COLOR)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -539,6 +542,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleOpacityLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_OPACITY)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -554,6 +558,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleRadiusLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleRadius(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_RADIUS)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -569,6 +574,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleStrokeColorIntLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleStrokeColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -582,6 +588,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleStrokeColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleStrokeColor(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_COLOR)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -597,6 +604,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleStrokeOpacityLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleStrokeOpacity(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_OPACITY)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -612,6 +620,7 @@ class CircleAnnotationManagerTest {
   @Test
   fun testCircleStrokeWidthLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.circleStrokeWidth(Expression.get(CircleAnnotationOptions.PROPERTY_CIRCLE_STROKE_WIDTH)) }
     val options = CircleAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PointAnnotationManagerTest.kt
@@ -74,7 +74,6 @@ class PointAnnotationManagerTest {
     }
     val styleStateDelegate = mockk<MapStyleStateDelegate>()
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate
-    every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
     every { style.getSource(any()) } returns null
     every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
@@ -279,6 +278,7 @@ class PointAnnotationManagerTest {
   @Test
   fun iconImageBitmapWithIconImage() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     val annotation = manager.create(
       PointAnnotationOptions()
         .withIconImage("car-15")
@@ -292,6 +292,7 @@ class PointAnnotationManagerTest {
   @Test
   fun iconImageBitmapWithoutIconImage() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     val annotation = manager.create(
       PointAnnotationOptions()
         .withIconImage(bitmap)
@@ -305,6 +306,7 @@ class PointAnnotationManagerTest {
   @Test
   fun iconImageBitmapWithSameImage() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     val annotation = manager.create(
       PointAnnotationOptions()
         .withIconImage(bitmap)
@@ -327,6 +329,7 @@ class PointAnnotationManagerTest {
   @Test
   fun updateIconImageBitmap() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     val annotation = manager.create(
       PointAnnotationOptions()
         .withIconImage(bitmap)
@@ -719,6 +722,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconAnchorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconAnchor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ANCHOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -734,6 +738,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconImageLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconImage(Expression.get(PointAnnotationOptions.PROPERTY_ICON_IMAGE)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -749,6 +754,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconOffsetLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconOffset(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OFFSET)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -764,6 +770,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconRotateLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconRotate(Expression.get(PointAnnotationOptions.PROPERTY_ICON_ROTATE)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -779,6 +786,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconSizeLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconSize(Expression.get(PointAnnotationOptions.PROPERTY_ICON_SIZE)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -794,6 +802,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testSymbolSortKeyLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.symbolSortKey(Expression.get(PointAnnotationOptions.PROPERTY_SYMBOL_SORT_KEY)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -809,6 +818,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextAnchorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textAnchor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ANCHOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -824,6 +834,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextFieldLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textField(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_FIELD)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -839,6 +850,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextJustifyLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textJustify(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_JUSTIFY)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -854,6 +866,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextLetterSpacingLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textLetterSpacing(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_LETTER_SPACING)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -869,6 +882,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextMaxWidthLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textMaxWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_MAX_WIDTH)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -884,6 +898,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextOffsetLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OFFSET)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -899,6 +914,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextRadialOffsetLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textRadialOffset(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_RADIAL_OFFSET)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -914,6 +930,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextRotateLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textRotate(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_ROTATE)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -929,6 +946,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextSizeLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textSize(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_SIZE)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -944,6 +962,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextTransformLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textTransform(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_TRANSFORM)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -959,6 +978,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconColorIntLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_COLOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -972,6 +992,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_COLOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -987,6 +1008,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconHaloBlurLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_BLUR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1002,6 +1024,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconHaloColorIntLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1015,6 +1038,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconHaloColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_COLOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1030,6 +1054,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconHaloWidthLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_ICON_HALO_WIDTH)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1045,6 +1070,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testIconOpacityLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.iconOpacity(Expression.get(PointAnnotationOptions.PROPERTY_ICON_OPACITY)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1060,6 +1086,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextColorIntLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_COLOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1073,6 +1100,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_COLOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1088,6 +1116,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextHaloBlurLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textHaloBlur(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_BLUR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1103,6 +1132,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextHaloColorIntLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1116,6 +1146,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextHaloColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textHaloColor(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_COLOR)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1131,6 +1162,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextHaloWidthLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textHaloWidth(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_HALO_WIDTH)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))
@@ -1146,6 +1178,7 @@ class PointAnnotationManagerTest {
   @Test
   fun testTextOpacityLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.textOpacity(Expression.get(PointAnnotationOptions.PROPERTY_TEXT_OPACITY)) }
     val options = PointAnnotationOptions()
       .withPoint(Point.fromLngLat(0.0, 0.0))

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolygonAnnotationManagerTest.kt
@@ -71,7 +71,6 @@ class PolygonAnnotationManagerTest {
     }
     val styleStateDelegate = mockk<MapStyleStateDelegate>()
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate
-    every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
     every { style.getSource(any()) } returns null
     every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
@@ -461,6 +460,7 @@ class PolygonAnnotationManagerTest {
   @Test
   fun testFillSortKeyLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.fillSortKey(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_SORT_KEY)) }
     val options = PolygonAnnotationOptions()
       .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -476,6 +476,7 @@ class PolygonAnnotationManagerTest {
   @Test
   fun testFillColorIntLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.fillColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_COLOR)) }
     val options = PolygonAnnotationOptions()
       .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -489,6 +490,7 @@ class PolygonAnnotationManagerTest {
   @Test
   fun testFillColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.fillColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_COLOR)) }
     val options = PolygonAnnotationOptions()
       .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -504,6 +506,7 @@ class PolygonAnnotationManagerTest {
   @Test
   fun testFillOpacityLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.fillOpacity(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OPACITY)) }
     val options = PolygonAnnotationOptions()
       .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -519,6 +522,7 @@ class PolygonAnnotationManagerTest {
   @Test
   fun testFillOutlineColorIntLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.fillOutlineColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR)) }
     val options = PolygonAnnotationOptions()
       .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -532,6 +536,7 @@ class PolygonAnnotationManagerTest {
   @Test
   fun testFillOutlineColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.fillOutlineColor(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_OUTLINE_COLOR)) }
     val options = PolygonAnnotationOptions()
       .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))
@@ -547,6 +552,7 @@ class PolygonAnnotationManagerTest {
   @Test
   fun testFillPatternLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.fillPattern(Expression.get(PolygonAnnotationOptions.PROPERTY_FILL_PATTERN)) }
     val options = PolygonAnnotationOptions()
       .withPoints(listOf(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(1.0, 1.0))))

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/generated/PolylineAnnotationManagerTest.kt
@@ -72,7 +72,6 @@ class PolylineAnnotationManagerTest {
     }
     val styleStateDelegate = mockk<MapStyleStateDelegate>()
     every { delegateProvider.styleStateDelegate } returns styleStateDelegate
-    every { styleStateDelegate.isFullyLoaded() } returns true
     every { style.addSource(any()) } just Runs
     every { style.getSource(any()) } returns null
     every { style.addPersistentStyleLayer(any(), any()) } returns ExpectedFactory.createNone()
@@ -485,6 +484,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLineJoinLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.lineJoin(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_JOIN)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -500,6 +500,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLineSortKeyLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.lineSortKey(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_SORT_KEY)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -515,6 +516,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLineBlurLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.lineBlur(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_BLUR)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -530,6 +532,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLineColorIntLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.lineColor(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_COLOR)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -543,6 +546,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLineColorLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.lineColor(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_COLOR)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -558,6 +562,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLineGapWidthLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.lineGapWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_GAP_WIDTH)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -573,6 +578,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLineOffsetLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.lineOffset(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OFFSET)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -588,6 +594,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLineOpacityLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.lineOpacity(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_OPACITY)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -603,6 +610,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLinePatternLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.linePattern(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_PATTERN)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
@@ -618,6 +626,7 @@ class PolylineAnnotationManagerTest {
   @Test
   fun testLineWidthLayerProperty() {
     every { style.styleSourceExists(any()) } returns true
+    every { style.styleLayerExists(any()) } returns true
     verify(exactly = 0) { manager.layer?.lineWidth(Expression.get(PolylineAnnotationOptions.PROPERTY_LINE_WIDTH)) }
     val options = PolylineAnnotationOptions()
       .withPoints(listOf(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Remove styleStateDelegate.isFullyLoaded() for AnnotationManagerImpl.kt to avoid update missing when style is loading sources</changelog>`.

### Summary of changes
styleStateDelegate.isFullyLoaded() will return false while it's loading some sources etc. if users update annotations in the same time, this update will be ignored because we will check the status of style by styleStateDelegate.isFullyLoaded().

Annotations should be able to be updated as long as the style is loaded for the first time.
This pr remove this check and enable update annotations when style is loading other resources.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->