### PR TITLE
[style] Promote persistent style layer APIs to be production-ready.

### DIFF
--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/LayerExt.kt
@@ -3,7 +3,6 @@ package com.mapbox.maps.extension.style.layers
 
 import com.mapbox.common.Logger
 import com.mapbox.maps.LayerPosition
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.StyleManagerInterface
 import com.mapbox.maps.extension.style.StyleContract
 import com.mapbox.maps.extension.style.StyleInterface
@@ -96,8 +95,6 @@ fun StyleInterface.addLayer(layer: StyleContract.StyleLayerExtension) {
 /**
  * Bind the layer to the map controller persistently.
  *
- * Note: This is an experimental API and is a subject to change.
- *
  * Whenever a new style is being parsed and currently used style has persistent layers,
  * an engine will try to do following:
  *   - keep the persistent layer at its relative position
@@ -110,7 +107,6 @@ fun StyleInterface.addLayer(layer: StyleContract.StyleLayerExtension) {
  * @param style The style
  * @param position the position that the current layer is added to
  */
-@MapboxExperimental
 internal fun Layer.bindPersistentlyTo(style: StyleInterface, position: LayerPosition? = null) {
   this.delegate = style
   val expected = style.addPersistentStyleLayer(getCachedLayerProperties(), position)
@@ -121,8 +117,6 @@ internal fun Layer.bindPersistentlyTo(style: StyleInterface, position: LayerPosi
 
 /**
  * Add layer to the style persistently.
- *
- * Note: This is an experimental API and is a subject to change.
  *
  * Whenever a new style is being parsed and currently used style has persistent layers,
  * an engine will try to do following:
@@ -136,7 +130,6 @@ internal fun Layer.bindPersistentlyTo(style: StyleInterface, position: LayerPosi
  * @param layer The layer to be added to the style
  * @param position the position that the current layer is added to
  */
-@MapboxExperimental
 @JvmOverloads
 fun StyleInterface.addPersistentLayer(layer: Layer, position: LayerPosition? = null) {
   layer.bindPersistentlyTo(this, position)
@@ -147,7 +140,6 @@ fun StyleInterface.addPersistentLayer(layer: Layer, position: LayerPosition? = n
  *
  * If true, the layer will be persisted across style changes.
  */
-@MapboxExperimental
 fun Layer.isPersistent(): Boolean? {
   return delegate?.isStyleLayerPersistent(layerId)?.value
 }

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -622,8 +622,6 @@ class Style internal constructor(
   /**
    * Adds a new [style layer](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layers).
    *
-   * Note: This is an experimental API and is a subject to change.
-   *
    * Whenever a new style is being parsed and currently used style has persistent layers,
    * an engine will try to do following:
    *   - keep the persistent layer at its relative position
@@ -638,7 +636,6 @@ class Style internal constructor(
    *
    * @return A string describing an error if the operation was not successful, or empty otherwise.
    */
-  @MapboxExperimental
   override fun addPersistentStyleLayer(
     properties: Value,
     layerPosition: LayerPosition?
@@ -650,8 +647,6 @@ class Style internal constructor(
 
   /**
    * Adds a new [style custom layer](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layers).
-   *
-   * Note: This is an experimental API and is a subject to change.
    *
    * Whenever a new style is being parsed and currently used style has persistent layers,
    * an engine will try to do following:
@@ -668,7 +663,6 @@ class Style internal constructor(
    *
    * @return A string describing an error if the operation was not successful, or empty otherwise.
    */
-  @MapboxExperimental
   override fun addPersistentStyleCustomLayer(
     layerId: String,
     layerHost: CustomLayerHost,
@@ -682,12 +676,9 @@ class Style internal constructor(
   /**
    * Checks if a style layer is persistent.
    *
-   * Note: This is an experimental API and is a subject to change.
-   *
    * @param layerId A style layer identifier.
    * @return A string describing an error if the operation was not successful, boolean representing state otherwise.
    */
-  @MapboxExperimental
   override fun isStyleLayerPersistent(layerId: String): Expected<String, Boolean> {
     return styleManagerRef.call {
       this.isStyleLayerPersistent(layerId)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Promote persistent style layer APIs to be production-ready.</changelog>`.

### Summary of changes

This PR promotes persistent style layer APIs to be production-ready. And removes the `MapboxExperimental` annotation from the related APIs.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->