### PR TITLE
Split callbacks originating on getStyle and loadStyle requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Bug fixes 🐞
 * Fix skipping / crashing user events scheduled on a render thread with `MapView#queueEvent`. ([#1068](https://github.com/mapbox/mapbox-maps-android/pull/1068))
+* Fix location puck not being shown if map is created without initial style (e.g. MapInitOptions.styleUri == null) and then loaded asynchronously. ([#1114](https://github.com/mapbox/mapbox-maps-android/pull/1114))
 * Fix crash within location plugin that happens when style is reloaded simultaneously with location plugin updates. ([#1112](https://github.com/mapbox/mapbox-maps-android/pull/1112))
 
 # 10.3.0 February 7, 2022

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapStyleStateDelegate.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/delegates/MapStyleStateDelegate.kt
@@ -8,5 +8,11 @@ fun interface MapStyleStateDelegate {
   /**
    * Returns if the style has fully loaded.
    */
+  @Deprecated(
+    "Use getStyle()?.isStyleLoaded instead.",
+    replaceWith = ReplaceWith(
+      "getStyle()?.isStyleLoaded",
+    )
+  )
   fun isFullyLoaded(): Boolean
 }

--- a/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
@@ -69,7 +69,7 @@ class StyleLoadTest {
       }
     }
     countDownLatch.await(10, TimeUnit.SECONDS)
-    Assert.assertEquals(1, styleLoadedCount)
+    Assert.assertEquals(2, styleLoadedCount)
   }
 
   @Test

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -67,7 +67,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       mapInitOptions,
       renderer,
     )
-    this.nativeObserver = NativeObserver(WeakReference(nativeMap as ObservableInterface))
+    this.nativeObserver = NativeObserver(WeakReference(nativeMap))
     this.mapboxMap =
       MapProvider.getMapboxMap(WeakReference(nativeMap), nativeObserver, mapInitOptions.mapOptions.pixelRatio)
     this.mapboxMap.renderHandler = renderer.renderThread.renderHandlerThread.handler

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -1333,6 +1333,12 @@ class MapboxMap internal constructor(
   /**
    * Returns if the style has been fully loaded.
    */
+  @Deprecated(
+    "Use getStyle()?.isStyleLoaded instead.",
+    replaceWith = ReplaceWith(
+      "getStyle()?.isStyleLoaded",
+    )
+  )
   override fun isFullyLoaded(): Boolean {
     return style?.isStyleLoaded ?: false
   }

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -37,7 +37,7 @@ import java.util.*
  * @property style the map style.
  */
 class MapboxMap internal constructor(
-  internal val nativeMapWeakRef: WeakReference<MapInterface>,
+  private val nativeMapWeakRef: WeakReference<MapInterface>,
   private val nativeObserver: NativeObserver,
   pixelRatio: Float
 ) : MapTransformDelegate,
@@ -49,11 +49,15 @@ class MapboxMap internal constructor(
   MapCameraManagerDelegate,
   MapStyleStateDelegate {
 
-  internal lateinit var style: Style
+  internal var style: Style? = null
   internal var isStyleLoadInitiated = false
-  private val styleObserver = StyleObserver(this, nativeObserver, pixelRatio)
+  private val styleObserver = StyleObserver(
+    nativeMapWeakRef,
+    { style -> this.style = style },
+    nativeObserver,
+    pixelRatio
+  )
   internal var renderHandler: Handler? = null
-  internal var styleLoaded = false
 
   /**
    * Represents current camera state.
@@ -102,9 +106,9 @@ class MapboxMap internal constructor(
   ) {
     initializeStyleLoad(onStyleLoaded, onMapLoadErrorListener)
     if (styleUri.isEmpty()) {
-      nativeMapWeakRef.call { (this as StyleManagerInterface).styleJSON = EMPTY_STYLE_JSON }
+      nativeMapWeakRef.call { styleJSON = EMPTY_STYLE_JSON }
     } else {
-      nativeMapWeakRef.call { (this as StyleManagerInterface).styleURI = styleUri }
+      nativeMapWeakRef.call { styleURI = styleUri }
     }
   }
 
@@ -138,7 +142,7 @@ class MapboxMap internal constructor(
   ) {
     initializeStyleLoad(onStyleLoaded, onMapLoadErrorListener)
     nativeMapWeakRef.call {
-      (this as StyleManagerInterface).styleJSON = styleJson
+      styleJSON = styleJson
     }
   }
 
@@ -214,16 +218,12 @@ class MapboxMap internal constructor(
     onStyleLoaded: Style.OnStyleLoaded? = null,
     onMapLoadErrorListener: OnMapLoadErrorListener? = null
   ) {
-    // clear listeners from previous invocation
-    styleObserver.onNewStyleLoad(
-      {
-        styleLoaded = true
-        onStyleLoaded?.onStyleLoaded(it)
-      },
+    style = null
+    styleObserver.setLoadStyleListener(
+      onStyleLoaded,
       onMapLoadErrorListener
     )
     isStyleLoadInitiated = true
-    styleLoaded = false
   }
 
   /**
@@ -232,29 +232,15 @@ class MapboxMap internal constructor(
    * @param onStyleLoaded the callback to be invoked when the style is fully loaded
    */
   fun getStyle(onStyleLoaded: Style.OnStyleLoaded) {
-    if (::style.isInitialized) {
-      if (styleLoaded) {
-        // style has loaded, notify callback immediately
-        onStyleLoaded.onStyleLoaded(style)
-      } else {
-        // style load is occurring now, add callback
-        styleObserver.addOnStyleLoadListener(onStyleLoaded)
-      }
-    } else {
-      // no style has loaded yet, add callback
-      styleObserver.addOnStyleLoadListener(onStyleLoaded)
-    }
+    style?.let(onStyleLoaded::onStyleLoaded)
+      ?: styleObserver.addGetStyleListener(onStyleLoaded)
   }
 
   /**
    * Get the Style of the map synchronously, will return null is style is not loaded yet.
    */
   fun getStyle(): Style? {
-    if (::style.isInitialized && styleLoaded) {
-      // style has loaded, return it immediately
-      return style
-    }
-    return null
+    return style
   }
 
   /**
@@ -1348,7 +1334,7 @@ class MapboxMap internal constructor(
    * Returns if the style has been fully loaded.
    */
   override fun isFullyLoaded(): Boolean {
-    return style.isStyleLoaded
+    return style?.isStyleLoaded ?: false
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -13,13 +13,18 @@ import java.util.concurrent.CopyOnWriteArrayList
  * and maintains and invokes user added listeners.
  */
 internal class StyleObserver(
-  private val mapboxMap: MapboxMap,
+  private val nativeMapWeakRef: WeakReference<MapInterface>,
+  private val styleLoadedListener: Style.OnStyleLoaded,
   private val nativeObserver: NativeObserver,
   private val pixelRatio: Float
 ) : OnStyleLoadedListener, OnMapLoadErrorListener {
 
-  private val awaitingStyleLoadListeners = CopyOnWriteArrayList<Style.OnStyleLoaded>()
-  private var awaitingStyleErrorListener: OnMapLoadErrorListener? = null
+  @Volatile
+  private var loadStyleListener : Style.OnStyleLoaded? = null
+  @Volatile
+  private var loadStyleErrorListener: OnMapLoadErrorListener? = null
+
+  private val getStyleListeners = CopyOnWriteArrayList<Style.OnStyleLoaded>()
 
   init {
     nativeObserver.addOnStyleLoadedListener(this)
@@ -27,37 +32,41 @@ internal class StyleObserver(
   }
 
   /**
-   * Clears previous added listeners and setup to receive callback for new style loaded or error events.
+   * Set a style listener coming from loadStyle request.
+   * Overwrites listener from previous loadStyle request.
+   * NOTE : listener is invoked only once after successful style load.
    */
-  fun onNewStyleLoad(
+  fun setLoadStyleListener(
     loadedListener: Style.OnStyleLoaded?,
     onMapLoadErrorListener: OnMapLoadErrorListener?
   ) {
-    awaitingStyleLoadListeners.clear()
-    loadedListener?.let {
-      awaitingStyleLoadListeners.add(loadedListener)
-    }
-    awaitingStyleErrorListener = onMapLoadErrorListener
+    loadStyleListener = loadedListener
+    loadStyleErrorListener = onMapLoadErrorListener
   }
 
   /**
-   * Add a style listener invoked when a new style loaded events occurs.
+   * Add a style listener coming from getStyle requests.
+   * NOTE : listener is invoked only once after successful style load.
    */
-  fun addOnStyleLoadListener(loadedListener: Style.OnStyleLoaded) {
-    awaitingStyleLoadListeners.add(loadedListener)
+  fun addGetStyleListener(loadedListener: Style.OnStyleLoaded) {
+    getStyleListeners.add(loadedListener)
   }
 
   /**
    * Invoked when a style has loaded
    */
   override fun onStyleLoaded(eventData: StyleLoadedEventData) {
-    mapboxMap.nativeMapWeakRef.get()?.let {
-      mapboxMap.style = Style(WeakReference(it as StyleManagerInterface), pixelRatio)
-      val iterator = awaitingStyleLoadListeners.iterator()
-      while (iterator.hasNext()) {
-        iterator.next().onStyleLoaded(mapboxMap.style)
+    nativeMapWeakRef.get()?.let {
+      val style = Style(WeakReference(it), pixelRatio)
+      styleLoadedListener.onStyleLoaded(style)
+
+      loadStyleListener?.onStyleLoaded(style)
+      loadStyleListener = null
+
+      getStyleListeners.forEach { listener ->
+        listener.onStyleLoaded(style)
       }
-      awaitingStyleLoadListeners.clear()
+      getStyleListeners.clear()
     }
   }
 
@@ -66,12 +75,13 @@ internal class StyleObserver(
       TAG,
       "OnMapLoadError: ${eventData.type}, message: ${eventData.message}, sourceID: ${eventData.sourceId}, tileID: ${eventData.tileId}"
     )
-    awaitingStyleErrorListener?.onMapLoadError(eventData)
+    loadStyleErrorListener?.onMapLoadError(eventData)
   }
 
   fun onDestroy() {
-    awaitingStyleLoadListeners.clear()
-    awaitingStyleErrorListener = null
+    loadStyleListener = null
+    loadStyleErrorListener = null
+    getStyleListeners.clear()
     nativeObserver.removeOnMapLoadErrorListener(this)
     nativeObserver.removeOnStyleLoadedListener(this)
   }

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -19,9 +19,7 @@ internal class StyleObserver(
   private val pixelRatio: Float
 ) : OnStyleLoadedListener, OnMapLoadErrorListener {
 
-  @Volatile
   private var loadStyleListener: Style.OnStyleLoaded? = null
-  @Volatile
   private var loadStyleErrorListener: OnMapLoadErrorListener? = null
 
   private val getStyleListeners = CopyOnWriteArrayList<Style.OnStyleLoaded>()

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -20,7 +20,7 @@ internal class StyleObserver(
 ) : OnStyleLoadedListener, OnMapLoadErrorListener {
 
   @Volatile
-  private var loadStyleListener : Style.OnStyleLoaded? = null
+  private var loadStyleListener: Style.OnStyleLoaded? = null
   @Volatile
   private var loadStyleErrorListener: OnMapLoadErrorListener? = null
 

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -159,7 +159,6 @@ class MapboxMapTest {
   fun getStyleLoadedCallback() {
     val style = mockk<Style>()
     mapboxMap.style = style
-    mapboxMap.styleLoaded = true
     val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     mapboxMap.getStyle(styleLoadCallback)
     verify { styleLoadCallback.onStyleLoaded(style) }
@@ -169,16 +168,7 @@ class MapboxMapTest {
   fun getStyleSynchronously() {
     val style = mockk<Style>()
     mapboxMap.style = style
-    mapboxMap.styleLoaded = true
     assertNotNull(mapboxMap.getStyle())
-  }
-
-  @Test
-  fun getStyleSynchronouslyNull() {
-    val style = mockk<Style>()
-    mapboxMap.style = style
-    mapboxMap.styleLoaded = false
-    assertNull(mapboxMap.getStyle())
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -47,7 +47,7 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val styleLoaded = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.onNewStyleLoad(styleLoaded, null)
+    styleObserver.setLoadStyleListener(styleLoaded, null)
     styleObserver.onStyleLoaded(mockk())
     verify { styleLoaded.onStyleLoaded(any()) }
   }
@@ -63,9 +63,9 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val styleLoaded = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.onNewStyleLoad(styleLoaded, null)
+    styleObserver.setLoadStyleListener(styleLoaded, null)
     val styleLoaded2 = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.addOnStyleLoadListener(styleLoaded2)
+    styleObserver.addGetStyleListener(styleLoaded2)
     styleObserver.onStyleLoaded(mockk())
     verify { styleLoaded.onStyleLoaded(any()) }
     verify { styleLoaded2.onStyleLoaded(any()) }
@@ -82,9 +82,9 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val styleLoadedFail = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.onNewStyleLoad(styleLoadedFail, null)
+    styleObserver.setLoadStyleListener(styleLoadedFail, null)
     val styleLoadedSucces = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.onNewStyleLoad(styleLoadedSucces, null)
+    styleObserver.setLoadStyleListener(styleLoadedSucces, null)
     styleObserver.onStyleLoaded(mockk())
     verify(exactly = 0) { styleLoadedFail.onStyleLoaded(any()) }
     verify { styleLoadedSucces.onStyleLoaded(any()) }
@@ -97,7 +97,7 @@ class StyleObserverTest {
   fun onStyleLoadError() {
     val styleObserver = StyleObserver(mockk(relaxed = true), mockk(relaxed = true), 1.0f)
     val errorListener = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.onNewStyleLoad(mockk(relaxed = true), errorListener)
+    styleObserver.setLoadStyleListener(mockk(relaxed = true), errorListener)
     styleObserver.onMapLoadError(mockk(relaxed = true))
     verify { errorListener.onMapLoadError(any()) }
   }
@@ -109,9 +109,9 @@ class StyleObserverTest {
   fun onStyleLoadErrorNotCalled() {
     val styleObserver = StyleObserver(mockk(relaxed = true), mockk(relaxed = true), 1.0f)
     val errorListenerFail = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.onNewStyleLoad(mockk(relaxed = true), errorListenerFail)
+    styleObserver.setLoadStyleListener(mockk(relaxed = true), errorListenerFail)
     val errorListenerSuccess = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.onNewStyleLoad(mockk(relaxed = true), errorListenerSuccess)
+    styleObserver.setLoadStyleListener(mockk(relaxed = true), errorListenerSuccess)
     styleObserver.onMapLoadError(mockk(relaxed = true))
     verify(exactly = 0) { errorListenerFail.onMapLoadError(any()) }
     verify { errorListenerSuccess.onMapLoadError(any()) }

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -20,7 +20,7 @@ class StyleObserverTest {
   @Test
   fun onStyleObserverCreate() {
     val nativeObserver = mockk<NativeObserver>(relaxed = true)
-    StyleObserver(mockk(), nativeObserver, 1.0f)
+    StyleObserver(mockk(), mockk(relaxed = true), nativeObserver, 1.0f)
     verify { nativeObserver.addOnStyleLoadedListener(any()) }
     verify { nativeObserver.addOnMapLoadErrorListener(any()) }
   }
@@ -31,7 +31,7 @@ class StyleObserverTest {
   @Test
   fun onStyleObserverDestroy() {
     val nativeObserver = mockk<NativeObserver>(relaxed = true)
-    StyleObserver(mockk(), nativeObserver, 1.0f).onDestroy()
+    StyleObserver(mockk(), mockk(relaxed = true), nativeObserver, 1.0f).onDestroy()
     verify { nativeObserver.removeOnStyleLoadedListener(any()) }
     verify { nativeObserver.removeOnMapLoadErrorListener(any()) }
   }
@@ -41,8 +41,10 @@ class StyleObserverTest {
    */
   @Test
   fun onStyleLoadSuccess() {
+    val mainStyleLoadedListener = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleObserver = StyleObserver(
-      mapboxMap = MapboxMap(WeakReference(mockk(relaxed = true)), mockk(relaxed = true), 1.0f),
+      nativeMapWeakRef = WeakReference(mockk(relaxed = true)),
+      styleLoadedListener = mainStyleLoadedListener,
       nativeObserver = mockk(relaxed = true),
       pixelRatio = 1.0f
     )
@@ -50,6 +52,7 @@ class StyleObserverTest {
     styleObserver.setLoadStyleListener(styleLoaded, null)
     styleObserver.onStyleLoaded(mockk())
     verify { styleLoaded.onStyleLoaded(any()) }
+    verify { mainStyleLoadedListener.onStyleLoaded(any()) }
   }
 
   /**
@@ -58,36 +61,41 @@ class StyleObserverTest {
   @Test
   fun onStyleLoadSuccessMulti() {
     val styleObserver = StyleObserver(
-      mapboxMap = MapboxMap(WeakReference(mockk(relaxed = true)), mockk(relaxed = true), 1.0f),
+      nativeMapWeakRef = WeakReference(mockk(relaxed = true)),
+      styleLoadedListener = mockk(relaxed = true),
       nativeObserver = mockk(relaxed = true),
       pixelRatio = 1.0f
     )
-    val styleLoaded = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(styleLoaded, null)
-    val styleLoaded2 = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.addGetStyleListener(styleLoaded2)
+    val loadStyleListener = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.setLoadStyleListener(loadStyleListener, null)
+    val getStyleListener = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.addGetStyleListener(getStyleListener)
+    val getStyleListener2 = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.addGetStyleListener(getStyleListener2)
     styleObserver.onStyleLoaded(mockk())
-    verify { styleLoaded.onStyleLoaded(any()) }
-    verify { styleLoaded2.onStyleLoaded(any()) }
+    verify { loadStyleListener.onStyleLoaded(any()) }
+    verify { getStyleListener.onStyleLoaded(any()) }
+    verify { getStyleListener2.onStyleLoaded(any()) }
   }
 
   /**
-   * Verifies if the user provided OnStyleLoaded is not called called when a new style has been loaded
+   * Verifies that loadStyle callback is overwritten with the consecutive call
    */
   @Test
-  fun onStyleLoadSuccessNotCalled() {
+  fun onStyleLoadedOverwritten() {
     val styleObserver = StyleObserver(
-      mapboxMap = MapboxMap(WeakReference(mockk(relaxed = true)), mockk(relaxed = true), 1.0f),
+      nativeMapWeakRef = WeakReference(mockk(relaxed = true)),
+      styleLoadedListener = mockk(relaxed = true),
       nativeObserver = mockk(relaxed = true),
       pixelRatio = 1.0f
     )
     val styleLoadedFail = mockk<Style.OnStyleLoaded>(relaxed = true)
     styleObserver.setLoadStyleListener(styleLoadedFail, null)
-    val styleLoadedSucces = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(styleLoadedSucces, null)
+    val styleLoadedSuccess = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.setLoadStyleListener(styleLoadedSuccess, null)
     styleObserver.onStyleLoaded(mockk())
     verify(exactly = 0) { styleLoadedFail.onStyleLoaded(any()) }
-    verify { styleLoadedSucces.onStyleLoaded(any()) }
+    verify { styleLoadedSuccess.onStyleLoaded(any()) }
   }
 
   /**
@@ -95,7 +103,12 @@ class StyleObserverTest {
    */
   @Test
   fun onStyleLoadError() {
-    val styleObserver = StyleObserver(mockk(relaxed = true), mockk(relaxed = true), 1.0f)
+    val styleObserver = StyleObserver(
+      nativeMapWeakRef = WeakReference(mockk(relaxed = true)),
+      styleLoadedListener = mockk(relaxed = true),
+      nativeObserver = mockk(relaxed = true),
+      pixelRatio = 1.0f
+    )
     val errorListener = mockk<OnMapLoadErrorListener>(relaxed = true)
     styleObserver.setLoadStyleListener(mockk(relaxed = true), errorListener)
     styleObserver.onMapLoadError(mockk(relaxed = true))
@@ -103,11 +116,16 @@ class StyleObserverTest {
   }
 
   /**
-   * Verifies if the user provided OnMapLoadListener is not called when a secondary style load occurs
+   * Verifies that loadStyle error callback is overwritten with the consecutive call
    */
   @Test
   fun onStyleLoadErrorNotCalled() {
-    val styleObserver = StyleObserver(mockk(relaxed = true), mockk(relaxed = true), 1.0f)
+    val styleObserver = StyleObserver(
+      nativeMapWeakRef = WeakReference(mockk(relaxed = true)),
+      styleLoadedListener = mockk(relaxed = true),
+      nativeObserver = mockk(relaxed = true),
+      pixelRatio = 1.0f
+    )
     val errorListenerFail = mockk<OnMapLoadErrorListener>(relaxed = true)
     styleObserver.setLoadStyleListener(mockk(relaxed = true), errorListenerFail)
     val errorListenerSuccess = mockk<OnMapLoadErrorListener>(relaxed = true)


### PR DESCRIPTION
### Summary of changes

Problem this PR addresses : location puck is not displayed after style load #321, #1048.

Background context  : at #300 the logic that clears `style loaded` callbacks added with `mapboxMap.getStyle` / `mapboxMap.loadStyle` was introduced. 

However, for the `getStyle` the behaviour doesn't feel right. `getStyle` name doesn't suggest that it depends on the specific `loadStyle` call, instead it would be natural to return ANY style whenever it is loaded.

Existing `getStyle` implementation also leads to the issues (mentioned above) with our own LocationComponent. If location component was triggered before style load was started (possible if `MapInitOptions.styleUri = null` or style fails to load), it needs style and waits for it to appear at `getStyle` (in couple places, e.g. [here](https://github.com/mapbox/mapbox-maps-android/blob/main/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt#L157) and [here](https://github.com/mapbox/mapbox-maps-android/blob/main/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt#L94). When new style is loaded afterwards - this callbacks of location component are being cleared so it's never initialized, if not triggered manually again after style loaded.

I've changed behaviour of `mapboxMap.getStyle` callbacks, now they are not cleared anymore after the `loadStyle` call, while callbacks `loadStyle` retain current behaviour.

### User impact (optional)
Aside from fixing bugs with location puck - when user calls `mapboxMap.getStyle` they will receive style from the first style that is loaded successfully in future. 

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Fix location component now shown in certain cases.</changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: #321, #1048

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
