### PR TITLE
[build] remove jcenter in favor of maven central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
     maven {
       url = uri("https://api.mapbox.com/downloads/v2/releases/maven")
       credentials {
@@ -29,7 +29,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
     maven {
       url = uri("https://api.mapbox.com/downloads/v2/releases/maven")
       credentials {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.kotlin.dsl.`kotlin-dsl`
 
 repositories {
-  jcenter()
+  mavenCentral()
   google()
 }
 

--- a/gradle/track-public-apis.gradle
+++ b/gradle/track-public-apis.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@
 pluginManagement {
   repositories {
     gradlePluginPortal()
-    jcenter()
+    mavenCentral()
   }
 }
 


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

Removes deprecated jcenter in favor of mavencentral