### PR TITLE
Apply ratio to the width of scalebar

### DIFF
--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarImpl.kt
@@ -60,7 +60,7 @@ class ScaleBarImpl : ScaleBar, View {
     }
 
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-    val width = mapViewWidth / 2
+    val width = mapViewWidth * settings.ratio
     val height = settings.run { textBarMargin + textSize + height + (borderWidth * 2) }
     setMeasuredDimension(width.toInt(), height.toInt())
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: #809 
## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix scalebar ratio setting not applied correctly issue.</changelog>`.

### Summary of changes
Scale bar uses the half of mapview width as its width, so the right part will be cut off if set the ratio bigger than o.5.
This pr applies ratio to scalebar and make the width changes with ratio.
The following picture shows the width of scalebar when setting ratio to 1.0
![image](https://user-images.githubusercontent.com/8577318/140691681-06cb65ce-b41c-414d-8e84-f7423f9fdaa7.png)

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->