### PR TITLE
Fix leak in view tree observer for view annotations

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
@@ -68,7 +68,8 @@ internal class ViewAnnotationManagerImpl(
 
   override fun removeViewAnnotation(view: View): Boolean {
     val id = idLookupMap.remove(view) ?: return false
-    annotationMap.remove(id) ?: return false
+    val annotation = annotationMap.remove(id) ?: return false
+    annotation.view.removeOnAttachStateChangeListener(annotation.attachStateListener)
     mapView.removeView(view)
     getValue(mapboxMap.removeViewAnnotation(id))
     return true

--- a/sdk/src/main/java/com/mapbox/maps/viewannotation/ViewAnnotation.kt
+++ b/sdk/src/main/java/com/mapbox/maps/viewannotation/ViewAnnotation.kt
@@ -1,7 +1,6 @@
 package com.mapbox.maps.viewannotation
 
 import android.view.View
-import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import com.mapbox.maps.ViewAnnotationOptions
 
@@ -36,11 +35,6 @@ internal data class ViewAnnotation(
    * String id needed to call functions from gl-native
    */
   val id: String = (VIEW_ANNOTATION_CURRENT_ID++).toString()
-
-  /**
-   * Global layout listener to control positioning on the screen based on view's actual visibility.
-   */
-  var globalLayoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
 
   companion object {
     private var VIEW_ANNOTATION_CURRENT_ID = 42

--- a/sdk/src/main/java/com/mapbox/maps/viewannotation/ViewAnnotation.kt
+++ b/sdk/src/main/java/com/mapbox/maps/viewannotation/ViewAnnotation.kt
@@ -10,6 +10,10 @@ internal data class ViewAnnotation(
    */
   val view: View,
   /**
+   * Attach state listener needed to control global layout listener lifecycle.
+   */
+  var attachStateListener: View.OnAttachStateChangeListener? = null,
+  /**
    * We handle visibility automatically in the manager
    * if user did not specify [ViewAnnotationOptions.visible]  explicitly  during add / update operation
    */

--- a/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerTest.kt
@@ -7,9 +7,7 @@ import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
 import com.mapbox.maps.ViewAnnotationManagerImpl.Companion.EXCEPTION_TEXT_ASSOCIATED_FEATURE_ID_ALREADY_EXISTS
 import com.mapbox.maps.viewannotation.viewAnnotationOptions
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.*
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
@@ -36,12 +34,14 @@ class ViewAnnotationManagerTest {
     every { view.visibility } returns View.VISIBLE
     every { view.viewTreeObserver } returns mockk(relaxed = true)
     every { mapView.context } returns mockk()
+    every { view.addOnAttachStateChangeListener(any()) } just Runs
     every { mapboxMap.addViewAnnotation(any(), any()) } returns ExpectedFactory.createNone()
   }
 
   @After
   fun tearDown() {
     every { mapboxMap.removeViewAnnotation(any()) } returns ExpectedFactory.createNone()
+    every { view.removeOnAttachStateChangeListener(any()) } just Runs
     viewAnnotationManager.destroy()
   }
 
@@ -162,6 +162,7 @@ class ViewAnnotationManagerTest {
   @Test
   fun removeViewAnnotationSuccess() {
     every { mapboxMap.removeViewAnnotation(any()) } returns ExpectedFactory.createNone()
+    every { view.removeOnAttachStateChangeListener(any()) } just Runs
     viewAnnotationManager.addViewAnnotation(
       view,
       viewAnnotationOptions {
@@ -172,6 +173,7 @@ class ViewAnnotationManagerTest {
     val removeActualResult = viewAnnotationManager.removeViewAnnotation(view)
     assertEquals(true, removeActualResult)
     assertNull(viewAnnotationManager.idLookupMap[view])
+    verify(exactly = 1) { view.removeOnAttachStateChangeListener(any()) }
     verify(exactly = 1) { mapboxMap.removeViewAnnotation(id!!) }
     verify(exactly = 1) { mapView.removeView(view) }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

When removing single view annotation or actually calling complete destroy wrong ref was used for view tree observer which caused leak in some scenarios (e.g. when using fragments).
Now this is fixed by revisiting an approach to use correct moments of time to register / unregister global layout listener under the hood.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix leak for view annotations caused by global layout listener.</changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: #1020 

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
