### PR TITLE
[gestures] restore unpitched fling behavior

### DIFF
--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -1175,10 +1175,10 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase {
     // We limit the amount of fling displacement based on the camera pitch value.
     val pitchFactorAdditionalComponent = when {
       pitch == MINIMUM_PITCH -> {
-        0.0
+        FLING_LIMITING_FACTOR
       }
       pitch > MINIMUM_PITCH && pitch < NORMAL_MAX_PITCH -> {
-        pitch / 10.0
+        FLING_LIMITING_FACTOR + (pitch / 10.0)
       }
       pitch in NORMAL_MAX_PITCH..MAXIMUM_PITCH -> {
         val a = ln(NORMAL_MAX_PITCH / 10.0)

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturePluginTest.kt
@@ -327,7 +327,7 @@ class GesturePluginTest {
   }
 
   @Test
-  fun verifyFling() {
+  fun verifyFlingLarge() {
     every { mapCameraManagerDelegate.cameraState } returns CameraState(
       Point.fromLngLat(0.0, 0.0),
       EdgeInsets(0.0, 0.0, 0.0, 0.0),
@@ -349,6 +349,155 @@ class GesturePluginTest {
       mapCameraManagerDelegate.getDragCameraOptions(
         ScreenCoordinate(0.0, 0.0),
         ScreenCoordinate(FLING_DISPLACEMENT, FLING_DISPLACEMENT)
+      )
+    }
+    verify { cameraAnimationsPlugin.easeTo(any(), any()) }
+    assert(result)
+  }
+
+  @Test
+  fun verifyFlingLargeTiltedNormal() {
+    every { mapCameraManagerDelegate.cameraState } returns CameraState(
+      Point.fromLngLat(0.0, 0.0),
+      EdgeInsets(0.0, 0.0, 0.0, 0.0),
+      0.0,
+      0.0,
+      55.0
+    )
+    every {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        any(),
+        any()
+      )
+    } returns CameraOptions.Builder().build()
+    val motionEvent = mockk<MotionEvent>()
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), FLING_VELOCITY, FLING_VELOCITY)
+    verify {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        ScreenCoordinate(0.0, 0.0),
+        // values should be smaller as verifyFlingLarge but larger as verifyFlingLargeTiltedLarge
+        ScreenCoordinate(588.2352941176471, 588.2352941176471)
+      )
+    }
+    verify { cameraAnimationsPlugin.easeTo(any(), any()) }
+    assert(result)
+  }
+
+  @Test
+  fun verifyFlingLargeTiltedLarge() {
+    every { mapCameraManagerDelegate.cameraState } returns CameraState(
+      Point.fromLngLat(0.0, 0.0),
+      EdgeInsets(0.0, 0.0, 0.0, 0.0),
+      0.0,
+      0.0,
+      80.0
+    )
+    every {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        any(),
+        any()
+      )
+    } returns CameraOptions.Builder().build()
+    val motionEvent = mockk<MotionEvent>()
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), FLING_VELOCITY, FLING_VELOCITY)
+    verify {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        ScreenCoordinate(0.0, 0.0),
+        // values should be smaller verifyFlingLargeTiltedNormal
+        ScreenCoordinate(194.08996167113608, 194.08996167113608)
+      )
+    }
+    verify { cameraAnimationsPlugin.easeTo(any(), any()) }
+    assert(result)
+  }
+
+  @Test
+  fun verifyFlingSmall() {
+    every { mapCameraManagerDelegate.cameraState } returns CameraState(
+      Point.fromLngLat(0.0, 0.0),
+      EdgeInsets(0.0, 0.0, 0.0, 0.0),
+      0.0,
+      0.0,
+      0.0
+    )
+    every {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        any(),
+        any()
+      )
+    } returns CameraOptions.Builder().build()
+    val motionEvent = mockk<MotionEvent>()
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), 800f, 750f)
+    verify {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        ScreenCoordinate(0.0, 0.0),
+        ScreenCoordinate(69.56521739130434, 65.21739130434783)
+      )
+    }
+    verify { cameraAnimationsPlugin.easeTo(any(), any()) }
+    assert(result)
+  }
+
+  @Test
+  fun verifyFlingSmallTiltedNormal() {
+    every { mapCameraManagerDelegate.cameraState } returns CameraState(
+      Point.fromLngLat(0.0, 0.0),
+      EdgeInsets(0.0, 0.0, 0.0, 0.0),
+      0.0,
+      0.0,
+      55.0
+    )
+    every {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        any(),
+        any()
+      )
+    } returns CameraOptions.Builder().build()
+    val motionEvent = mockk<MotionEvent>()
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), 800f, 750f)
+    verify {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        ScreenCoordinate(0.0, 0.0),
+        // values should be smaller as verifyFlingSmall but larger as verifyFlingSmallTiltedLarge
+        ScreenCoordinate(47.05882352941177, 44.11764705882353)
+      )
+    }
+    verify { cameraAnimationsPlugin.easeTo(any(), any()) }
+    assert(result)
+  }
+
+  @Test
+  fun verifyFlingSmallTiltedLarge() {
+    every { mapCameraManagerDelegate.cameraState } returns CameraState(
+      Point.fromLngLat(0.0, 0.0),
+      EdgeInsets(0.0, 0.0, 0.0, 0.0),
+      0.0,
+      0.0,
+      80.0
+    )
+    every {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        any(),
+        any()
+      )
+    } returns CameraOptions.Builder().build()
+    val motionEvent = mockk<MotionEvent>()
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
+    val result = presenter.handleFlingEvent(motionEvent, mockk(), 800f, 750f)
+    verify {
+      mapCameraManagerDelegate.getDragCameraOptions(
+        ScreenCoordinate(0.0, 0.0),
+        // values should be smaller as verifyFlingSmallTiltedNormal
+        ScreenCoordinate(15.527196933690886, 14.556747125335207)
       )
     }
     verify { cameraAnimationsPlugin.easeTo(any(), any()) }
@@ -870,7 +1019,7 @@ class GesturePluginTest {
   }
 
   private companion object {
-    const val FLING_DISPLACEMENT = 6666.666666666667
+    const val FLING_DISPLACEMENT = 869.5652173913044
     const val FLING_VELOCITY = 10000f
   }
 }


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Integrate same limiting fling factor for unpitched or slightly pitched maps. This restores the behavior that was in place before the workaround of highly pitched maps.</changelog>`.

### Summary of changes

Restores changes made in https://github.com/mapbox/mapbox-maps-android/pull/754 for unpitched and slightly pitched maps to match values from prior that change. 