### PR TITLE
[lifecycle-plugin] Use ComponentCallbacks2 instead ComponentCallbacks and hook into onTrimMemory.

### DIFF
--- a/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
+++ b/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
@@ -45,6 +45,7 @@ class MapboxLifecyclePluginImpl : MapboxLifecyclePlugin {
         override fun onTrimMemory(level: Int) {
           when (level) {
             ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL, ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> {
+              Logger.w(TAG, "onTrimMemory with level $level is received, reduceMemoryUse will be called.")
               observer.onLowMemory()
             }
             ComponentCallbacks2.TRIM_MEMORY_BACKGROUND, ComponentCallbacks2.TRIM_MEMORY_COMPLETE, ComponentCallbacks2.TRIM_MEMORY_MODERATE, ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE, ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> Unit

--- a/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
+++ b/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.plugin.lifecycle
 
 import android.content.ComponentCallbacks2
+import android.content.ComponentCallbacks2.*
 import android.content.res.Configuration
 import android.view.View
 import androidx.lifecycle.Lifecycle
@@ -44,11 +45,11 @@ class MapboxLifecyclePluginImpl : MapboxLifecyclePlugin {
 
         override fun onTrimMemory(level: Int) {
           when (level) {
-            ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL, ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> {
+            TRIM_MEMORY_RUNNING_CRITICAL, TRIM_MEMORY_RUNNING_LOW -> {
               Logger.w(TAG, "onTrimMemory with level $level is received, reduceMemoryUse will be called.")
               observer.onLowMemory()
             }
-            ComponentCallbacks2.TRIM_MEMORY_BACKGROUND, ComponentCallbacks2.TRIM_MEMORY_COMPLETE, ComponentCallbacks2.TRIM_MEMORY_MODERATE, ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE, ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> Unit
+            TRIM_MEMORY_BACKGROUND, TRIM_MEMORY_COMPLETE, TRIM_MEMORY_MODERATE, TRIM_MEMORY_RUNNING_MODERATE, TRIM_MEMORY_UI_HIDDEN -> Unit
           }
         }
       }

--- a/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
+++ b/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
@@ -1,6 +1,6 @@
 package com.mapbox.maps.plugin.lifecycle
 
-import android.content.ComponentCallbacks
+import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 import android.view.View
 import androidx.lifecycle.Lifecycle
@@ -33,13 +33,39 @@ class MapboxLifecyclePluginImpl : MapboxLifecyclePlugin {
           you need manually invoke the corresponding lifecycle methods in onStart/onStop/onDestroy/onLowMemory methods of the host Activity"""
       )
     } else {
-      val componentCallback = object : ComponentCallbacks {
+      val componentCallback = object : ComponentCallbacks2 {
         override fun onConfigurationChanged(newConfig: Configuration) {
           // no need
         }
 
         override fun onLowMemory() {
           observer.onLowMemory()
+        }
+
+        override fun onTrimMemory(level: Int) {
+          when(level) {
+            ComponentCallbacks2.TRIM_MEMORY_BACKGROUND -> {
+              observer.onLowMemory()
+            }
+            ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> {
+              observer.onLowMemory()
+            }
+            ComponentCallbacks2.TRIM_MEMORY_MODERATE -> {
+              observer.onLowMemory()
+            }
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> {
+              observer.onLowMemory()
+            }
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> {
+              observer.onLowMemory()
+            }
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE -> {
+              observer.onLowMemory()
+            }
+            ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> {
+              observer.onLowMemory()
+            }
+          }
         }
       }
       mapView.context.registerComponentCallbacks(componentCallback)

--- a/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
+++ b/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
@@ -1,7 +1,13 @@
 package com.mapbox.maps.plugin.lifecycle
 
 import android.content.ComponentCallbacks2
-import android.content.ComponentCallbacks2.*
+import android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
+import android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE
+import android.content.ComponentCallbacks2.TRIM_MEMORY_MODERATE
+import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
+import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
+import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE
+import android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 import android.content.res.Configuration
 import android.view.View
 import androidx.lifecycle.Lifecycle

--- a/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
+++ b/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/MapboxLifecyclePluginImpl.kt
@@ -43,28 +43,11 @@ class MapboxLifecyclePluginImpl : MapboxLifecyclePlugin {
         }
 
         override fun onTrimMemory(level: Int) {
-          when(level) {
-            ComponentCallbacks2.TRIM_MEMORY_BACKGROUND -> {
+          when (level) {
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL, ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> {
               observer.onLowMemory()
             }
-            ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> {
-              observer.onLowMemory()
-            }
-            ComponentCallbacks2.TRIM_MEMORY_MODERATE -> {
-              observer.onLowMemory()
-            }
-            ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> {
-              observer.onLowMemory()
-            }
-            ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> {
-              observer.onLowMemory()
-            }
-            ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE -> {
-              observer.onLowMemory()
-            }
-            ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> {
-              observer.onLowMemory()
-            }
+            ComponentCallbacks2.TRIM_MEMORY_BACKGROUND, ComponentCallbacks2.TRIM_MEMORY_COMPLETE, ComponentCallbacks2.TRIM_MEMORY_MODERATE, ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE, ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> Unit
           }
         }
       }

--- a/plugin-lifecycle/src/test/java/com/mapbox/common/ShadowLogger.java
+++ b/plugin-lifecycle/src/test/java/com/mapbox/common/ShadowLogger.java
@@ -1,0 +1,33 @@
+package com.mapbox.common;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(Logger.class)
+public class ShadowLogger {
+
+    @Implementation
+    public static void e(@Nullable String tag, @NonNull String message) {
+        Log.e(message, tag);
+    }
+
+    @Implementation
+    public static void d(@Nullable String tag, @NonNull String message) {
+        Log.d(message, tag);
+    }
+
+    @Implementation
+    public static void w(@Nullable String tag, @NonNull String message) {
+        Log.w(message, tag);
+    }
+
+    @Implementation
+    public static void i(@Nullable String tag, @NonNull String message) {
+        Log.i(message, tag);
+    }
+}

--- a/plugin-lifecycle/src/test/java/com/mapbox/maps/extension/lifecycle/MapboxLifecyclePluginImplTest.kt
+++ b/plugin-lifecycle/src/test/java/com/mapbox/maps/extension/lifecycle/MapboxLifecyclePluginImplTest.kt
@@ -1,6 +1,6 @@
 package com.mapbox.maps.extension.lifecycle
 
-import android.content.ComponentCallbacks
+import android.content.ComponentCallbacks2
 import android.content.Context
 import android.widget.FrameLayout
 import androidx.lifecycle.LifecycleOwner
@@ -17,7 +17,7 @@ class MapboxLifecyclePluginImplTest {
   private val mapView: FrameLayout = mockk(relaxed = true)
   private val context: Context = mockk(relaxed = true)
   private val lifecycleOwner: LifecycleOwner = mockk(relaxed = true)
-  private val slot = slot<ComponentCallbacks>()
+  private val slot = slot<ComponentCallbacks2>()
 
   @Before
   fun setUp() {

--- a/plugin-lifecycle/src/test/java/com/mapbox/maps/extension/lifecycle/MapboxLifecyclePluginImplTest.kt
+++ b/plugin-lifecycle/src/test/java/com/mapbox/maps/extension/lifecycle/MapboxLifecyclePluginImplTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.extension.lifecycle
 
 import android.content.ComponentCallbacks2
+import android.content.ComponentCallbacks2.*
 import android.content.Context
 import android.widget.FrameLayout
 import androidx.lifecycle.LifecycleOwner
@@ -75,10 +76,7 @@ class AcceptedTrimMemoryLevelTest(private val level: Int) {
   companion object {
     @JvmStatic
     @ParameterizedRobolectricTestRunner.Parameters(name = "TrimMemoryLevel {0} should trigger onLowMemory")
-    fun data() = listOf(
-      ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
-      ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
-    )
+    fun data() = listOf(TRIM_MEMORY_RUNNING_CRITICAL, TRIM_MEMORY_RUNNING_LOW)
   }
 }
 
@@ -113,11 +111,11 @@ class IgnoredTrimMemoryLevelTest(private val level: Int) {
     @JvmStatic
     @Parameterized.Parameters(name = "TrimMemoryLevel {0} should not trigger onLowMemory")
     fun data() = listOf(
-      ComponentCallbacks2.TRIM_MEMORY_BACKGROUND,
-      ComponentCallbacks2.TRIM_MEMORY_COMPLETE,
-      ComponentCallbacks2.TRIM_MEMORY_MODERATE,
-      ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE,
-      ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+      TRIM_MEMORY_BACKGROUND,
+      TRIM_MEMORY_COMPLETE,
+      TRIM_MEMORY_MODERATE,
+      TRIM_MEMORY_RUNNING_MODERATE,
+      TRIM_MEMORY_UI_HIDDEN
     )
   }
 }

--- a/plugin-lifecycle/src/test/java/com/mapbox/maps/extension/lifecycle/MapboxLifecyclePluginImplTest.kt
+++ b/plugin-lifecycle/src/test/java/com/mapbox/maps/extension/lifecycle/MapboxLifecyclePluginImplTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.widget.FrameLayout
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewTreeLifecycleOwner
+import com.mapbox.common.ShadowLogger
 import com.mapbox.maps.MapboxLifecycleObserver
 import com.mapbox.maps.plugin.lifecycle.MapboxLifecyclePlugin
 import com.mapbox.maps.plugin.lifecycle.MapboxLifecyclePluginImpl
@@ -13,6 +14,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.annotation.Config
 
 class MapboxLifecyclePluginImplTest {
   private lateinit var mapboxLifecyclePlugin: MapboxLifecyclePlugin
@@ -41,7 +44,8 @@ class MapboxLifecyclePluginImplTest {
   }
 }
 
-@RunWith(Parameterized::class)
+@RunWith(ParameterizedRobolectricTestRunner::class)
+@Config(shadows = [ShadowLogger::class])
 class AcceptedTrimMemoryLevelTest(private val level: Int) {
   private lateinit var mapboxLifecyclePlugin: MapboxLifecyclePlugin
   private val mapView: FrameLayout = mockk(relaxed = true)
@@ -70,7 +74,7 @@ class AcceptedTrimMemoryLevelTest(private val level: Int) {
 
   companion object {
     @JvmStatic
-    @Parameterized.Parameters(name = "TrimMemoryLevel {0} should trigger onLowMemory")
+    @ParameterizedRobolectricTestRunner.Parameters(name = "TrimMemoryLevel {0} should trigger onLowMemory")
     fun data() = listOf(
       ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
       ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW

--- a/plugin-lifecycle/src/test/java/com/mapbox/maps/extension/lifecycle/MapboxLifecyclePluginImplTest.kt
+++ b/plugin-lifecycle/src/test/java/com/mapbox/maps/extension/lifecycle/MapboxLifecyclePluginImplTest.kt
@@ -11,6 +11,8 @@ import com.mapbox.maps.plugin.lifecycle.MapboxLifecyclePluginImpl
 import io.mockk.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
 class MapboxLifecyclePluginImplTest {
   private lateinit var mapboxLifecyclePlugin: MapboxLifecyclePlugin
@@ -36,5 +38,82 @@ class MapboxLifecyclePluginImplTest {
     mapboxLifecyclePlugin.registerLifecycleObserver(mapView, mapboxLifecycleObserver)
 
     verify { mapboxLifecycleObserver.onLowMemory() }
+  }
+}
+
+@RunWith(Parameterized::class)
+class AcceptedTrimMemoryLevelTest(private val level: Int) {
+  private lateinit var mapboxLifecyclePlugin: MapboxLifecyclePlugin
+  private val mapView: FrameLayout = mockk(relaxed = true)
+  private val context: Context = mockk(relaxed = true)
+  private val lifecycleOwner: LifecycleOwner = mockk(relaxed = true)
+  private val slot = slot<ComponentCallbacks2>()
+
+  @Before
+  fun setUp() {
+    mockkStatic(ViewTreeLifecycleOwner::class)
+    every { mapView.context } returns context
+    every { ViewTreeLifecycleOwner.get(any()) } returns lifecycleOwner
+    mapboxLifecyclePlugin = MapboxLifecyclePluginImpl()
+  }
+
+  @Test
+  fun checkOnLowMemoryIsCalled() {
+    val mapboxLifecycleObserver: MapboxLifecycleObserver = mockk(relaxed = true)
+    every { context.registerComponentCallbacks(capture(slot)) } answers {
+      slot.captured.onTrimMemory(level)
+    }
+    mapboxLifecyclePlugin.registerLifecycleObserver(mapView, mapboxLifecycleObserver)
+
+    verify { mapboxLifecycleObserver.onLowMemory() }
+  }
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "TrimMemoryLevel {0} should trigger onLowMemory")
+    fun data() = listOf(
+      ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
+      ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
+    )
+  }
+}
+
+@RunWith(Parameterized::class)
+class IgnoredTrimMemoryLevelTest(private val level: Int) {
+  private lateinit var mapboxLifecyclePlugin: MapboxLifecyclePlugin
+  private val mapView: FrameLayout = mockk(relaxed = true)
+  private val context: Context = mockk(relaxed = true)
+  private val lifecycleOwner: LifecycleOwner = mockk(relaxed = true)
+  private val slot = slot<ComponentCallbacks2>()
+
+  @Before
+  fun setUp() {
+    mockkStatic(ViewTreeLifecycleOwner::class)
+    every { mapView.context } returns context
+    every { ViewTreeLifecycleOwner.get(any()) } returns lifecycleOwner
+    mapboxLifecyclePlugin = MapboxLifecyclePluginImpl()
+  }
+
+  @Test
+  fun checkOnLowMemoryIsNotCalled() {
+    val mapboxLifecycleObserver: MapboxLifecycleObserver = mockk(relaxed = true)
+    every { context.registerComponentCallbacks(capture(slot)) } answers {
+      slot.captured.onTrimMemory(level)
+    }
+    mapboxLifecyclePlugin.registerLifecycleObserver(mapView, mapboxLifecycleObserver)
+
+    verify(exactly = 0) { mapboxLifecycleObserver.onLowMemory() }
+  }
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "TrimMemoryLevel {0} should not trigger onLowMemory")
+    fun data() = listOf(
+      ComponentCallbacks2.TRIM_MEMORY_BACKGROUND,
+      ComponentCallbacks2.TRIM_MEMORY_COMPLETE,
+      ComponentCallbacks2.TRIM_MEMORY_MODERATE,
+      ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE,
+      ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+    )
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Use ComponentCallbacks2 instead ComponentCallbacks and hook into onTrimMemory callback.</changelog>`.

### Summary of changes

This PR replaces ComponentCallbacks2 instead ComponentCallbacks and hook into onTrimMemory. As it has more granular control and works better for Android Q and later according to [Android memory and games (Google I/O'19)](https://www.youtube.com/watch?v=Do7oYWwOXTk)

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->