### PR TITLE
simplify CI instrumentation machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,6 +516,5 @@ executors:
     docker:
       - image: cimg/base:2021.10
     resource_class: << parameters.machine >>
-    working_directory: /src
     environment:
       BUILDTYPE: Debug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,8 +401,7 @@ jobs:
 
   run-robo-test:
     executor:
-      name: ubuntu
-      machine: small
+      name: instrumentation-test-runner
     steps:
       - read-from-workspace
       - login-google-cloud-platform
@@ -410,8 +409,7 @@ jobs:
 
   run-app-instrumentation-test:
     executor:
-      name: ubuntu
-      machine: small
+      name: instrumentation-test-runner
     steps:
       - read-from-workspace
       - login-google-cloud-platform
@@ -420,8 +418,7 @@ jobs:
 
   run-sdk-instrumentation-test:
     executor:
-      name: ubuntu
-      machine: small
+      name: instrumentation-test-runner
     steps:
       - read-from-workspace
       - mapbox-gl-native-begin
@@ -510,3 +507,15 @@ executors:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
       GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
+
+  instrumentation-test-runner:
+    parameters:
+      machine:
+        type: string
+        default: small
+    docker:
+      - image: cimg/base:2021.10
+    resource_class: << parameters.machine >>
+    working_directory: /src
+    environment:
+      BUILDTYPE: Debug


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

there is not need to use ndk21 docker images for running instrumentation test on firebase
so I add new type of machine with default pre-build docker image for it
https://circleci.com/developer/images/image/cimg/base

it can save as several minutes for each job and several Gb of downloading

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->