### PR TITLE
revert jcenter to fix ci job

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ buildscript {
     maven {
       url = uri("https://plugins.gradle.org/m2/")
     }
+    jcenter()
   }
   dependencies {
     classpath(Plugins.android)
@@ -43,6 +44,7 @@ allprojects {
     maven {
       url = uri("https://oss.jfrog.org/artifactory/oss-snapshot-local/")
     }
+    jcenter()
   }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ pluginManagement {
   repositories {
     gradlePluginPortal()
     mavenCentral()
+    jcenter()
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please fill out the sections below to complete your submission.

We appreciate your contributions!
-->
PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

### Summary of changes
With dokka version 1.4.10.2, transitive dependencies not present on mavencentral were failing. this pr fixes the ci job issue by adding jcenter to build file.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->