### PR TITLE
Fix scale bar texts missing on devices with Android 6 issue

### DIFF
--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarImpl.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
-import android.graphics.Path
 import android.os.Handler
 import android.os.Message
 import android.util.AttributeSet
@@ -39,11 +38,6 @@ class ScaleBarImpl : ScaleBar, View {
    * The paint draw text border
    */
   internal val strokePaint = Paint()
-
-  /**
-   * The text path
-   */
-  internal val path = Path()
 
   /**
    * The unit for distance
@@ -277,14 +271,8 @@ class ScaleBarImpl : ScaleBar, View {
             }
           }
 
-        textPaint.getTextPath(
-          distanceText, 0, distanceText.length, (unitBarWidth * i) + xPositionShitForText,
-          textSize, path
-        )
-        if (showTextBorder) {
-          canvas.drawPath(path, strokePaint)
-        }
-        canvas.drawPath(path, textPaint)
+        drawText(canvas, distanceText, (unitBarWidth * i) + xPositionShitForText, textSize)
+
         canvas.drawRect(
           (borderWidth * 2) + (unitBarWidth * i),
           textBarMargin + textSize,
@@ -294,18 +282,18 @@ class ScaleBarImpl : ScaleBar, View {
         )
       }
       val distanceText = getDistanceText(unitDistance * pair.second)
-      textPaint.getTextPath(
-        distanceText, 0, distanceText.length, unitBarWidth * pair.second,
-        textSize, path
-      )
-      if (showTextBorder) {
-        canvas.drawPath(path, strokePaint)
-      }
-      canvas.drawPath(path, textPaint)
+      drawText(canvas, distanceText, unitBarWidth * pair.second, textSize)
     }
     if (useContinuousRendering) {
       reusableCanvas = canvas
     }
+  }
+
+  private fun drawText(canvas: Canvas, text: String, x: Float, y: Float) {
+    if (settings.showTextBorder) {
+      canvas.drawText(text, x, y, strokePaint)
+    }
+    canvas.drawText(text, x, y, textPaint)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix scale bar texts missing on devices with Android 6 issue</changelog>`.

### Summary of changes
The texts in scalebar are missing on Android 6 devices. The root cause is `drawPath` does not work on these devices.
This PR replace `drawPath` with drawText to fix this issue.
The following screenshot is taken from emulator of API 23
![image](https://user-images.githubusercontent.com/8577318/141071736-3655ed7d-df50-4c38-9b3c-f02fb3c3d318.png)

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->