### PR TITLE
Add tile requests delay apis

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/style/TileJsonActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/style/TileJsonActivity.kt
@@ -1,6 +1,8 @@
 package com.mapbox.maps.testapp.examples.style
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -12,8 +14,10 @@ import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.generated.rasterLayer
 import com.mapbox.maps.extension.style.sources.TileSet
 import com.mapbox.maps.extension.style.sources.addSource
+import com.mapbox.maps.extension.style.sources.generated.RasterSource
 import com.mapbox.maps.extension.style.sources.generated.Scheme
 import com.mapbox.maps.extension.style.sources.generated.rasterSource
+import com.mapbox.maps.extension.style.sources.getSourceAs
 import com.mapbox.maps.testapp.R
 
 /**
@@ -65,6 +69,38 @@ class TileJsonActivity : AppCompatActivity() {
     }
   }
 
+  override fun onCreateOptionsMenu(menu: Menu): Boolean {
+    menuInflater.inflate(R.menu.menu_tilejson, menu)
+    return true
+  }
+
+  override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    when (item.itemId) {
+      R.id.menu_set_tile_request_delay -> {
+        item.isChecked = !item.isChecked
+        setTileDelay(TILE_REQUEST, item.isChecked)
+      }
+      R.id.menu_set_tile_network_request_delay -> {
+        item.isChecked = !item.isChecked
+        setTileDelay(NETWORK_REQUEST, item.isChecked)
+      }
+    }
+    return true
+  }
+
+  private fun setTileDelay(requestType: String, isChecked: Boolean = false) {
+    mapboxMap.getStyle {
+      it.getSourceAs<RasterSource>(SOURCE_ID)?.apply {
+        if (requestType == TILE_REQUEST) {
+          tileRequestsDelay(if (isChecked) RASTER_TILE_DELAY else DEFAULT_RASTER_TILE_DELAY)
+        }
+        if (requestType == NETWORK_REQUEST) {
+          tileNetworkRequestsDelay(if (isChecked) RASTER_TILE_DELAY else DEFAULT_RASTER_TILE_DELAY)
+        }
+      }
+    }
+  }
+
   private companion object {
     const val SOURCE_ID = "osm"
     const val LAYER_ID = SOURCE_ID
@@ -77,6 +113,10 @@ class TileJsonActivity : AppCompatActivity() {
     const val TILE_JSON_MIN_ZOOM = 0
     const val TILE_JSON_MAX_ZOOM = 18
 
+    const val RASTER_TILE_DELAY = 2000.0
+    const val DEFAULT_RASTER_TILE_DELAY = 0.0
+    const val TILE_REQUEST = "tile"
+    const val NETWORK_REQUEST = "network"
     const val OSM_RASTER_TILE_URL = "http://tile.openstreetmap.org/{z}/{x}/{y}.png"
     const val RASTER_TILE_SIZE_PIXELS = 256L
 

--- a/app/src/main/res/menu/menu_tilejson.xml
+++ b/app/src/main/res/menu/menu_tilejson.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_set_tile_request_delay"
+        android:checkable="true"
+        android:checked="false"
+        android:title="@string/set_tile_request_delay" />
+    <item
+        android:id="@+id/menu_set_tile_network_request_delay"
+        android:checkable="true"
+        android:checked="false"
+        android:title="@string/set_tile_network_request_delay" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,4 +146,8 @@
 
     <!--View Annotations-->
     <string name="content_description_close">Close callout</string>
+
+    <!-- Tile requests -->
+    <string name="set_tile_request_delay">Set tile request delay to 2 sec</string>
+    <string name="set_tile_network_request_delay">Set tile network delay to 2 sec</string>
 </resources>

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/RasterDemSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/RasterDemSourceTest.kt
@@ -245,6 +245,50 @@ class RasterDemSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
+  fun tileRequestsDelayTest() {
+    val testSource = rasterDemSource(SOURCE_ID) {
+      url(TEST_URI)
+      tileRequestsDelay(1.0)
+    }
+    setupSource(testSource)
+    assertEquals(1.0, testSource.tileRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
+  fun tileRequestsDelayAfterBindTest() {
+    val testSource = rasterDemSource(SOURCE_ID) {
+      url(TEST_URI)
+    }
+    setupSource(testSource)
+    testSource.tileRequestsDelay(1.0)
+    assertEquals(1.0, testSource.tileRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
+  fun tileNetworkRequestsDelayTest() {
+    val testSource = rasterDemSource(SOURCE_ID) {
+      url(TEST_URI)
+      tileNetworkRequestsDelay(1.0)
+    }
+    setupSource(testSource)
+    assertEquals(1.0, testSource.tileNetworkRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
+  fun tileNetworkRequestsDelayAfterBindTest() {
+    val testSource = rasterDemSource(SOURCE_ID) {
+      url(TEST_URI)
+    }
+    setupSource(testSource)
+    testSource.tileNetworkRequestsDelay(1.0)
+    assertEquals(1.0, testSource.tileNetworkRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
   fun tileSetTest() {
     val testSource = rasterDemSource(SOURCE_ID) {
       url(TEST_URI)
@@ -276,6 +320,8 @@ class RasterDemSourceTest : BaseStyleTest() {
     assertNotNull("defaultVolatile should not be null", RasterDemSource.defaultVolatile)
     assertNotNull("defaultPrefetchZoomDelta should not be null", RasterDemSource.defaultPrefetchZoomDelta)
     assertNotNull("defaultMinimumTileUpdateInterval should not be null", RasterDemSource.defaultMinimumTileUpdateInterval)
+    assertNotNull("defaultTileRequestsDelay should not be null", RasterDemSource.defaultTileRequestsDelay)
+    assertNotNull("defaultTileNetworkRequestsDelay should not be null", RasterDemSource.defaultTileNetworkRequestsDelay)
   }
 
   private companion object {

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/RasterSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/RasterSourceTest.kt
@@ -245,6 +245,50 @@ class RasterSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
+  fun tileRequestsDelayTest() {
+    val testSource = rasterSource(SOURCE_ID) {
+      url(TEST_URI)
+      tileRequestsDelay(1.0)
+    }
+    setupSource(testSource)
+    assertEquals(1.0, testSource.tileRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
+  fun tileRequestsDelayAfterBindTest() {
+    val testSource = rasterSource(SOURCE_ID) {
+      url(TEST_URI)
+    }
+    setupSource(testSource)
+    testSource.tileRequestsDelay(1.0)
+    assertEquals(1.0, testSource.tileRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
+  fun tileNetworkRequestsDelayTest() {
+    val testSource = rasterSource(SOURCE_ID) {
+      url(TEST_URI)
+      tileNetworkRequestsDelay(1.0)
+    }
+    setupSource(testSource)
+    assertEquals(1.0, testSource.tileNetworkRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
+  fun tileNetworkRequestsDelayAfterBindTest() {
+    val testSource = rasterSource(SOURCE_ID) {
+      url(TEST_URI)
+    }
+    setupSource(testSource)
+    testSource.tileNetworkRequestsDelay(1.0)
+    assertEquals(1.0, testSource.tileNetworkRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
   fun tileSetTest() {
     val testSource = rasterSource(SOURCE_ID) {
       url(TEST_URI)
@@ -276,6 +320,8 @@ class RasterSourceTest : BaseStyleTest() {
     assertNotNull("defaultVolatile should not be null", RasterSource.defaultVolatile)
     assertNotNull("defaultPrefetchZoomDelta should not be null", RasterSource.defaultPrefetchZoomDelta)
     assertNotNull("defaultMinimumTileUpdateInterval should not be null", RasterSource.defaultMinimumTileUpdateInterval)
+    assertNotNull("defaultTileRequestsDelay should not be null", RasterSource.defaultTileRequestsDelay)
+    assertNotNull("defaultTileNetworkRequestsDelay should not be null", RasterSource.defaultTileNetworkRequestsDelay)
   }
 
   private companion object {

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/VectorSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/VectorSourceTest.kt
@@ -246,6 +246,50 @@ class VectorSourceTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
+  fun tileRequestsDelayTest() {
+    val testSource = vectorSource(SOURCE_ID) {
+      url(TEST_URI)
+      tileRequestsDelay(1.0)
+    }
+    setupSource(testSource)
+    assertEquals(1.0, testSource.tileRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
+  fun tileRequestsDelayAfterBindTest() {
+    val testSource = vectorSource(SOURCE_ID) {
+      url(TEST_URI)
+    }
+    setupSource(testSource)
+    testSource.tileRequestsDelay(1.0)
+    assertEquals(1.0, testSource.tileRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
+  fun tileNetworkRequestsDelayTest() {
+    val testSource = vectorSource(SOURCE_ID) {
+      url(TEST_URI)
+      tileNetworkRequestsDelay(1.0)
+    }
+    setupSource(testSource)
+    assertEquals(1.0, testSource.tileNetworkRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
+  fun tileNetworkRequestsDelayAfterBindTest() {
+    val testSource = vectorSource(SOURCE_ID) {
+      url(TEST_URI)
+    }
+    setupSource(testSource)
+    testSource.tileNetworkRequestsDelay(1.0)
+    assertEquals(1.0, testSource.tileNetworkRequestsDelay)
+  }
+
+  @Test
+  @UiThreadTest
   fun tileSetTest() {
     val testSource = vectorSource(SOURCE_ID) {
       url(TEST_URI)
@@ -277,6 +321,8 @@ class VectorSourceTest : BaseStyleTest() {
     assertNotNull("defaultVolatile should not be null", VectorSource.defaultVolatile)
     assertNotNull("defaultPrefetchZoomDelta should not be null", VectorSource.defaultPrefetchZoomDelta)
     assertNotNull("defaultMinimumTileUpdateInterval should not be null", VectorSource.defaultMinimumTileUpdateInterval)
+    assertNotNull("defaultTileRequestsDelay should not be null", VectorSource.defaultTileRequestsDelay)
+    assertNotNull("defaultTileNetworkRequestsDelay should not be null", VectorSource.defaultTileNetworkRequestsDelay)
   }
 
   private companion object {

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -243,6 +243,52 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("max-overscale-factor-for-parent-tiles")
 
   /**
+   * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+   * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+   * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+   */
+  fun tileRequestsDelay(value: Double = 0.0) = apply {
+    setVolatileProperty(PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value)))
+  }
+
+  /**
+   * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+   * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+   * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+   */
+  val tileRequestsDelay: Double?
+    /**
+     * Get the TileRequestsDelay property
+     *
+     * @return Double
+     */
+    get() = getPropertyValue("tile-requests-delay")
+
+  /**
+   * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+   * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+   * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+   * superseded with tile-requests-delay property value, if both are provided.
+   */
+  fun tileNetworkRequestsDelay(value: Double = 0.0) = apply {
+    setVolatileProperty(PropertyValue("tile-network-requests-delay", TypeUtils.wrapToValue(value)))
+  }
+
+  /**
+   * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+   * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+   * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+   * superseded with tile-requests-delay property value, if both are provided.
+   */
+  val tileNetworkRequestsDelay: Double?
+    /**
+     * Get the TileNetworkRequestsDelay property
+     *
+     * @return Double
+     */
+    get() = getPropertyValue("tile-network-requests-delay")
+
+  /**
    * Builder for RasterDemSource.
    *
    * @param sourceId the ID of the source
@@ -360,6 +406,27 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
+     * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+     * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+     * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+     */
+    fun tileRequestsDelay(value: Double = 0.0) = apply {
+      val propertyValue = PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value))
+      volatileProperties[propertyValue.propertyName] = propertyValue
+    }
+
+    /**
+     * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+     * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+     * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+     * superseded with tile-requests-delay property value, if both are provided.
+     */
+    fun tileNetworkRequestsDelay(value: Double = 0.0) = apply {
+      val propertyValue = PropertyValue("tile-network-requests-delay", TypeUtils.wrapToValue(value))
+      volatileProperties[propertyValue.propertyName] = propertyValue
+    }
+
+    /**
      * Add a TileSet to the Source.
      *
      * @param tileSet
@@ -473,6 +540,33 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
        * @return Double
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "minimum-tile-update-interval").silentUnwrap()
+
+    /**
+     * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+     * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+     * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+     */
+    val defaultTileRequestsDelay: Double?
+      /**
+       * Get the TileRequestsDelay property
+       *
+       * @return Double
+       */
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "tile-requests-delay").silentUnwrap()
+
+    /**
+     * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+     * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+     * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+     * superseded with tile-requests-delay property value, if both are provided.
+     */
+    val defaultTileNetworkRequestsDelay: Double?
+      /**
+       * Get the TileNetworkRequestsDelay property
+       *
+       * @return Double
+       */
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "tile-network-requests-delay").silentUnwrap()
   }
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -243,6 +243,52 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("max-overscale-factor-for-parent-tiles")
 
   /**
+   * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+   * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+   * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+   */
+  fun tileRequestsDelay(value: Double = 0.0) = apply {
+    setVolatileProperty(PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value)))
+  }
+
+  /**
+   * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+   * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+   * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+   */
+  val tileRequestsDelay: Double?
+    /**
+     * Get the TileRequestsDelay property
+     *
+     * @return Double
+     */
+    get() = getPropertyValue("tile-requests-delay")
+
+  /**
+   * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+   * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+   * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+   * superseded with tile-requests-delay property value, if both are provided.
+   */
+  fun tileNetworkRequestsDelay(value: Double = 0.0) = apply {
+    setVolatileProperty(PropertyValue("tile-network-requests-delay", TypeUtils.wrapToValue(value)))
+  }
+
+  /**
+   * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+   * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+   * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+   * superseded with tile-requests-delay property value, if both are provided.
+   */
+  val tileNetworkRequestsDelay: Double?
+    /**
+     * Get the TileNetworkRequestsDelay property
+     *
+     * @return Double
+     */
+    get() = getPropertyValue("tile-network-requests-delay")
+
+  /**
    * Builder for RasterSource.
    *
    * @param sourceId the ID of the source
@@ -360,6 +406,27 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
+     * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+     * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+     * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+     */
+    fun tileRequestsDelay(value: Double = 0.0) = apply {
+      val propertyValue = PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value))
+      volatileProperties[propertyValue.propertyName] = propertyValue
+    }
+
+    /**
+     * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+     * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+     * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+     * superseded with tile-requests-delay property value, if both are provided.
+     */
+    fun tileNetworkRequestsDelay(value: Double = 0.0) = apply {
+      val propertyValue = PropertyValue("tile-network-requests-delay", TypeUtils.wrapToValue(value))
+      volatileProperties[propertyValue.propertyName] = propertyValue
+    }
+
+    /**
      * Add a TileSet to the Source.
      *
      * @param tileSet
@@ -473,6 +540,33 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
        * @return Double
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("raster", "minimum-tile-update-interval").silentUnwrap()
+
+    /**
+     * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+     * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+     * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+     */
+    val defaultTileRequestsDelay: Double?
+      /**
+       * Get the TileRequestsDelay property
+       *
+       * @return Double
+       */
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("raster", "tile-requests-delay").silentUnwrap()
+
+    /**
+     * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+     * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+     * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+     * superseded with tile-requests-delay property value, if both are provided.
+     */
+    val defaultTileNetworkRequestsDelay: Double?
+      /**
+       * Get the TileNetworkRequestsDelay property
+       *
+       * @return Double
+       */
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("raster", "tile-network-requests-delay").silentUnwrap()
   }
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -252,6 +252,52 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     get() = getPropertyValue("max-overscale-factor-for-parent-tiles")
 
   /**
+   * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+   * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+   * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+   */
+  fun tileRequestsDelay(value: Double = 0.0) = apply {
+    setVolatileProperty(PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value)))
+  }
+
+  /**
+   * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+   * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+   * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+   */
+  val tileRequestsDelay: Double?
+    /**
+     * Get the TileRequestsDelay property
+     *
+     * @return Double
+     */
+    get() = getPropertyValue("tile-requests-delay")
+
+  /**
+   * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+   * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+   * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+   * superseded with tile-requests-delay property value, if both are provided.
+   */
+  fun tileNetworkRequestsDelay(value: Double = 0.0) = apply {
+    setVolatileProperty(PropertyValue("tile-network-requests-delay", TypeUtils.wrapToValue(value)))
+  }
+
+  /**
+   * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+   * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+   * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+   * superseded with tile-requests-delay property value, if both are provided.
+   */
+  val tileNetworkRequestsDelay: Double?
+    /**
+     * Get the TileNetworkRequestsDelay property
+     *
+     * @return Double
+     */
+    get() = getPropertyValue("tile-network-requests-delay")
+
+  /**
    * Builder for VectorSource.
    *
    * @param sourceId the ID of the source
@@ -371,6 +417,27 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     }
 
     /**
+     * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+     * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+     * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+     */
+    fun tileRequestsDelay(value: Double = 0.0) = apply {
+      val propertyValue = PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value))
+      volatileProperties[propertyValue.propertyName] = propertyValue
+    }
+
+    /**
+     * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+     * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+     * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+     * superseded with tile-requests-delay property value, if both are provided.
+     */
+    fun tileNetworkRequestsDelay(value: Double = 0.0) = apply {
+      val propertyValue = PropertyValue("tile-network-requests-delay", TypeUtils.wrapToValue(value))
+      volatileProperties[propertyValue.propertyName] = propertyValue
+    }
+
+    /**
      * Add a TileSet to the Source.
      *
      * @param tileSet
@@ -484,6 +551,33 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
        * @return Double
        */
       get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "minimum-tile-update-interval").silentUnwrap()
+
+    /**
+     * For the tiled sources, this property sets the tile requests delay. The given delay comes in
+     * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
+     * of the transient tiles and thus to improve the rendering performance, especially on low-end devices.
+     */
+    val defaultTileRequestsDelay: Double?
+      /**
+       * Get the TileRequestsDelay property
+       *
+       * @return Double
+       */
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "tile-requests-delay").silentUnwrap()
+
+    /**
+     * For the tiled sources, this property sets the tile network requests delay. The given delay comes
+     * in action only during an ongoing animation or gestures. It helps to avoid loading the transient
+     * tiles from the network and thus to avoid redundant network requests. Note that tile-network-requests-delay value is
+     * superseded with tile-requests-delay property value, if both are provided.
+     */
+    val defaultTileNetworkRequestsDelay: Double?
+      /**
+       * Get the TileNetworkRequestsDelay property
+       *
+       * @return Double
+       */
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("vector", "tile-network-requests-delay").silentUnwrap()
   }
 }
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSourceTest.kt
@@ -382,6 +382,68 @@ class RasterDemSourceTest {
   }
 
   @Test
+  fun tileRequestsDelaySet() {
+    val testSource = rasterDemSource("testId") {
+      tileRequestsDelay(1.0)
+    }
+    testSource.bindTo(style)
+
+    verify { style.setStyleSourceProperty("testId", "tile-requests-delay", capture(valueSlot)) }
+    assertEquals("1.0", valueSlot.captured.toString())
+  }
+
+  @Test
+  fun tileRequestsDelaySetAfterBind() {
+    val testSource = rasterDemSource("testId") {}
+    testSource.bindTo(style)
+    testSource.tileRequestsDelay(1.0)
+
+    verify { style.setStyleSourceProperty("testId", "tile-requests-delay", capture(valueSlot)) }
+    assertEquals(valueSlot.captured.toString(), "1.0")
+  }
+
+  @Test
+  fun tileRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+    val testSource = rasterDemSource("testId") {}
+    testSource.bindTo(style)
+
+    assertEquals(1.0.toString(), testSource.tileRequestsDelay?.toString())
+    verify { style.getStyleSourceProperty("testId", "tile-requests-delay") }
+  }
+
+  @Test
+  fun tileNetworkRequestsDelaySet() {
+    val testSource = rasterDemSource("testId") {
+      tileNetworkRequestsDelay(1.0)
+    }
+    testSource.bindTo(style)
+
+    verify { style.setStyleSourceProperty("testId", "tile-network-requests-delay", capture(valueSlot)) }
+    assertEquals("1.0", valueSlot.captured.toString())
+  }
+
+  @Test
+  fun tileNetworkRequestsDelaySetAfterBind() {
+    val testSource = rasterDemSource("testId") {}
+    testSource.bindTo(style)
+    testSource.tileNetworkRequestsDelay(1.0)
+
+    verify { style.setStyleSourceProperty("testId", "tile-network-requests-delay", capture(valueSlot)) }
+    assertEquals(valueSlot.captured.toString(), "1.0")
+  }
+
+  @Test
+  fun tileNetworkRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+    val testSource = rasterDemSource("testId") {}
+    testSource.bindTo(style)
+
+    assertEquals(1.0.toString(), testSource.tileNetworkRequestsDelay?.toString())
+    verify { style.getStyleSourceProperty("testId", "tile-network-requests-delay") }
+  }
+
+  @Test
   fun tileSetTest() {
     val testSource = rasterDemSource("testId") {
       tileSet(
@@ -460,6 +522,22 @@ class RasterDemSourceTest {
 
     assertEquals(1.0.toString(), RasterDemSource.defaultMinimumTileUpdateInterval?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "minimum-tile-update-interval") }
+  }
+
+  @Test
+  fun defaultTileRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+
+    assertEquals(1.0.toString(), RasterDemSource.defaultTileRequestsDelay?.toString())
+    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "tile-requests-delay") }
+  }
+
+  @Test
+  fun defaultTileNetworkRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+
+    assertEquals(1.0.toString(), RasterDemSource.defaultTileNetworkRequestsDelay?.toString())
+    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "tile-network-requests-delay") }
   }
 }
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/RasterSourceTest.kt
@@ -382,6 +382,68 @@ class RasterSourceTest {
   }
 
   @Test
+  fun tileRequestsDelaySet() {
+    val testSource = rasterSource("testId") {
+      tileRequestsDelay(1.0)
+    }
+    testSource.bindTo(style)
+
+    verify { style.setStyleSourceProperty("testId", "tile-requests-delay", capture(valueSlot)) }
+    assertEquals("1.0", valueSlot.captured.toString())
+  }
+
+  @Test
+  fun tileRequestsDelaySetAfterBind() {
+    val testSource = rasterSource("testId") {}
+    testSource.bindTo(style)
+    testSource.tileRequestsDelay(1.0)
+
+    verify { style.setStyleSourceProperty("testId", "tile-requests-delay", capture(valueSlot)) }
+    assertEquals(valueSlot.captured.toString(), "1.0")
+  }
+
+  @Test
+  fun tileRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+    val testSource = rasterSource("testId") {}
+    testSource.bindTo(style)
+
+    assertEquals(1.0.toString(), testSource.tileRequestsDelay?.toString())
+    verify { style.getStyleSourceProperty("testId", "tile-requests-delay") }
+  }
+
+  @Test
+  fun tileNetworkRequestsDelaySet() {
+    val testSource = rasterSource("testId") {
+      tileNetworkRequestsDelay(1.0)
+    }
+    testSource.bindTo(style)
+
+    verify { style.setStyleSourceProperty("testId", "tile-network-requests-delay", capture(valueSlot)) }
+    assertEquals("1.0", valueSlot.captured.toString())
+  }
+
+  @Test
+  fun tileNetworkRequestsDelaySetAfterBind() {
+    val testSource = rasterSource("testId") {}
+    testSource.bindTo(style)
+    testSource.tileNetworkRequestsDelay(1.0)
+
+    verify { style.setStyleSourceProperty("testId", "tile-network-requests-delay", capture(valueSlot)) }
+    assertEquals(valueSlot.captured.toString(), "1.0")
+  }
+
+  @Test
+  fun tileNetworkRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+    val testSource = rasterSource("testId") {}
+    testSource.bindTo(style)
+
+    assertEquals(1.0.toString(), testSource.tileNetworkRequestsDelay?.toString())
+    verify { style.getStyleSourceProperty("testId", "tile-network-requests-delay") }
+  }
+
+  @Test
   fun tileSetTest() {
     val testSource = rasterSource("testId") {
       tileSet(
@@ -460,6 +522,22 @@ class RasterSourceTest {
 
     assertEquals(1.0.toString(), RasterSource.defaultMinimumTileUpdateInterval?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "minimum-tile-update-interval") }
+  }
+
+  @Test
+  fun defaultTileRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+
+    assertEquals(1.0.toString(), RasterSource.defaultTileRequestsDelay?.toString())
+    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "tile-requests-delay") }
+  }
+
+  @Test
+  fun defaultTileNetworkRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+
+    assertEquals(1.0.toString(), RasterSource.defaultTileNetworkRequestsDelay?.toString())
+    verify { StyleManager.getStyleSourcePropertyDefaultValue("raster", "tile-network-requests-delay") }
   }
 }
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/VectorSourceTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/sources/generated/VectorSourceTest.kt
@@ -383,6 +383,68 @@ class VectorSourceTest {
   }
 
   @Test
+  fun tileRequestsDelaySet() {
+    val testSource = vectorSource("testId") {
+      tileRequestsDelay(1.0)
+    }
+    testSource.bindTo(style)
+
+    verify { style.setStyleSourceProperty("testId", "tile-requests-delay", capture(valueSlot)) }
+    assertEquals("1.0", valueSlot.captured.toString())
+  }
+
+  @Test
+  fun tileRequestsDelaySetAfterBind() {
+    val testSource = vectorSource("testId") {}
+    testSource.bindTo(style)
+    testSource.tileRequestsDelay(1.0)
+
+    verify { style.setStyleSourceProperty("testId", "tile-requests-delay", capture(valueSlot)) }
+    assertEquals(valueSlot.captured.toString(), "1.0")
+  }
+
+  @Test
+  fun tileRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+    val testSource = vectorSource("testId") {}
+    testSource.bindTo(style)
+
+    assertEquals(1.0.toString(), testSource.tileRequestsDelay?.toString())
+    verify { style.getStyleSourceProperty("testId", "tile-requests-delay") }
+  }
+
+  @Test
+  fun tileNetworkRequestsDelaySet() {
+    val testSource = vectorSource("testId") {
+      tileNetworkRequestsDelay(1.0)
+    }
+    testSource.bindTo(style)
+
+    verify { style.setStyleSourceProperty("testId", "tile-network-requests-delay", capture(valueSlot)) }
+    assertEquals("1.0", valueSlot.captured.toString())
+  }
+
+  @Test
+  fun tileNetworkRequestsDelaySetAfterBind() {
+    val testSource = vectorSource("testId") {}
+    testSource.bindTo(style)
+    testSource.tileNetworkRequestsDelay(1.0)
+
+    verify { style.setStyleSourceProperty("testId", "tile-network-requests-delay", capture(valueSlot)) }
+    assertEquals(valueSlot.captured.toString(), "1.0")
+  }
+
+  @Test
+  fun tileNetworkRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+    val testSource = vectorSource("testId") {}
+    testSource.bindTo(style)
+
+    assertEquals(1.0.toString(), testSource.tileNetworkRequestsDelay?.toString())
+    verify { style.getStyleSourceProperty("testId", "tile-network-requests-delay") }
+  }
+
+  @Test
   fun tileSetTest() {
     val testSource = vectorSource("testId") {
       tileSet(
@@ -461,6 +523,22 @@ class VectorSourceTest {
 
     assertEquals(1.0.toString(), VectorSource.defaultMinimumTileUpdateInterval?.toString())
     verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "minimum-tile-update-interval") }
+  }
+
+  @Test
+  fun defaultTileRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+
+    assertEquals(1.0.toString(), VectorSource.defaultTileRequestsDelay?.toString())
+    verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "tile-requests-delay") }
+  }
+
+  @Test
+  fun defaultTileNetworkRequestsDelayGet() {
+    every { styleProperty.value } returns TypeUtils.wrapToValue(1.0)
+
+    assertEquals(1.0.toString(), VectorSource.defaultTileNetworkRequestsDelay?.toString())
+    verify { StyleManager.getStyleSourcePropertyDefaultValue("vector", "tile-network-requests-delay") }
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
Introduce `tile-requests-delay` and `tile-network-requests-delay` APIs to set delay in tile requests for vector, raster and raster-dem sources.

The `tile-requests-delay` property:
```
    /**
     * For vector, raster and raster-dem sources, this property sets the tile requests delay.
     *
     * The given delay comes in action only during an ongoing animation or gestures.
     * It helps to avoid loading, parsing and rendering of the "transient" tiles and
     * thus to improve the rendering performance, especially on low-end devices.
     *
     * The delay is represented by a Double value in milliseconds.
     */
```
The `tile-network-requests-delay` property:
```
    /**
     * For vector, raster and raster-dem sources, this property sets the tile network requests delay.
     *
     * The given delay comes in action only during an ongoing animation or gestures.
     * It helps to avoid loading the "transient" tiles from the network and
     * thus to avoid redundant network requests.
     *
     * The delay is represented by a Double value in milliseconds.
     * 
     * Note that "tile-network-requests-delay" value is superseded with "tile-requests-delay" 
     * property value, if both are provided.
     */
```


| Before | After |
| ----- | ----- |
| <video src="https://user-images.githubusercontent.com/11589497/145201247-f6c0ac72-ff8a-43c9-a662-ce55b5b0eb77.mp4" width = 250/> | <video src="https://user-images.githubusercontent.com/11589497/145201304-ab0b97f8-6015-48fe-8356-313d70d6c5bd.mp4" width = 250/> |

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Added "tile-requests-delay" and "tile-network-requests-delay" source properties for tile requests delay.</changelog>`.
 - [x] If this PR is a `v10.3` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.3` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
