### PR TITLE
Fix bearing of the puck being reset on settings change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ mapView.location2.puckBearingEnabled = false
 * Avoid possible crash at program exit caused by dummy tracer accessed after the destruction. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Fix crash for the case when a map event is handled by an Observer of a destructed map. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Fix shimmering artifact when pitched raster tiles with compressed textures are rendered. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
-* Fix bearing of the puck resetted on settings change. ([#1112](https://github.com/mapbox/mapbox-maps-android/pull/1144))
+* Fix bearing of the puck reseted on settings change. ([#1144](https://github.com/mapbox/mapbox-maps-android/pull/1144))
 
 ## Dependencies
 * Bump gl-native to 10.4.0-beta.1, mapbox-common to v21.2.0-beta.1 ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ mapView.location2.puckBearingEnabled = false
 * Avoid possible crash at program exit caused by dummy tracer accessed after the destruction. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Fix crash for the case when a map event is handled by an Observer of a destructed map. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Fix shimmering artifact when pitched raster tiles with compressed textures are rendered. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
+* Fix bearing of the puck resetted on settings change. ([#1112](https://github.com/mapbox/mapbox-maps-android/pull/1144))
 
 ## Dependencies
 * Bump gl-native to 10.4.0-beta.1, mapbox-common to v21.2.0-beta.1 ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapper.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapper.kt
@@ -8,6 +8,7 @@ internal class LocationIndicatorLayerWrapper(layerId: String) : LocationLayerWra
     layerProperties["id"] = Value(layerId)
     layerProperties["type"] = Value("location-indicator")
     layerProperties["location-transition"] = buildTransition(delay = 0, duration = 0)
+    layerProperties["bearing-transition"] = buildTransition(delay = 0, duration = 0)
     layerProperties["perspective-compensation"] = Value(0.9)
     layerProperties["image-pitch-displacement"] = Value(4.0)
   }

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -61,11 +61,11 @@ internal class LocationPuckManager(
       animationManager.setLocationLayerRenderer(locationLayerRenderer)
       animationManager.applyPulsingAnimationSettings(settings)
       animationManager.applySettings2(settings2)
-      locationLayerRenderer.addLayers(positionManager)
       lastLocation?.let {
         updateCurrentPosition(it)
       }
       updateCurrentBearing(lastBearing)
+      locationLayerRenderer.addLayers(positionManager)
       locationLayerRenderer.initializeComponents(style)
       styleScaling(settings)
       if (lastLocation != null && settings.enabled) {

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapperTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapperTest.kt
@@ -36,7 +36,7 @@ class LocationIndicatorLayerWrapperTest {
   @Test
   fun testInitialProperties() {
     val value = layer.toValue()
-    assertEquals("{image-pitch-displacement=4.0, location-transition={duration=0, delay=0}, perspective-compensation=0.9, id=indicatorLayerId, type=location-indicator}", value.toString())
+    assertEquals("{bearing-transition={duration=0, delay=0}, image-pitch-displacement=4.0, location-transition={duration=0, delay=0}, perspective-compensation=0.9, id=indicatorLayerId, type=location-indicator}", value.toString())
   }
 
   @Test

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -22,7 +22,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.math.abs
 
-
 @RunWith(RobolectricTestRunner::class)
 class LocationPuckManagerTest {
 
@@ -265,8 +264,6 @@ class LocationPuckManagerTest {
         assert(absoluteDifference < 2 * maxUlp)
       }
   }
-
-
 
   @Test
   fun testDoesntInitialiseIfRendererInitialised() {

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -14,20 +14,14 @@ import com.mapbox.maps.plugin.locationcomponent.animators.PuckAnimatorManager
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings2
 import com.mapbox.maps.util.captureVararg
-import io.mockk.CapturingSlot
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.verify
-import io.mockk.verifyOrder
-import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import io.mockk.*
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.math.abs
+
 
 @RunWith(RobolectricTestRunner::class)
 class LocationPuckManagerTest {
@@ -257,11 +251,22 @@ class LocationPuckManagerTest {
     every { Value.fromJson(any()) } returns ExpectedFactory.createValue(Value("expression"))
     locationPuckManager.styleScaling(settings)
     verify { locationLayerRenderer.styleScaling(capture(valueSlot)) }
-    assertEquals(
-      "[interpolate, [exponential, 0.5], [zoom], 0.5, [literal, [$MODEL_SCALE_CONSTANT, $MODEL_SCALE_CONSTANT, $MODEL_SCALE_CONSTANT]], 22.0, [literal, [1.0, 1.0, 1.0]]]",
-      valueSlot.captured.toString()
-    )
+    val value = valueSlot.captured.toString()
+    assertTrue(value.startsWith("[interpolate, [exponential, 0.5], [zoom], 0.5, [literal, ["))
+    assertTrue(value.endsWith("]], 22.0, [literal, [1.0, 1.0, 1.0]]]"))
+    value
+      .replace("[interpolate, [exponential, 0.5], [zoom], 0.5, [literal, [", "")
+      .replace("]], 22.0, [literal, [1.0, 1.0, 1.0]]]", "")
+      .split(", ")
+      .map { it.toDouble() }
+      .forEach {
+        val absoluteDifference: Float = abs(it - MODEL_SCALE_CONSTANT).toFloat()
+        val maxUlp = Math.ulp(it).coerceAtLeast(Math.ulp(MODEL_SCALE_CONSTANT)).toFloat()
+        assert(absoluteDifference < 2 * maxUlp)
+      }
   }
+
+
 
   @Test
   fun testDoesntInitialiseIfRendererInitialised() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

The fix resolves the issue with puck bearing, that can jump to zero on when location component settings are changed. The wrong animation looks in the following way : 

https://user-images.githubusercontent.com/2265924/143263474-a9588dc7-9327-4518-917b-103ffaac44ee.mp4

There are two issues causing such behaviour. 
First - we add layer on the map _before_ applying current bearing value. Renderer, which is running in parallel on the background thread, may (and sometimes does) actually run rendering before bearing is applied, thus jumping to the default (0) bearing. 
Second - `bearing-transition` property is not set and defaults to animating during 300 milliseconds. I'm not actually sure about this one since after the first fix it seems not necessary, but iOS for example resets this to zero https://github.com/mapbox/mapbox-maps-ios/blob/9f0e9605b081e45dce808a53f70b5eb0747858ab/Sources/MapboxMaps/Location/Puck/Puck2D.swift#L129. Seems it is some sort of outdated bearing animation in GL native that is not used since we do animations on platforms directly. @mapbox/maps-android please advice here

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
