### PR TITLE
[ci] add support for invoking internal CI with a datetime

### DIFF
--- a/scripts/ci-circleci-start-pipeline.py
+++ b/scripts/ci-circleci-start-pipeline.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import requests
 import sys
+import datetime
 
 MAIN_BRANCH_NAME = "main"
 
@@ -53,6 +54,7 @@ def Main():
             help="Build a specific branch, otherwise it will build the default branch.")
     parser.add_argument("--current-branch",
             help="Current branch name.")
+    parser.add_argument('--created', help="Provide a date string in ISO 8601 format (eg. 2030-12-30T09:10:20.304050)")
 
     args = parser.parse_args()
 
@@ -60,11 +62,16 @@ def Main():
         print("CircleCI token not set. Use --token or set CIRCLE_API_TOKEN.")
         sys.exit(1)
 
+    created = args.created
+    if not created:
+        created = datetime.datetime.utcnow().isoformat()
+
     params = {
         "mapbox_android_upstream": True,
         "mapbox_slug": args.origin_slug,
         "mapbox_android_hash": args.hash,
-        "mapbox_merge_main": args.current_branch == MAIN_BRANCH_NAME
+        "mapbox_merge_main": args.current_branch == MAIN_BRANCH_NAME,
+        "benchmark_date": created
     }
 
     TriggerPipeline(args.target_slug, args.token, args.branch, params)


### PR DESCRIPTION
### Summary of changes
This PR allows to invoke internal CI with datetime to have more granular control over the generated datapoints (unlocks retroactively capturing data). 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
