### PR TITLE
View annotations: move async inflater instance out of SDK

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/ViewAnnotationShowcaseActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/ViewAnnotationShowcaseActivity.kt
@@ -10,6 +10,7 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.asynclayoutinflater.view.AsyncLayoutInflater
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
@@ -45,6 +46,8 @@ class ViewAnnotationShowcaseActivity : AppCompatActivity(), OnMapClickListener, 
 
   private var markerWidth = 0
   private var markerHeight = 0
+
+  private val asyncInflater by lazy { AsyncLayoutInflater(this) }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -137,13 +140,14 @@ class ViewAnnotationShowcaseActivity : AppCompatActivity(), OnMapClickListener, 
   @SuppressLint("SetTextI18n")
   private fun addViewAnnotation(point: Point, markerId: String) {
     viewAnnotationManager.addViewAnnotation(
-      R.layout.item_callout_view,
-      viewAnnotationOptions {
+      resId = R.layout.item_callout_view,
+      options = viewAnnotationOptions {
         geometry(point)
         associatedFeatureId(markerId)
         anchor(ViewAnnotationAnchor.BOTTOM)
         allowOverlap(false)
-      }
+      },
+      asyncInflater = asyncInflater
     ) { viewAnnotation ->
       viewAnnotation.visibility = View.GONE
       // calculate offsetY manually taking into account icon height only because of bottom anchoring

--- a/sdk/src/main/java/com/mapbox/maps/viewannotation/ViewAnnotationManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/viewannotation/ViewAnnotationManager.kt
@@ -3,6 +3,7 @@ package com.mapbox.maps.viewannotation
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
+import androidx.asynclayoutinflater.view.AsyncLayoutInflater
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
@@ -60,13 +61,15 @@ interface ViewAnnotationManager {
    *
    * @param resId layout resource id
    * @param options view annotation options
+   * @param asyncInflater instance of [AsyncLayoutInflater] provided by the user
    * @param asyncInflateCallback callback triggered when [View] is inflated.
    *
-   * @throws [RuntimeException] if options did not include geometry or async inflater [dependency](https://mvnrepository.com/artifact/androidx.asynclayoutinflater/asynclayoutinflater/1.0.0) was not added.
+   * @throws [RuntimeException] if options did not include geometry.
    */
   fun addViewAnnotation(
     @LayoutRes resId: Int,
     options: ViewAnnotationOptions,
+    asyncInflater: AsyncLayoutInflater,
     asyncInflateCallback: (View) -> Unit
   )
 

--- a/sdk/src/main/java/com/mapbox/maps/viewannotation/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/viewannotation/ViewAnnotationManagerImpl.kt
@@ -7,7 +7,6 @@ import android.widget.FrameLayout
 import androidx.annotation.LayoutRes
 import androidx.asynclayoutinflater.view.AsyncLayoutInflater
 import com.mapbox.maps.*
-import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.HashMap
 
@@ -23,17 +22,6 @@ internal class ViewAnnotationManagerImpl(
     mapboxMap.setViewAnnotationPositionsUpdateListener(this)
   }
 
-  private val asyncInflater by lazy {
-    try {
-      AsyncLayoutInflater(mapView.context)
-    } catch (e: NoClassDefFoundError) {
-      throw RuntimeException(
-        "Please add https://mvnrepository.com/artifact/androidx.asynclayoutinflater/asynclayoutinflater/1.0.0 dependency " +
-          "to your project to make use of asynchronous view inflation when adding view annotation!"
-      )
-    }
-  }
-
   private val annotationMap = ConcurrentHashMap<String, ViewAnnotation>()
   private val idLookupMap = ConcurrentHashMap<View, String>()
 
@@ -43,6 +31,7 @@ internal class ViewAnnotationManagerImpl(
   override fun addViewAnnotation(
     @LayoutRes resId: Int,
     options: ViewAnnotationOptions,
+    asyncInflater: AsyncLayoutInflater,
     asyncInflateCallback: (View) -> Unit
   ) {
     validateOptions(options)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.

### Summary of changes

Nice idea from @yunikkk - in order to simplify maintaining async inflater which we include only as `compileOnly` - we move it out to client code.

<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->