### PR TITLE
[Gesture] Update default shove gesture angle

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
@@ -74,8 +74,7 @@ class GesturesActivity : AppCompatActivity() {
   private fun initializeMap() {
     gesturesPlugin = binding.mapView.gestures
     gesturesManager = gesturesPlugin.getGesturesManager()
-    // enable map pitch at higher touch point angle (default 20.0f).
-    gesturesManager.shoveGestureDetector.maxShoveAngle = 60.0f
+
     val layoutParams = binding.recycler.layoutParams as RelativeLayout.LayoutParams
     layoutParams.height = (binding.mapView.height / 1.75).toInt()
     layoutParams.width = binding.mapView.width / 3

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
@@ -74,7 +74,8 @@ class GesturesActivity : AppCompatActivity() {
   private fun initializeMap() {
     gesturesPlugin = binding.mapView.gestures
     gesturesManager = gesturesPlugin.getGesturesManager()
-
+    // enable map pitch at higher touch point angle (default 20.0f).
+    gesturesManager.shoveGestureDetector.maxShoveAngle = 60.0f
     val layoutParams = binding.recycler.layoutParams as RelativeLayout.LayoutParams
     layoutParams.height = (binding.mapView.height / 1.75).toInt()
     layoutParams.width = binding.mapView.width / 3

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -231,7 +231,8 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase {
         scaleLongPressSet
       )
     }
-    gesturesManager.rotateGestureDetector.angleThreshold = 3.0f
+    gesturesManager.rotateGestureDetector.angleThreshold = ROTATION_ANGLE_THRESHOLD
+    gesturesManager.shoveGestureDetector.maxShoveAngle = MAX_SHOVE_ANGLE
     this.gesturesManager = gesturesManager
   }
 
@@ -1642,5 +1643,10 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase {
   override fun initialize() {
     initializeGesturesManager(gesturesManager, true)
     initializeGestureListeners(context, true)
+  }
+
+  private companion object {
+    const val ROTATION_ANGLE_THRESHOLD = 3.0f
+    const val MAX_SHOVE_ANGLE = 45.0f
   }
 }

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
@@ -782,6 +782,25 @@ class GesturesPluginTest {
   fun obtainMotionEventActionLater(action: Int): MotionEvent {
     return MotionEvent.obtain(200, 500, action, 15.0f, 10.0f, 0)
   }
+
+  @Test
+  fun verifyDefaultShoveGestureAngle() {
+    verify {
+      gesturesManager.shoveGestureDetector.maxShoveAngle = MAX_SHOVE_ANGLE
+    }
+  }
+
+  @Test
+  fun verifyDefaultRotationAngleThreshold() {
+    verify {
+      gesturesManager.rotateGestureDetector.angleThreshold = ROTATION_ANGLE_THRESHOLD
+    }
+  }
+
+  private companion object {
+    const val ROTATION_ANGLE_THRESHOLD = 3.0f
+    const val MAX_SHOVE_ANGLE = 45.0f
+  }
 }
 
 @RunWith(ParameterizedRobolectricTestRunner::class)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix an issue where shove gesture was not detected when angle between touch points are not horizontal.</changelog>`.

### Summary of changes
Update maximum allowed angle between touch points to qualify it as a shove gesture.

  | Before | After |
  | ----- | ----- |
  | <video src="https://user-images.githubusercontent.com/11589497/142613735-83b9b8c5-4c61-4382-9e37-bb512ca6ca17.mp4" width = 250/> | <video src="https://user-images.githubusercontent.com/11589497/142613750-315b186c-8221-44d4-b28c-432c5bc78fce.mp4" width = 250/> |


### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->