### PR TITLE
Fix issue with map rendering when limiting max FPS

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -174,6 +174,9 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     val currentTimeNs = SystemClock.elapsedRealtimeNanos()
     val expectedEndRenderTimeNs = currentTimeNs + renderTimeNsCopy
     if (expectedVsyncWakeTimeNs > currentTimeNs) {
+      // when we have FPS limited and desire to skip core render - we must schedule new draw call
+      // otherwise map may remain in not fully loaded state
+      postPrepareRenderFrame()
       return
     }
     mapboxRenderer.onDrawFrame()

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -465,4 +465,17 @@ class MapboxRenderThreadTest {
       eglCore.swapBuffers(any())
     }
   }
+
+  @Test
+  fun renderWithMaxFpsSet() {
+    mockValidSurface()
+    mapboxRenderThread.setMaximumFps(15)
+    Shadows.shadowOf(renderHandlerThread.handler?.looper).pause()
+    mapboxRenderThread.requestRender()
+    Shadows.shadowOf(renderHandlerThread.handler?.looper).idle()
+    // 1 swap when creating surface + 1 for request render call
+    verify(exactly = 2) {
+      eglCore.swapBuffers(any())
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

When limiting rendering FPS with `MapView#setMaxFps(fps)` last render call will be skipped leading to map state being inconsistent (not all tiles are loaded, not all labels are placed, layers are not added to the map).

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix issue with map rendering when limiting max FPS.</changelog>`.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: https://github.com/mapbox/mapbox-maps-android/issues/1098
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/1097
Fixes: https://github.com/mapbox/mapbox-maps-android/issues/1099

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
