### PR TITLE
[Doc] Fix geojson doc for listener events

### DIFF
--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -276,7 +276,7 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
    * use main thread to pass this data to gl-native.
    *
    * In order to capture events when actual data is drawn on the map please refer to [Observer] API
-   * and listen to [MapEvents.STYLE_DATA_LOADED] or [MapEvents.MAP_LOADING_ERROR] with `type = source`
+   * and listen to [MapEvents.SOURCE_DATA_LOADED] or [MapEvents.MAP_LOADING_ERROR] with `type = metadata`
    * if data parsing error has occurred.
    *
    * Note: This method is not thread-safe. The Feature is parsed on a worker thread, please make sure
@@ -292,7 +292,7 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
    * use main thread to pass this data to gl-native.
    *
    * In order to capture events when actual data is drawn on the map please refer to [Observer] API
-   * and listen to [MapEvents.STYLE_DATA_LOADED] or [MapEvents.MAP_LOADING_ERROR] with `type = source`
+   * and listen to [MapEvents.SOURCE_DATA_LOADED] or [MapEvents.MAP_LOADING_ERROR] with `type = metadata`
    * if data parsing error has occurred.
    *
    * Note: This method is not thread-safe. The FeatureCollection is parsed on a worker thread, please make sure
@@ -308,7 +308,7 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
    * use main thread to pass this data to gl-native.
    *
    * In order to capture events when actual data is drawn on the map please refer to [Observer] API
-   * and listen to [MapEvents.STYLE_DATA_LOADED] or [MapEvents.MAP_LOADING_ERROR] with `type = source`
+   * and listen to [MapEvents.SOURCE_DATA_LOADED] or [MapEvents.MAP_LOADING_ERROR] with `type = metadata`
    * if data parsing error has occurred.
    *
    * Note: This method is not thread-safe. The Geometry is parsed on a worker thread, please make sure
@@ -762,7 +762,7 @@ fun geoJsonSource(
  * [GeoJsonSource.featureCollection] or [GeoJsonSource.geometry] on the map.
  *
  * In order to capture events when actual data is drawn on the map please refer to [Observer] API
- * and listen to [MapEvents.STYLE_DATA_LOADED] or [MapEvents.MAP_LOADING_ERROR] with `type = source`
+ * and listen to [MapEvents.SOURCE_DATA_LOADED] or [MapEvents.MAP_LOADING_ERROR] with `type = metadata`
  * if data parsing error has occurred.
  */
 fun geoJsonSource(

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/listeners/OnSourceDataLoadedListener.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/listeners/OnSourceDataLoadedListener.kt
@@ -3,7 +3,7 @@ package com.mapbox.maps.plugin.delegates.listeners
 import com.mapbox.maps.extension.observable.eventdata.SourceDataLoadedEventData
 
 /**
- * Definition for listener invoked when the requested style data has been loaded.
+ * Definition for listener invoked when the requested source data has been loaded.
  */
 fun interface OnSourceDataLoadedListener {
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

### Summary of changes
- When applying data to geojson source, we should listen to `SOURCE_DATA_LOADED` events.
### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->