### PR TITLE
[gestures] Use overscroller for fling gestures.

### DIFF
--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesConstants.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesConstants.kt
@@ -80,6 +80,10 @@ internal const val MAX_FLING_PITCH_FACTOR = 300.0
  */
 internal const val MAXIMUM_PITCH = 85.0
 
+internal const val MAXIMUM_FLING_FRICTION = 0.25f
+
+internal const val MINIMUM_FLING_FRICTION = 0.07f
+
 /**
  * Default animation time
  */

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/ContextBinder.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/ContextBinder.kt
@@ -8,8 +8,7 @@ import android.util.AttributeSet
  */
 fun interface ContextBinder {
   /**
-   * Bind the ViewPlugin with current map context. This will create a View that
-   * will be added to the MapView.
+   * Bind the plugin with current map context.
    *
    * @param context The hosting context
    * @param attrs parent attributes

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/ViewBinder.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/ViewBinder.kt
@@ -1,0 +1,15 @@
+package com.mapbox.maps.plugin
+
+import android.widget.FrameLayout
+
+/**
+ * Interface to bind a View and underlying context
+ */
+fun interface ViewBinder {
+  /**
+   * Bind the plugin with current frame layout that contains the map.
+   *
+   * @param view The FrameLayout that contains the map.
+   */
+  fun bind(view: FrameLayout)
+}

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPlugin.kt
@@ -5,6 +5,7 @@ import com.mapbox.android.gestures.AndroidGesturesManager
 import com.mapbox.maps.plugin.ContextBinder
 import com.mapbox.maps.plugin.MapPlugin
 import com.mapbox.maps.plugin.MapSizePlugin
+import com.mapbox.maps.plugin.ViewBinder
 import com.mapbox.maps.plugin.animation.CameraAnimatorOptions
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.gestures.generated.GesturesSettingsInterface
@@ -12,7 +13,7 @@ import com.mapbox.maps.plugin.gestures.generated.GesturesSettingsInterface
 /**
  * Define the interfaces for the Layer plugin.
  */
-interface GesturesPlugin : MapPlugin, ContextBinder, MapSizePlugin, GesturesSettingsInterface {
+interface GesturesPlugin : MapPlugin, ContextBinder, ViewBinder, MapSizePlugin, GesturesSettingsInterface {
 
   /**
    * Called when user touches the screen, all positions are absolute.
@@ -37,6 +38,14 @@ interface GesturesPlugin : MapPlugin, ContextBinder, MapSizePlugin, GesturesSett
    * @return True is the event is handled
    */
   fun onGenericMotionEvent(event: MotionEvent): Boolean
+
+  /**
+   * Called by a parent to request that a child update its values for mScrollX
+   * and mScrollY if necessary. This will typically be done if the child is
+   * animating a scroll using a {@link android.widget.Scroller Scroller}
+   * object.
+   */
+  fun computeScroll()
 
   /**
    * Add a map click listener that is invoked when a map is clicked.

--- a/sdk/src/main/java/com/mapbox/maps/MapControllable.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapControllable.kt
@@ -33,6 +33,14 @@ interface MapControllable : MapboxLifecycleObserver {
   fun onGenericMotionEvent(event: MotionEvent): Boolean
 
   /**
+   * Called by a parent to request that a child update its values for mScrollX
+   * and mScrollY if necessary. This will typically be done if the child is
+   * animating a scroll using a {@link android.widget.Scroller Scroller}
+   * object.
+   */
+  fun computeScroll()
+
+  /**
    * Called when the size has changed.
    *
    * @param w width of the viewport

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -171,6 +171,10 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     return pluginRegistry.onGenericMotionEvent(event)
   }
 
+  override fun computeScroll() {
+    pluginRegistry.computeScroll()
+  }
+
   override fun onSizeChanged(w: Int, h: Int) {
     pluginRegistry.onSizeChanged(w, h)
   }

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -93,6 +93,10 @@ class MapSurface @JvmOverloads constructor(
     return mapController.onGenericMotionEvent(event)
   }
 
+  override fun computeScroll() {
+    mapController.computeScroll()
+  }
+
   /**
    * Called when the size has changed.
    *

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -300,6 +300,17 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   }
 
   /**
+   * Called by a parent to request that a child update its values for mScrollX
+   * and mScrollY if necessary. This will typically be done if the child is
+   * animating a scroll using a {@link android.widget.Scroller Scroller}
+   * object.
+   */
+  override fun computeScroll() {
+    super.computeScroll()
+    mapController.computeScroll()
+  }
+
+  /**
    * Set [OnFpsChangedListener] to get map rendering FPS.
    */
   override fun setOnFpsChangedListener(listener: OnFpsChangedListener) {

--- a/sdk/src/main/java/com/mapbox/maps/plugin/MapPluginRegistry.kt
+++ b/sdk/src/main/java/com/mapbox/maps/plugin/MapPluginRegistry.kt
@@ -71,6 +71,12 @@ internal class MapPluginRegistry(
           viewPlugins[mapPlugin] = pluginView
         }
 
+        if (mapPlugin is ViewBinder) {
+          mapView?.let {
+            mapPlugin.bind(it)
+          }
+        }
+
         if (mapPlugin is ContextBinder) {
           mapPlugin.bind(
             mapInitOptions.context,
@@ -136,6 +142,12 @@ internal class MapPluginRegistry(
       onGenericMotionEventResult = it.onGenericMotionEvent(event) || onGenericMotionEventResult
     }
     return onGenericMotionEventResult
+  }
+
+  fun computeScroll() {
+    gesturePlugins.forEach {
+      it.computeScroll()
+    }
   }
 
   fun onSizeChanged(width: Int, height: Int) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

According to the [Android developer guide](https://developer.android.com/training/gestures/scroll), it's [suggested](https://developer.android.com/training/gestures/scroll#scroll) to use [OverScroller](https://developer.android.com/reference/android/widget/OverScroller) to handle the fling gesture. The [OverScroller](https://android.googlesource.com/platform/frameworks/base/+/jb-release/core/java/android/widget/OverScroller.java) implements some algorithms to calculate the velocity, distance and duration of the fling gesture, and it backs many Android native widgets.

Changes in this PR include:
* Replace our custom deceleration fling animation with the OverScroller provided by Android platform.
* Remove the logic to adjust the deceleration rate according to pitch level.
* Use a simulated touch point (offsetting the start point to 3/4 size of the screen) when calculating the next camera position during fling using drag API. This allows to compensate the larger displacement at high pitch level.

### User impact (optional)

| Before | After |
| ----- | ----- |
| <video src="https://user-images.githubusercontent.com/2764714/144598811-3611f2fb-5a66-423c-be01-9c7ca5aad3db.mp4" width = 250/> | <video src="https://user-images.githubusercontent.com/2764714/144598820-e1cb15d8-33a5-4eb3-a6d1-83803da9981f.mp4" width = 250/> |

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).


