### PR TITLE
MapboxRenderer: unsubscribe from RENDER_FRAME_FINISHED after the first event

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -34,11 +34,14 @@ internal abstract class MapboxRenderer : MapClient {
   // when map is rendered fully
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var readyForSnapshot = AtomicBoolean(false)
-  private val observer = Observer { event ->
-    if (event.type == MapEvents.RENDER_FRAME_FINISHED) {
-      val data = event.getRenderFrameFinishedEventData()
-      if (data.renderMode == RenderMode.FULL) {
-        readyForSnapshot.set(true)
+  private val observer = object : Observer {
+    override fun notify(event: Event) {
+      if (event.type == MapEvents.RENDER_FRAME_FINISHED) {
+        val data = event.getRenderFrameFinishedEventData()
+        if (data.renderMode == RenderMode.FULL) {
+          readyForSnapshot.set(true)
+          map?.unsubscribe(this)
+        }
       }
     }
   }


### PR DESCRIPTION
### Summary of changes

Unsubscribe MapboxRenderer from RENDER_FRAME_FINISHED events after readyForSnapshot is set.

It is a minor performance optimization to reduce cpu load on each frame. The change became less important after getRenderFrameFinishedEventData was implemented without json operations but is still relevant.

### User impact (optional)

There is no change in behavior.


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Remove observer after it's not needed anymore from map renderer resulting in slightly better CPU consumption.</changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
