### PR TITLE
remove useless CI job build-sdk-from-source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,6 @@ workflows:
       - run-style-test:
           requires:
             - start-run-style-test
-      - build-sdk-from-source:
-          requires:
-            - verify-code
       - build-android-auto-app:
           requires:
             - verify-code
@@ -453,15 +450,6 @@ jobs:
       - run-firebase-instrumentation:
           module_target: "extension-style-app"
           app_target: "extension-style-app"
-
-  build-sdk-from-source:
-    executor: ubuntu
-    steps:
-      - checkout
-      - restore-gradle-cache
-      - build-module:
-          module_target: "sdk"
-          variant: "Release"
 
   build-android-auto-app:
     executor: ubuntu


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

Remove `build-sdk-from-source` CI job because its duplicate [`build-sdk-release`](https://github.com/mapbox/mapbox-maps-android/blob/main/.circleci/config.yml#L475)

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->