### PR TITLE
fix 3d puck scaling issue

### DIFF
--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -148,11 +148,17 @@ internal class LocationPuckManager(
     locationLayerRenderer.hide()
   }
 
+  /**
+   * function to set scaling for [LocationPuck].
+   * In order to keep 3D puck size constant across all zoom levels, we interpolate the model based on
+   * current zoom level. MIN_ZOOM, MAX_ZOOM are used as two anchor points to calculate
+   * the scale expression.
+   */
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal fun styleScaling(settings: LocationComponentSettings) {
     val puck = settings.locationPuck
-    val minZoom = delegateProvider.mapCameraManagerDelegate.getBounds().minZoom
-    val maxZoom = delegateProvider.mapCameraManagerDelegate.getBounds().maxZoom
+    val minZoom = MIN_ZOOM
+    val maxZoom = MAX_ZOOM
     when (puck) {
       is LocationPuck2D -> {
         val scaleExpression = puck.scaleExpression
@@ -202,6 +208,11 @@ internal class LocationPuckManager(
         locationLayerRenderer.styleScaling(scaleExpression)
       }
     }
+  }
+
+  private companion object {
+    const val MIN_ZOOM = 0.50
+    const val MAX_ZOOM = 22.0
   }
 }
 

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -149,7 +149,7 @@ internal class LocationPuckManager(
   }
 
   /**
-   * function to set scaling for [LocationPuck].
+   * Function to set scaling for [LocationPuck].
    * In order to keep 3D puck size constant across all zoom levels, we interpolate the model based on
    * current zoom level. MIN_ZOOM, MAX_ZOOM are used as two anchor points to calculate
    * the scale expression.

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -156,10 +156,7 @@ internal class LocationPuckManager(
    */
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal fun styleScaling(settings: LocationComponentSettings) {
-    val puck = settings.locationPuck
-    val minZoom = MIN_ZOOM
-    val maxZoom = MAX_ZOOM
-    when (puck) {
+    when (val puck = settings.locationPuck) {
       is LocationPuck2D -> {
         val scaleExpression = puck.scaleExpression
         if (scaleExpression != null) {
@@ -167,6 +164,7 @@ internal class LocationPuckManager(
         }
       }
       is LocationPuck3D -> {
+        val modelScaleConstant = 2.0.pow(MAX_ZOOM - MIN_ZOOM)
         val modelScaleExpression = puck.modelScaleExpression
         val scaleExpression = if (modelScaleExpression == null) {
           Value(
@@ -174,20 +172,20 @@ internal class LocationPuckManager(
               Value("interpolate"),
               Value(arrayListOf(Value("exponential"), Value(0.5))),
               Value(arrayListOf(Value("zoom"))),
-              Value(minZoom),
+              Value(MIN_ZOOM),
               Value(
                 arrayListOf(
                   Value("literal"),
                   Value(
                     arrayListOf(
-                      Value(2.0.pow(maxZoom - minZoom) * puck.modelScale[0].toDouble()),
-                      Value(2.0.pow(maxZoom - minZoom) * puck.modelScale[1].toDouble()),
-                      Value(2.0.pow(maxZoom - minZoom) * puck.modelScale[2].toDouble())
+                      Value(modelScaleConstant * puck.modelScale[0].toDouble()),
+                      Value(modelScaleConstant * puck.modelScale[1].toDouble()),
+                      Value(modelScaleConstant * puck.modelScale[2].toDouble())
                     )
                   )
                 )
               ),
-              Value(maxZoom),
+              Value(MAX_ZOOM),
               Value(
                 arrayListOf(
                   Value("literal"),

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -255,8 +255,12 @@ class LocationPuckManagerTest {
     locationPuckManager.styleScaling(settings)
     verify { locationLayerRenderer.styleScaling(capture(valueSlot)) }
     assertEquals(
-      "[interpolate, [exponential, 0.5], [zoom], 0.0, [literal, [1.0, 1.0, 1.0]], 0.0, [literal, [1.0, 1.0, 1.0]]]",
+      "[interpolate, [exponential, 0.5], [zoom], 0.5, [literal, [$MODEL_SCALE_CONSTANT, $MODEL_SCALE_CONSTANT, $MODEL_SCALE_CONSTANT]], 22.0, [literal, [1.0, 1.0, 1.0]]]",
       valueSlot.captured.toString()
     )
+  }
+
+  private companion object {
+    const val MODEL_SCALE_CONSTANT = 2965820.800757861
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
Currently, in order to keep the 3d puck visible across all zoom levels, we use scale expression to calculate the scale according to the current zoom based on two anchor `maxZoom` and `minZoom` from coordinate bounds, the issue is if CoordinateBounds changes, the 3d puck size also change with it. 
this pr fixes this issue using a constant value for `minZoom` and `maxZoom`. Keeping the constants same as before so existing users don't have to scale the puck.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix an issue where 3D puck used to scale when changing coordinate bounds.</changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
