### PR TITLE
V10.3 port: Fix map not rendering on emulators when MSAA is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+# 10.3.0-rc.1 January 26, 2022
+
+## Bug fixes 🐞
+* Fix map not rendering on emulators when MSAA is enabled. ([#1077](https://github.com/mapbox/mapbox-maps-android/pull/1077))
+
 # 10.3.0-beta.1 January 12, 2022
 
 ## Features ✨ and improvements 🏁

--- a/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLConfigChooser.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLConfigChooser.kt
@@ -14,9 +14,9 @@ import javax.microedition.khronos.egl.EGLDisplay
 
 internal class EGLConfigChooser constructor(
   private val translucentSurface: Boolean,
-  private val antialiasingSampleCount: Int,
+  private var antialiasingSampleCount: Int,
 ) {
-  private val antialiasingEnabled = antialiasingSampleCount > DEFAULT_ANTIALIASING_SAMPLE_COUNT
+  private val antialiasingEnabled get() = antialiasingSampleCount > DEFAULT_ANTIALIASING_SAMPLE_COUNT
 
   // Get all configs at least RGB 565 with 16 depth and 8 stencil
   private val configAttributes: IntArray
@@ -57,9 +57,8 @@ internal class EGLConfigChooser constructor(
   private var eglChooserSuccess = true
 
   fun chooseConfig(egl: EGL10, display: EGLDisplay): EGLConfig? {
-    val configAttrs = configAttributes
     // Determine number of possible configurations
-    val numConfigs = getNumberOfConfigurations(egl, display, configAttrs)
+    val numConfigs = getNumberOfConfigurations(egl, display)
     if (!eglChooserSuccess) {
       return null
     }
@@ -71,7 +70,6 @@ internal class EGLConfigChooser constructor(
     val possibleConfigurations = getPossibleConfigurations(
       egl,
       display,
-      configAttrs,
       numConfigs
     )
     if (!eglChooserSuccess) {
@@ -88,28 +86,48 @@ internal class EGLConfigChooser constructor(
 
   private fun getNumberOfConfigurations(
     egl: EGL10,
-    display: EGLDisplay,
-    configAttributes: IntArray
+    display: EGLDisplay
   ): IntArray {
     val numConfigs = IntArray(1)
-    if (!egl.eglChooseConfig(display, configAttributes, null, 0, numConfigs)) {
-      Logger.e(
-        TAG,
-        String.format(
-          MAPBOX_LOCALE,
-          "eglChooseConfig returned error %d",
-          egl.eglGetError()
+    val initialSampleCount = antialiasingSampleCount
+    while (true) {
+      val success = egl.eglChooseConfig(display, configAttributes, null, 0, numConfigs)
+      if (!success || numConfigs[0] < 1) {
+        Logger.e(
+          TAG,
+          String.format(
+            MAPBOX_LOCALE,
+            "eglChooseConfig returned error %d",
+            egl.eglGetError()
+          )
         )
-      )
-      eglChooserSuccess = false
+        if (antialiasingSampleCount > 1) {
+          Logger.w(TAG, "Reducing sample count in 2 times for MSAA as EGL_SAMPLES=$antialiasingSampleCount is not supported")
+          antialiasingSampleCount /= 2
+        } else {
+          // we did all we could, breaking the loop and indicating EGL config was not found
+          Logger.e(TAG, "No suitable EGL configs were found.")
+          eglChooserSuccess = false
+          break
+        }
+      } else {
+        break
+      }
     }
+    if (initialSampleCount != antialiasingSampleCount) {
+      if (antialiasingSampleCount == 1) {
+        Logger.w(TAG, "Found EGL configs only with MSAA disabled.")
+      } else {
+        Logger.w(TAG, "Found EGL configs with MSAA enabled, EGL_SAMPLES=$antialiasingSampleCount.")
+      }
+    }
+    eglChooserSuccess = true
     return numConfigs
   }
 
   private fun getPossibleConfigurations(
     egl: EGL10,
     display: EGLDisplay,
-    configAttributes: IntArray,
     numConfigs: IntArray
   ): Array<EGLConfig> {
     val configs = arrayOfNulls<EGLConfig>(numConfigs[0])
@@ -118,7 +136,7 @@ internal class EGLConfigChooser constructor(
         TAG,
         String.format(
           MAPBOX_LOCALE,
-          "eglChooseConfig() returned error %d",
+          "Weird: eglChooseConfig() returned error %d although ran fine before.",
           egl.eglGetError()
         )
       )

--- a/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLConfigChooser.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLConfigChooser.kt
@@ -90,7 +90,8 @@ internal class EGLConfigChooser constructor(
   ): IntArray {
     val numConfigs = IntArray(1)
     val initialSampleCount = antialiasingSampleCount
-    while (true) {
+    var suitableConfigsFound = false
+    while (!suitableConfigsFound) {
       val success = egl.eglChooseConfig(display, configAttributes, null, 0, numConfigs)
       if (!success || numConfigs[0] < 1) {
         Logger.e(
@@ -105,13 +106,14 @@ internal class EGLConfigChooser constructor(
           Logger.w(TAG, "Reducing sample count in 2 times for MSAA as EGL_SAMPLES=$antialiasingSampleCount is not supported")
           antialiasingSampleCount /= 2
         } else {
-          // we did all we could, breaking the loop and indicating EGL config was not found
+          // we did all we could, return error
           Logger.e(TAG, "No suitable EGL configs were found.")
+          numConfigs[0] = 0
           eglChooserSuccess = false
-          break
+          return numConfigs
         }
       } else {
-        break
+        suitableConfigsFound = true
       }
     }
     if (initialSampleCount != antialiasingSampleCount) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

At least Google simulators seem not to support MSAA option when configuring EGL. This will result in map not being rendered at all. Now logic is introduced to try double down `EGL_SAMPLE` value in a loop until either supported MSAA config will be found (fixing an issue of map not being rendered even on physical device when setting huge MSAA value) or EGL will be configured without MSAA (fixing an issue with emulators).

Port for https://github.com/mapbox/mapbox-maps-android/pull/1077

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix map not rendering on emulators when MSAA is enabled.</changelog>`.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
