### PR TITLE
Workaround fast fling in downward direction when map is pitched

### DIFF
--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesConstants.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesConstants.kt
@@ -60,6 +60,16 @@ internal const val SHOVE_PIXEL_CHANGE_FACTOR = 0.1f
 internal const val MINIMUM_PITCH = 0.0
 
 /**
+ * Maximum locked pitch value.
+ */
+internal const val NORMAL_MAX_PITCH = 60.0
+
+/**
+ * Pitch factor base.
+ */
+internal const val PITCH_BASE_FACTOR = 1.5
+
+/**
  * The currently supported maximum unlocked pitch value.
  */
 internal const val MAXIMUM_PITCH = 85.0

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
@@ -321,7 +321,7 @@ class GesturePluginTest {
     val listener: OnFlingListener = mockk(relaxed = true)
     presenter.addOnFlingListener(listener)
     presenter.scrollEnabled = false
-    val result = presenter.handleFlingEvent(mockk(), mockk(), 10000f, 10000f)
+    val result = presenter.handleFlingEvent(mockk(), mockk(), FLING_VELOCITY, FLING_VELOCITY)
     assertFalse(result)
     verify(exactly = 0) { listener.onFling() }
   }
@@ -344,11 +344,11 @@ class GesturePluginTest {
     val motionEvent = mockk<MotionEvent>()
     every { motionEvent.x } returns 0.0f
     every { motionEvent.y } returns 0.0f
-    val result = presenter.handleFlingEvent(motionEvent, mockk(), 10000f, 10000f)
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), FLING_VELOCITY, FLING_VELOCITY)
     verify {
       mapCameraManagerDelegate.getDragCameraOptions(
         ScreenCoordinate(0.0, 0.0),
-        ScreenCoordinate(1000.0, 1000.0)
+        ScreenCoordinate(FLING_DISPLACEMENT, FLING_DISPLACEMENT)
       )
     }
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }
@@ -374,11 +374,11 @@ class GesturePluginTest {
     val motionEvent = mockk<MotionEvent>()
     every { motionEvent.x } returns 0.0f
     every { motionEvent.y } returns 0.0f
-    val result = presenter.handleFlingEvent(motionEvent, mockk(), 10000f, 10000f)
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), FLING_VELOCITY, FLING_VELOCITY)
     verify {
       mapCameraManagerDelegate.getDragCameraOptions(
         ScreenCoordinate(0.0, 0.0),
-        ScreenCoordinate(0.0, 1000.0)
+        ScreenCoordinate(0.0, FLING_DISPLACEMENT)
       )
     }
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }
@@ -404,11 +404,11 @@ class GesturePluginTest {
     val motionEvent = mockk<MotionEvent>()
     every { motionEvent.x } returns 0.0f
     every { motionEvent.y } returns 0.0f
-    val result = presenter.handleFlingEvent(motionEvent, mockk(), 10000f, 10000f)
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), FLING_VELOCITY, FLING_VELOCITY)
     verify {
       mapCameraManagerDelegate.getDragCameraOptions(
         ScreenCoordinate(0.0, 0.0),
-        ScreenCoordinate(1000.0, 0.0)
+        ScreenCoordinate(FLING_DISPLACEMENT, 0.0)
       )
     }
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }
@@ -867,5 +867,10 @@ class GesturePluginTest {
 
   fun obtainMotionEventActionLater(action: Int): MotionEvent {
     return MotionEvent.obtain(200, 500, action, 15.0f, 10.0f, 0)
+  }
+
+  private companion object {
+    const val FLING_DISPLACEMENT = 6666.666666666667
+    const val FLING_VELOCITY = 10000f
   }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Limit fast fling gesture in a downwards direction when map is pitched</changelog>`.

### Summary of changes

Workaround fast fling in downward direction when map is pitched

By reintroducing the pitch limiting factor, we workaround the issue of transforming the map too much in a downward direction when the map is fully pitched. This improves the UX to a more expected behavior. It also improves the UX when using terrain, you will see less tiles missing when flinging. The pitch limiting factor was initially removed as part of https://github.com/mapbox/mapbox-maps-android/pull/599, which did fix the correct integration into drag API but we weren't aware of this specific issue. 

Before:
https://user-images.githubusercontent.com/2151639/131337336-5f494ac8-c92a-474f-b21a-6dbf12b9f10d.mp4

After:
https://user-images.githubusercontent.com/2151639/137868251-6a0592d3-3bf0-48d8-ad30-3d83c1ffb082.mp4



