### PR TITLE
Fix Scale bar texts overlap and clipped issue

### DIFF
--- a/plugin-scalebar/build.gradle.kts
+++ b/plugin-scalebar/build.gradle.kts
@@ -13,7 +13,9 @@ android {
     targetSdkVersion(AndroidVersions.targetSdkVersion)
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
-
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
   sourceSets {
     // limit amount of exposed library resources
     getByName("main").res.srcDirs("src/main/res-public")

--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
@@ -60,7 +60,9 @@ open class ScaleBarPluginImpl(
   override fun bind(mapView: FrameLayout, attrs: AttributeSet?, pixelRatio: Float): View {
     internalSettings =
       ScaleBarAttributeParser.parseScaleBarSettings(mapView.context, attrs, pixelRatio)
-    return viewImplProvider(mapView.context)
+    val scaleBarImpl = viewImplProvider(mapView.context)
+    (scaleBarImpl as ScaleBar).pixelRatio = pixelRatio
+    return scaleBarImpl
   }
 
   /**

--- a/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarImplTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarImplTest.kt
@@ -39,6 +39,21 @@ class ScaleBarImplTest {
   }
 
   @Test
+  fun calculateWidthAndHeight() {
+    scaleBarView.mapViewWidth = 100f
+    val viewSize = scaleBarView.calculateWidthAndHeight()
+    assertEquals(50.0f, viewSize.first)
+    assertEquals(22.0f, viewSize.second)
+  }
+
+  @Test
+  fun pixelRatio() {
+    assertEquals(ScaleBarImpl.DEFAULT_PIXEL_RATIO, scaleBarView.pixelRatio)
+    scaleBarView.pixelRatio = 2.0f
+    assertEquals(2.0f, scaleBarView.pixelRatio)
+  }
+
+  @Test
   fun scaleTable() {
     assertEquals(metricTable, scaleBarView.scaleTable)
     scaleBarSettings.isMetricUnits = false

--- a/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginTest.kt
@@ -60,8 +60,8 @@ class ScaleBarPluginTest {
     every { typedArray.hasValue(any()) } returns true
 
     scaleBarPlugin = ScaleBarPluginImpl { scaleBarView }
-    scaleBarPlugin.onPluginView(scaleBarView)
     scaleBarPlugin.onDelegateProvider(delegateProvider)
+    scaleBarPlugin.onPluginView(scaleBarView)
     scaleBarPlugin.initialize()
   }
 

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBar.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBar.kt
@@ -27,6 +27,11 @@ interface ScaleBar {
   var mapViewWidth: Float
 
   /**
+   * Defines the pixel ratio in the current display.
+   */
+  var pixelRatio: Float
+
+  /**
    * If set to True scale bar will be triggering onDraw depending on [ScaleBarSettings.refreshInterval]
    * even if actual data did not change. If set to False scale bar will redraw only on demand.
    *


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.

| Before | After |
 | ----- | ----- |
| <img src="https://user-images.githubusercontent.com/8577318/141930496-31bf31bd-a0f6-4c63-a4ac-20af094d37ce.png"/> | <img src="https://user-images.githubusercontent.com/8577318/141930349-a8b1f73c-d465-4179-97f5-5f7bd2c9224b.png"/> |


 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix Scale bar texts overlap and clipped issue</changelog>`.

### Summary of changes
This PR fixes Scale bar texts overlap and clipped issue and extract the logic of calculating width and height into a method to add test for it.
<!--
What changes does this pull request introduce?

• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->