### PR TITLE
Add example that uses tilejson through the tileset class.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1077,6 +1077,18 @@
                 android:value=".ExampleOverviewActivity" />
         </activity>
         <activity
+            android:name=".examples.style.TileJsonActivity"
+            android:description="@string/description_osm"
+            android:exported="true"
+            android:label="@string/activity_osm">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_styles" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".ExampleOverviewActivity" />
+        </activity>
+        <activity
             android:name=".TestMapActivity"
             android:exported="true" />
     </application>

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/style/TileJsonActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/style/TileJsonActivity.kt
@@ -1,0 +1,86 @@
+package com.mapbox.maps.testapp.examples.style
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.mapbox.common.Logger
+import com.mapbox.common.ValueConverter
+import com.mapbox.maps.MapView
+import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.extension.style.layers.addLayer
+import com.mapbox.maps.extension.style.layers.generated.rasterLayer
+import com.mapbox.maps.extension.style.sources.TileSet
+import com.mapbox.maps.extension.style.sources.addSource
+import com.mapbox.maps.extension.style.sources.generated.Scheme
+import com.mapbox.maps.extension.style.sources.generated.rasterSource
+import com.mapbox.maps.testapp.R
+
+/**
+ * Activity showcases usage of TileSet to load a TileJSON compatible configuration as a source.
+ *
+ * This example uses OSM tiles as a raster source and visualises them using a raster layer.
+ */
+class TileJsonActivity : AppCompatActivity() {
+
+  private lateinit var mapboxMap: MapboxMap
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_custom_layer)
+    val mapView: MapView = findViewById(R.id.mapView)
+
+    val tileSet = TileSet.Builder(TILE_JSON_VERSION, listOf(OSM_RASTER_TILE_URL))
+      .name(TILE_JSON_NAME)
+      .description(TILE_JSON_DESCRIPTION)
+      .attribution(TILE_JSON_ATTRIBUTION)
+      .scheme(Scheme.XYZ)
+      .minZoom(TILE_JSON_MIN_ZOOM)
+      .maxZoom(TILE_JSON_MAX_ZOOM)
+      .bounds(MERCATOR_BOUNDS)
+      .center(CENTER_MAP_LOCATION)
+      .build()
+
+    mapboxMap = mapView.getMapboxMap()
+    mapboxMap.loadStyleJson("{}") {
+      it.addSource(
+        rasterSource(SOURCE_ID) {
+          tileSet(tileSet)
+          tileSize(RASTER_TILE_SIZE_PIXELS)
+        }
+      )
+      it.addLayer(rasterLayer(LAYER_ID, SOURCE_ID) {})
+    }
+
+    // Click on button to print out tile set information
+    findViewById<FloatingActionButton>(R.id.fab).setOnClickListener {
+      if (::mapboxMap.isInitialized) {
+        mapboxMap.getStyle {
+          val properties = it.getStyleSourceProperties(SOURCE_ID).value!!
+          val propertiesJson = ValueConverter.toJson(properties)
+          Logger.i(TAG, propertiesJson)
+          Toast.makeText(this, propertiesJson, Toast.LENGTH_LONG).show()
+        }
+      }
+    }
+  }
+
+  private companion object {
+    const val SOURCE_ID = "osm"
+    const val LAYER_ID = SOURCE_ID
+    const val TAG = SOURCE_ID
+
+    const val TILE_JSON_VERSION = "2.0.0"
+    const val TILE_JSON_NAME = "OpenStreetMap"
+    const val TILE_JSON_DESCRIPTION = "A free editable map of the whole world."
+    const val TILE_JSON_ATTRIBUTION = "&copy; OpenStreetMap contributors, CC-BY-SA"
+    const val TILE_JSON_MIN_ZOOM = 0
+    const val TILE_JSON_MAX_ZOOM = 18
+
+    const val OSM_RASTER_TILE_URL = "http://tile.openstreetmap.org/{z}/{x}/{y}.png"
+    const val RASTER_TILE_SIZE_PIXELS = 256L
+
+    val MERCATOR_BOUNDS = listOf(-180.0, -85.0, 180.0, 85.0)
+    val CENTER_MAP_LOCATION = listOf(11.9, 57.7, 8.0)
+  }
+}

--- a/app/src/main/res/values/example_descriptions.xml
+++ b/app/src/main/res/values/example_descriptions.xml
@@ -84,4 +84,6 @@
     <string name="description_nine_patch">Add 9-patch image to the style</string>
     <string name="description_feature_state">Create interactive hover effects with feature state</string>
     <string name="description_3d_globe">Showcasing 3D globe</string>
+    <string name="description_osm">Using raster source and layer to render OSM tiles with TileSet class</string>
+
 </resources>

--- a/app/src/main/res/values/example_titles.xml
+++ b/app/src/main/res/values/example_titles.xml
@@ -84,4 +84,5 @@
     <string name="activity_nine_patch">9-patch image</string>
     <string name="activity_feature_state">Feature state</string>
     <string name="activity_globe">3D globe</string>
+    <string name="activity_osm">TileJson</string>
 </resources>


### PR DESCRIPTION
## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

While validating if something was correctly working with tilejson, I noticed we didn't have any code using the TileSet API in an actual map example. The added example uses OSM based raster tiles through tileset configuration of a RasterSource and visualising it with a RasterLayer. 

![image](https://user-images.githubusercontent.com/2151639/140545241-57995e45-ed72-46f0-88a4-40fcca1e36f0.png)



