### PR TITLE
[viewport] Fix an issue that causes transition not fired when bearing is set to constant.

### DIFF
--- a/plugin-viewport/src/main/kotlin/com/mapbox/maps/plugin/viewport/state/FollowingViewportStateImpl.kt
+++ b/plugin-viewport/src/main/kotlin/com/mapbox/maps/plugin/viewport/state/FollowingViewportStateImpl.kt
@@ -57,7 +57,7 @@ internal class FollowingViewportStateImpl(
   }
 
   private fun notifyLatestViewportData() {
-    if (lastLocation != null && lastBearing != null) {
+    if (lastLocation != null && (options.bearing is FollowingViewportStateBearing.Constant || lastBearing != null)) {
       val viewportData = evaluateViewportData()
       if (isFollowingStateRunning) {
         // Use instant update here since the location updates are already interpolated by the location component plugin


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

This PR fixes an issue that causes transition to following viewport state not being fired when the bearing is set to constant.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fixes an issue that causes transition to following viewport state not being fired when the bearing is set to constant.</changelog>`.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
