### PR TITLE
Add map function to apply style transition during style load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ mapView.location2.puckBearingEnabled = false
 * Enable tile packs for DEM terrain tiles, it includes both Offline API and `TileStoreUsageMode::ReadAndUpdate` resource option. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Render tiles with partial content while the glyph dependencies are loading. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Canonicalize URLs and enable Offline API usage for the 3dtiles/v1 tiles. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
-* Add overloaded `MapboxMap.loadStyleUri`, `MapboxMap.loadStyleJson`, `MapboxMap.loadStyle` with `TransitionOptions` parameter allowing to apply transition style being loaded. ([#1174](https://github.com/mapbox/mapbox-maps-android/pull/1174))
+* Add optional `TransitionOptions` parameter to `MapboxMap.loadStyleUri`, `MapboxMap.loadStyleJson`, `MapboxMap.loadStyle` to apply transition to style being loaded. ([#1174](https://github.com/mapbox/mapbox-maps-android/pull/1174))
 
 ## Bug fixes 🐞
 * Fix skipping / crashing user events scheduled on a render thread with `MapView#queueEvent`. ([#1068](https://github.com/mapbox/mapbox-maps-android/pull/1068))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ mapView.location2.puckBearingEnabled = false
 * Enable tile packs for DEM terrain tiles, it includes both Offline API and `TileStoreUsageMode::ReadAndUpdate` resource option. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Render tiles with partial content while the glyph dependencies are loading. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Canonicalize URLs and enable Offline API usage for the 3dtiles/v1 tiles. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
-* Add `MapboxMap.setStyleTransition` function and deprecate `Style.setStyleTransition` fixing style transition options not being applied. ([#1174](https://github.com/mapbox/mapbox-maps-android/pull/1174))
+* Add `MapboxMap.setStyleTransition` / `MapboxMap.getStyleTransition` function and deprecate `Style.setStyleTransition` / `Style.getStyleTransition` fixing style transition options not being applied. ([#1174](https://github.com/mapbox/mapbox-maps-android/pull/1174))
 
 ## Bug fixes 🐞
 * Fix skipping / crashing user events scheduled on a render thread with `MapView#queueEvent`. ([#1068](https://github.com/mapbox/mapbox-maps-android/pull/1068))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ mapView.location2.puckBearingEnabled = false
 * Enable tile packs for DEM terrain tiles, it includes both Offline API and `TileStoreUsageMode::ReadAndUpdate` resource option. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Render tiles with partial content while the glyph dependencies are loading. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Canonicalize URLs and enable Offline API usage for the 3dtiles/v1 tiles. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
+* Add `MapboxMap.setStyleTransition` function and deprecate `Style.setStyleTransition` fixing style transition options not being applied. ([#1174](https://github.com/mapbox/mapbox-maps-android/pull/1174))
 
 ## Bug fixes 🐞
 * Fix skipping / crashing user events scheduled on a render thread with `MapView#queueEvent`. ([#1068](https://github.com/mapbox/mapbox-maps-android/pull/1068))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ mapView.location2.puckBearingEnabled = false
 * Enable tile packs for DEM terrain tiles, it includes both Offline API and `TileStoreUsageMode::ReadAndUpdate` resource option. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Render tiles with partial content while the glyph dependencies are loading. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
 * Canonicalize URLs and enable Offline API usage for the 3dtiles/v1 tiles. ([#1160](https://github.com/mapbox/mapbox-maps-android/pull/1160))
-* Add `MapboxMap.setStyleTransition` / `MapboxMap.getStyleTransition` function and deprecate `Style.setStyleTransition` / `Style.getStyleTransition` fixing style transition options not being applied. ([#1174](https://github.com/mapbox/mapbox-maps-android/pull/1174))
+* Add overloaded `MapboxMap.loadStyleUri`, `MapboxMap.loadStyleJson`, `MapboxMap.loadStyle` with `TransitionOptions` parameter allowing to apply transition style being loaded. ([#1174](https://github.com/mapbox/mapbox-maps-android/pull/1174))
 
 ## Bug fixes 🐞
 * Fix skipping / crashing user events scheduled on a render thread with `MapView#queueEvent`. ([#1068](https://github.com/mapbox/mapbox-maps-android/pull/1068))

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/CircleLayerClusteringActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/CircleLayerClusteringActivity.kt
@@ -35,35 +35,34 @@ class CircleLayerClusteringActivity : AppCompatActivity() {
 
     // Disable any type of fading transition when icons collide on the map. This enhances the visual
     // look of the data clustering together and breaking apart.
-    mapboxMap.setStyleTransition(
-      TransitionOptions.Builder()
+    mapboxMap.loadStyleUri(
+      styleUri = Style.LIGHT,
+      styleTransitionOptions = TransitionOptions.Builder()
         .duration(0)
         .delay(0)
         .enablePlacementTransitions(false)
-        .build()
-    )
-    mapboxMap.loadStyleUri(
-      Style.LIGHT
-    ) {
-      mapboxMap.flyTo(
-        CameraOptions.Builder()
-          .center(Point.fromLngLat(-79.045, 12.099))
-          .zoom(3.0)
-          .build()
-      )
+        .build(),
+      onStyleLoaded = {
+        mapboxMap.flyTo(
+          CameraOptions.Builder()
+            .center(Point.fromLngLat(-79.045, 12.099))
+            .zoom(3.0)
+            .build()
+        )
 
-      addClusteredGeoJsonSource(it)
+        addClusteredGeoJsonSource(it)
 
-      bitmapFromDrawableRes(this, R.drawable.ic_cross)?.let { bitmap ->
-        it.addImage(CROSS_ICON_ID, bitmap, true)
+        bitmapFromDrawableRes(this, R.drawable.ic_cross)?.let { bitmap ->
+          it.addImage(CROSS_ICON_ID, bitmap, true)
+        }
+
+        Toast.makeText(
+          this@CircleLayerClusteringActivity,
+          R.string.zoom_map_in_and_out_instruction,
+          Toast.LENGTH_SHORT
+        ).show()
       }
-
-      Toast.makeText(
-        this@CircleLayerClusteringActivity,
-        R.string.zoom_map_in_and_out_instruction,
-        Toast.LENGTH_SHORT
-      ).show()
-    }
+    )
   }
 
   private fun addClusteredGeoJsonSource(style: Style) {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/CircleLayerClusteringActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/CircleLayerClusteringActivity.kt
@@ -33,17 +33,18 @@ class CircleLayerClusteringActivity : AppCompatActivity() {
     setContentView(mapView)
     val mapboxMap = mapView.getMapboxMap()
 
-    mapboxMap.loadStyleUri(
-      Style.LIGHT
-    ) {
-      // Disable any type of fading transition when icons collide on the map. This enhances the visual
-      // look of the data clustering together and breaking apart.
-      it.styleTransition = TransitionOptions.Builder()
+    // Disable any type of fading transition when icons collide on the map. This enhances the visual
+    // look of the data clustering together and breaking apart.
+    mapboxMap.setStyleTransition(
+      TransitionOptions.Builder()
         .duration(0)
         .delay(0)
         .enablePlacementTransitions(false)
         .build()
-
+    )
+    mapboxMap.loadStyleUri(
+      Style.LIGHT
+    ) {
       mapboxMap.flyTo(
         CameraOptions.Builder()
           .center(Point.fromLngLat(-79.045, 12.099))

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/CircleLayerClusteringActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/CircleLayerClusteringActivity.kt
@@ -33,10 +33,10 @@ class CircleLayerClusteringActivity : AppCompatActivity() {
     setContentView(mapView)
     val mapboxMap = mapView.getMapboxMap()
 
-    // Disable any type of fading transition when icons collide on the map. This enhances the visual
-    // look of the data clustering together and breaking apart.
     mapboxMap.loadStyleUri(
       styleUri = Style.LIGHT,
+      // Disable any type of fading transition when icons collide on the map. This enhances the visual
+      // look of the data clustering together and breaking apart.
       styleTransitionOptions = TransitionOptions.Builder()
         .duration(0)
         .delay(0)

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/JavaInterfaceChecker.java
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/JavaInterfaceChecker.java
@@ -48,6 +48,7 @@ import com.mapbox.maps.ScreenCoordinate;
 import com.mapbox.maps.SnapshotOverlayOptions;
 import com.mapbox.maps.Snapshotter;
 import com.mapbox.maps.Style;
+import com.mapbox.maps.TransitionOptions;
 import com.mapbox.maps.extension.style.StyleContract;
 import com.mapbox.maps.extension.style.StyleInterface;
 import com.mapbox.maps.extension.style.expressions.generated.Expression;
@@ -347,12 +348,15 @@ public class JavaInterfaceChecker {
         mapboxMap.loadStyleUri(Style.MAPBOX_STREETS);
         mapboxMap.loadStyleUri(Style.MAPBOX_STREETS, onStyleLoaded);
         mapboxMap.loadStyleUri(Style.MAPBOX_STREETS, onStyleLoaded, onMapLoadErrorListener);
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS, new TransitionOptions.Builder().build(), onStyleLoaded, onMapLoadErrorListener);
         mapboxMap.loadStyleJson("json");
         mapboxMap.loadStyleJson("json", onStyleLoaded);
         mapboxMap.loadStyleJson("json", onStyleLoaded, onMapLoadErrorListener);
+        mapboxMap.loadStyleJson("json", new TransitionOptions.Builder().build(), onStyleLoaded, onMapLoadErrorListener);
         mapboxMap.loadStyle(styleExtension);
         mapboxMap.loadStyle(styleExtension, onStyleLoaded);
         mapboxMap.loadStyle(styleExtension, onStyleLoaded, onMapLoadErrorListener);
+        mapboxMap.loadStyle(styleExtension, new TransitionOptions.Builder().build(), onStyleLoaded, onMapLoadErrorListener);
     }
 
     private void mapInitOptionsOverloads(Context context,

--- a/extension-androidauto/src/test/java/com/mapbox/maps/extension/androidauto/CarMapSurfaceCallbackTest.kt
+++ b/extension-androidauto/src/test/java/com/mapbox/maps/extension/androidauto/CarMapSurfaceCallbackTest.kt
@@ -68,7 +68,7 @@ class CarMapSurfaceCallbackTest {
   @Test
   fun `onSurfaceAvailable should notify surfaceAvailable when style is loaded`() {
     every { testMapSurface.getMapboxMap() } returns mockk(relaxed = true) {
-      every { loadStyleUri(any(), any(), any()) } answers {
+      every { loadStyleUri(any(), onStyleLoaded = any(), any()) } answers {
         secondArg<Style.OnStyleLoaded>().onStyleLoaded(mockk())
       }
     }

--- a/sdk/api/sdk.api
+++ b/sdk/api/sdk.api
@@ -202,24 +202,27 @@ public final class com/mapbox/maps/MapboxMap : com/mapbox/maps/ObservableInterfa
 	public fun getSize ()Lcom/mapbox/maps/Size;
 	public final fun getStyle ()Lcom/mapbox/maps/Style;
 	public final fun getStyle (Lcom/mapbox/maps/Style$OnStyleLoaded;)V
-	public final fun getStyleTransition ()Lcom/mapbox/maps/TransitionOptions;
-	public final fun getStyleTransition (Z)Lcom/mapbox/maps/TransitionOptions;
-	public static synthetic fun getStyleTransition$default (Lcom/mapbox/maps/MapboxMap;ZILjava/lang/Object;)Lcom/mapbox/maps/TransitionOptions;
 	public fun isFullyLoaded ()Z
 	public fun isGestureInProgress ()Z
 	public fun isUserAnimationInProgress ()Z
 	public final fun loadStyle (Lcom/mapbox/maps/extension/style/StyleContract$StyleExtension;)V
 	public final fun loadStyle (Lcom/mapbox/maps/extension/style/StyleContract$StyleExtension;Lcom/mapbox/maps/Style$OnStyleLoaded;)V
 	public final fun loadStyle (Lcom/mapbox/maps/extension/style/StyleContract$StyleExtension;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;)V
+	public final fun loadStyle (Lcom/mapbox/maps/extension/style/StyleContract$StyleExtension;Lcom/mapbox/maps/TransitionOptions;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;)V
 	public static synthetic fun loadStyle$default (Lcom/mapbox/maps/MapboxMap;Lcom/mapbox/maps/extension/style/StyleContract$StyleExtension;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;ILjava/lang/Object;)V
+	public static synthetic fun loadStyle$default (Lcom/mapbox/maps/MapboxMap;Lcom/mapbox/maps/extension/style/StyleContract$StyleExtension;Lcom/mapbox/maps/TransitionOptions;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;ILjava/lang/Object;)V
 	public final fun loadStyleJson (Ljava/lang/String;)V
 	public final fun loadStyleJson (Ljava/lang/String;Lcom/mapbox/maps/Style$OnStyleLoaded;)V
 	public final fun loadStyleJson (Ljava/lang/String;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;)V
+	public final fun loadStyleJson (Ljava/lang/String;Lcom/mapbox/maps/TransitionOptions;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;)V
 	public static synthetic fun loadStyleJson$default (Lcom/mapbox/maps/MapboxMap;Ljava/lang/String;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;ILjava/lang/Object;)V
+	public static synthetic fun loadStyleJson$default (Lcom/mapbox/maps/MapboxMap;Ljava/lang/String;Lcom/mapbox/maps/TransitionOptions;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;ILjava/lang/Object;)V
 	public final fun loadStyleUri (Ljava/lang/String;)V
 	public final fun loadStyleUri (Ljava/lang/String;Lcom/mapbox/maps/Style$OnStyleLoaded;)V
 	public final fun loadStyleUri (Ljava/lang/String;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;)V
+	public final fun loadStyleUri (Ljava/lang/String;Lcom/mapbox/maps/TransitionOptions;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;)V
 	public static synthetic fun loadStyleUri$default (Lcom/mapbox/maps/MapboxMap;Ljava/lang/String;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;ILjava/lang/Object;)V
+	public static synthetic fun loadStyleUri$default (Lcom/mapbox/maps/MapboxMap;Ljava/lang/String;Lcom/mapbox/maps/TransitionOptions;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;ILjava/lang/Object;)V
 	public fun pixelForCoordinate (Lcom/mapbox/geojson/Point;)Lcom/mapbox/maps/ScreenCoordinate;
 	public fun pixelsForCoordinates (Ljava/util/List;)Ljava/util/List;
 	public fun project (Lcom/mapbox/geojson/Point;D)Lcom/mapbox/maps/MercatorCoordinate;
@@ -262,9 +265,6 @@ public final class com/mapbox/maps/MapboxMap : com/mapbox/maps/ObservableInterfa
 	public fun setNorthOrientation (Lcom/mapbox/maps/NorthOrientation;)V
 	public final fun setPrefetchZoomDelta (B)V
 	public final fun setRenderCacheOptions (Lcom/mapbox/maps/RenderCacheOptions;)V
-	public final fun setStyleTransition (Lcom/mapbox/maps/TransitionOptions;)V
-	public final fun setStyleTransition (Lcom/mapbox/maps/TransitionOptions;Z)V
-	public static synthetic fun setStyleTransition$default (Lcom/mapbox/maps/MapboxMap;Lcom/mapbox/maps/TransitionOptions;ZILjava/lang/Object;)V
 	public fun setUserAnimationInProgress (Z)V
 	public fun setViewportMode (Lcom/mapbox/maps/ViewportMode;)V
 	public fun subscribe (Lcom/mapbox/maps/Observer;Ljava/util/List;)V

--- a/sdk/api/sdk.api
+++ b/sdk/api/sdk.api
@@ -202,6 +202,9 @@ public final class com/mapbox/maps/MapboxMap : com/mapbox/maps/ObservableInterfa
 	public fun getSize ()Lcom/mapbox/maps/Size;
 	public final fun getStyle ()Lcom/mapbox/maps/Style;
 	public final fun getStyle (Lcom/mapbox/maps/Style$OnStyleLoaded;)V
+	public final fun getStyleTransition ()Lcom/mapbox/maps/TransitionOptions;
+	public final fun getStyleTransition (Z)Lcom/mapbox/maps/TransitionOptions;
+	public static synthetic fun getStyleTransition$default (Lcom/mapbox/maps/MapboxMap;ZILjava/lang/Object;)Lcom/mapbox/maps/TransitionOptions;
 	public fun isFullyLoaded ()Z
 	public fun isGestureInProgress ()Z
 	public fun isUserAnimationInProgress ()Z
@@ -260,6 +263,8 @@ public final class com/mapbox/maps/MapboxMap : com/mapbox/maps/ObservableInterfa
 	public final fun setPrefetchZoomDelta (B)V
 	public final fun setRenderCacheOptions (Lcom/mapbox/maps/RenderCacheOptions;)V
 	public final fun setStyleTransition (Lcom/mapbox/maps/TransitionOptions;)V
+	public final fun setStyleTransition (Lcom/mapbox/maps/TransitionOptions;Z)V
+	public static synthetic fun setStyleTransition$default (Lcom/mapbox/maps/MapboxMap;Lcom/mapbox/maps/TransitionOptions;ZILjava/lang/Object;)V
 	public fun setUserAnimationInProgress (Z)V
 	public fun setViewportMode (Lcom/mapbox/maps/ViewportMode;)V
 	public fun subscribe (Lcom/mapbox/maps/Observer;Ljava/util/List;)V

--- a/sdk/api/sdk.api
+++ b/sdk/api/sdk.api
@@ -259,6 +259,7 @@ public final class com/mapbox/maps/MapboxMap : com/mapbox/maps/ObservableInterfa
 	public fun setNorthOrientation (Lcom/mapbox/maps/NorthOrientation;)V
 	public final fun setPrefetchZoomDelta (B)V
 	public final fun setRenderCacheOptions (Lcom/mapbox/maps/RenderCacheOptions;)V
+	public final fun setStyleTransition (Lcom/mapbox/maps/TransitionOptions;)V
 	public fun setUserAnimationInProgress (Z)V
 	public fun setViewportMode (Lcom/mapbox/maps/ViewportMode;)V
 	public fun subscribe (Lcom/mapbox/maps/Observer;Ljava/util/List;)V

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -36,11 +36,8 @@ import java.util.*
  *
  * @property style the map style.
  */
-class MapboxMap internal constructor(
-  private val nativeMapWeakRef: WeakReference<MapInterface>,
-  private val nativeObserver: NativeObserver,
-  pixelRatio: Float
-) : MapTransformDelegate,
+class MapboxMap :
+  MapTransformDelegate,
   MapProjectionDelegate,
   MapFeatureQueryDelegate,
   ObservableInterface,
@@ -49,14 +46,12 @@ class MapboxMap internal constructor(
   MapCameraManagerDelegate,
   MapStyleStateDelegate {
 
+  private val nativeMapWeakRef: WeakReference<MapInterface>
+  private val nativeObserver: NativeObserver
+
   internal var style: Style? = null
   internal var isStyleLoadInitiated = false
-  private val styleObserver = StyleObserver(
-    nativeMapWeakRef,
-    { style -> this.style = style },
-    nativeObserver,
-    pixelRatio
-  )
+  private val styleObserver: StyleObserver
   internal var renderHandler: Handler? = null
 
   /**
@@ -72,6 +67,32 @@ class MapboxMap internal constructor(
   internal var gesturesPlugin: WeakReference<GesturesPlugin>? = null
 
   private var styleTransitionOptions: TransitionOptions? = null
+
+  @VisibleForTesting(otherwise = PRIVATE)
+  internal constructor(
+    nativeMapWeakRef: WeakReference<MapInterface>,
+    nativeObserver: NativeObserver,
+    styleObserver: StyleObserver
+  ) {
+    this.nativeMapWeakRef = nativeMapWeakRef
+    this.nativeObserver = nativeObserver
+    this.styleObserver = styleObserver
+  }
+
+  internal constructor(
+    nativeMapWeakRef: WeakReference<MapInterface>,
+    nativeObserver: NativeObserver,
+    pixelRatio: Float
+  ) {
+    this.nativeMapWeakRef = nativeMapWeakRef
+    this.nativeObserver = nativeObserver
+    this.styleObserver = StyleObserver(
+      nativeMapWeakRef,
+      { style -> this.style = style },
+      nativeObserver,
+      pixelRatio
+    )
+  }
 
   /**
    * Will load a new map style asynchronous from the specified URI.

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -71,6 +71,8 @@ class MapboxMap internal constructor(
   @VisibleForTesting(otherwise = PRIVATE)
   internal var gesturesPlugin: WeakReference<GesturesPlugin>? = null
 
+  private var styleTransitionOptions: TransitionOptions? = null
+
   /**
    * Will load a new map style asynchronous from the specified URI.
    *
@@ -192,6 +194,16 @@ class MapboxMap internal constructor(
   ) = loadStyle(styleExtension, null, null)
 
   /**
+   * Set style transition options that will be applied to all style loads happening after.
+   *
+   * In order to obtain current transition options please use [Style.getStyleTransition]
+   * when style will be loaded.
+   */
+  fun setStyleTransition(transitionOptions: TransitionOptions) {
+    styleTransitionOptions = transitionOptions
+  }
+
+  /**
    * Handle the style loading from Style Extension.
    */
   internal fun onFinishLoadingStyleExtension(
@@ -220,6 +232,7 @@ class MapboxMap internal constructor(
   ) {
     style = null
     styleObserver.setLoadStyleListener(
+      styleTransitionOptions,
       onStyleLoaded,
       onMapLoadErrorListener
     )

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -92,7 +92,7 @@ class Style internal constructor(
    * @param transitionOptions Map style transition options.
    */
   @Deprecated(
-    "Given transition options will not be applied properly, please use another function.",
+    "Transition options will not be applied properly, please use another function.",
     replaceWith = ReplaceWith("mapboxMap.setStyleTransition")
   )
   override fun setStyleTransition(transitionOptions: TransitionOptions) =

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -91,6 +91,10 @@ class Style internal constructor(
    *
    * @param transitionOptions Map style transition options.
    */
+  @Deprecated(
+    "Given transition options will not be applied properly, please use another function.",
+    replaceWith = ReplaceWith("mapboxMap.setStyleTransition")
+  )
   override fun setStyleTransition(transitionOptions: TransitionOptions) =
     styleManagerRef.call { this.styleTransition = transitionOptions }
 

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -89,11 +89,17 @@ class Style internal constructor(
    *
    * The style transition is re-evaluated when a new style is loaded.
    *
+   * Deprecated: please use [MapboxMap.setStyleTransition] before loading style
+   * to apply [transitionOptions] properly.
+   *
    * @param transitionOptions Map style transition options.
    */
   @Deprecated(
-    "Transition options will not be applied properly, please use another function.",
-    replaceWith = ReplaceWith("mapboxMap.setStyleTransition")
+    "Transition options will not always be applied properly " +
+      "as Style instance is returned when style is already loaded.",
+    ReplaceWith(
+      "mapboxMap.setStyleTransition(transitionOptions)"
+    )
   )
   override fun setStyleTransition(transitionOptions: TransitionOptions) =
     styleManagerRef.call { this.styleTransition = transitionOptions }

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -79,16 +79,8 @@ class Style internal constructor(
    *
    * The style transition is re-evaluated when a new style is loaded.
    *
-   * Deprecated: please use [MapboxMap.getStyleTransition].
-   *
    * @return Returns the map style transition options.
    */
-  @Deprecated(
-    "Calling this method does not always produce correct results.",
-    ReplaceWith(
-      "mapboxMap.getStyleTransition()"
-    )
-  )
   override fun getStyleTransition(): TransitionOptions =
     styleManagerRef.call { this.styleTransition }
 
@@ -97,16 +89,8 @@ class Style internal constructor(
    *
    * The style transition is re-evaluated when a new style is loaded.
    *
-   * Deprecated: please use [MapboxMap.setStyleTransition].
-   *
    * @param transitionOptions Map style transition options.
    */
-  @Deprecated(
-    "Calling this method does not always produce correct results.",
-    ReplaceWith(
-      "mapboxMap.setStyleTransition(transitionOptions)"
-    )
-  )
   override fun setStyleTransition(transitionOptions: TransitionOptions) =
     styleManagerRef.call { this.styleTransition = transitionOptions }
 

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -79,8 +79,16 @@ class Style internal constructor(
    *
    * The style transition is re-evaluated when a new style is loaded.
    *
+   * Deprecated: please use [MapboxMap.getStyleTransition].
+   *
    * @return Returns the map style transition options.
    */
+  @Deprecated(
+    "Calling this method does not always produce correct results.",
+    ReplaceWith(
+      "mapboxMap.getStyleTransition()"
+    )
+  )
   override fun getStyleTransition(): TransitionOptions =
     styleManagerRef.call { this.styleTransition }
 
@@ -89,14 +97,12 @@ class Style internal constructor(
    *
    * The style transition is re-evaluated when a new style is loaded.
    *
-   * Deprecated: please use [MapboxMap.setStyleTransition] before loading style
-   * to apply [transitionOptions] properly.
+   * Deprecated: please use [MapboxMap.setStyleTransition].
    *
    * @param transitionOptions Map style transition options.
    */
   @Deprecated(
-    "Transition options will not always be applied properly " +
-      "as Style instance is returned when style is already loaded.",
+    "Calling this method does not always produce correct results.",
     ReplaceWith(
       "mapboxMap.setStyleTransition(transitionOptions)"
     )

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -89,6 +89,8 @@ internal class StyleObserver(
     loadStyleTransitionOptions?.let {
       if (eventData.type == StyleDataType.STYLE) {
         nativeMapWeakRef.get()?.styleTransition = it
+        // per gl-native docs style transition options should be reset for a new style so resetting them here
+        loadStyleTransitionOptions = null
       }
     }
   }

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -84,6 +84,7 @@ internal class StyleObserver(
   }
 
   override fun onStyleDataLoaded(eventData: StyleDataLoadedEventData) {
+    // style data arrives in following order: STYLE, SOURCES, SPRITE
     // transition options must be applied after style but before sprite and sources to take effect
     loadStyleTransitionOptions?.let {
       if (eventData.type == StyleDataType.STYLE) {

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -2,8 +2,11 @@ package com.mapbox.maps
 
 import com.mapbox.common.Logger
 import com.mapbox.maps.extension.observable.eventdata.MapLoadingErrorEventData
+import com.mapbox.maps.extension.observable.eventdata.StyleDataLoadedEventData
 import com.mapbox.maps.extension.observable.eventdata.StyleLoadedEventData
+import com.mapbox.maps.extension.observable.model.StyleDataType
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
+import com.mapbox.maps.plugin.delegates.listeners.OnStyleDataLoadedListener
 import com.mapbox.maps.plugin.delegates.listeners.OnStyleLoadedListener
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
@@ -17,16 +20,18 @@ internal class StyleObserver(
   private val styleLoadedListener: Style.OnStyleLoaded,
   private val nativeObserver: NativeObserver,
   private val pixelRatio: Float
-) : OnStyleLoadedListener, OnMapLoadErrorListener {
+) : OnStyleLoadedListener, OnMapLoadErrorListener, OnStyleDataLoadedListener {
 
   private var loadStyleListener: Style.OnStyleLoaded? = null
   private var loadStyleErrorListener: OnMapLoadErrorListener? = null
+  private var loadStyleTransitionOptions: TransitionOptions? = null
 
   private val getStyleListeners = CopyOnWriteArrayList<Style.OnStyleLoaded>()
 
   init {
     nativeObserver.addOnStyleLoadedListener(this)
     nativeObserver.addOnMapLoadErrorListener(this)
+    nativeObserver.addOnStyleDataLoadedListener(this)
   }
 
   /**
@@ -35,9 +40,11 @@ internal class StyleObserver(
    * NOTE : listener is invoked only once after successful style load.
    */
   fun setLoadStyleListener(
+    transitionOptions: TransitionOptions?,
     loadedListener: Style.OnStyleLoaded?,
     onMapLoadErrorListener: OnMapLoadErrorListener?
   ) {
+    loadStyleTransitionOptions = transitionOptions
     loadStyleListener = loadedListener
     loadStyleErrorListener = onMapLoadErrorListener
   }
@@ -76,12 +83,23 @@ internal class StyleObserver(
     loadStyleErrorListener?.onMapLoadError(eventData)
   }
 
+  override fun onStyleDataLoaded(eventData: StyleDataLoadedEventData) {
+    // transition options must be applied after style but before sprite and sources to take effect
+    loadStyleTransitionOptions?.let {
+      if (eventData.type == StyleDataType.STYLE) {
+        nativeMapWeakRef.get()?.styleTransition = it
+      }
+    }
+  }
+
   fun onDestroy() {
     loadStyleListener = null
     loadStyleErrorListener = null
+    loadStyleTransitionOptions = null
     getStyleListeners.clear()
     nativeObserver.removeOnMapLoadErrorListener(this)
     nativeObserver.removeOnStyleLoadedListener(this)
+    nativeObserver.removeOnStyleDataLoadedListener(this)
   }
 
   companion object {

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -5,6 +5,7 @@ import com.mapbox.bindgen.Value
 import com.mapbox.common.ShadowLogger
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Point
+import com.mapbox.maps.extension.observable.eventdata.MapLoadingErrorEventData
 import com.mapbox.maps.extension.style.StyleContract
 import com.mapbox.maps.extension.style.style
 import com.mapbox.maps.plugin.MapProjection
@@ -1039,10 +1040,16 @@ class MapboxMapTest {
   @Test
   fun setStyleTransition() {
     val options = mockk<TransitionOptions>(relaxed = true)
-    mapboxMap.setStyleTransition(options)
-    mapboxMap.loadStyleUri("style")
+    mapboxMap.loadStyleUri(
+      "style",
+      options,
+      {},
+      object : OnMapLoadErrorListener {
+        override fun onMapLoadError(eventData: MapLoadingErrorEventData) {}
+      }
+    )
     verify(exactly = 1) {
-      styleObserver.setLoadStyleListener(options, null, null)
+      styleObserver.setLoadStyleListener(options, any(), any())
     }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -34,6 +34,7 @@ class MapboxMapTest {
   private val nativeObserver: NativeObserver = mockk(relaxed = true)
   private val resourceOptions = mockk<ResourceOptions>(relaxed = true)
 
+  private lateinit var styleObserver: StyleObserver
   private lateinit var mapboxMap: MapboxMap
 
   @Before
@@ -41,7 +42,8 @@ class MapboxMapTest {
     mockkStatic(Map::class)
     every { Map.clearData(any(), any()) } just runs
     every { nativeMap.resourceOptions } returns resourceOptions
-    mapboxMap = MapboxMap(WeakReference(nativeMap), nativeObserver, 1.0f)
+    styleObserver = mockk(relaxUnitFun = true)
+    mapboxMap = MapboxMap(WeakReference(nativeMap), nativeObserver, styleObserver)
   }
 
   @Test
@@ -1032,5 +1034,15 @@ class MapboxMapTest {
     val memoryBudget = mockk<MapMemoryBudget>()
     mapboxMap.setMemoryBudget(memoryBudget)
     verify { nativeMap.setMemoryBudget(memoryBudget) }
+  }
+
+  @Test
+  fun setStyleTransition() {
+    val options = mockk<TransitionOptions>(relaxed = true)
+    mapboxMap.setStyleTransition(options)
+    mapboxMap.loadStyleUri("style")
+    verify(exactly = 1) {
+      styleObserver.setLoadStyleListener(options, null, null)
+    }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -23,6 +23,7 @@ class StyleObserverTest {
     StyleObserver(mockk(), mockk(relaxed = true), nativeObserver, 1.0f)
     verify { nativeObserver.addOnStyleLoadedListener(any()) }
     verify { nativeObserver.addOnMapLoadErrorListener(any()) }
+    verify { nativeObserver.addOnStyleDataLoadedListener(any()) }
   }
 
   /**
@@ -34,6 +35,7 @@ class StyleObserverTest {
     StyleObserver(mockk(), mockk(relaxed = true), nativeObserver, 1.0f).onDestroy()
     verify { nativeObserver.removeOnStyleLoadedListener(any()) }
     verify { nativeObserver.removeOnMapLoadErrorListener(any()) }
+    verify { nativeObserver.removeOnStyleDataLoadedListener(any()) }
   }
 
   /**
@@ -49,7 +51,7 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val styleLoaded = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(styleLoaded, null)
+    styleObserver.setLoadStyleListener(null, styleLoaded, null)
     styleObserver.onStyleLoaded(mockk())
     verify { styleLoaded.onStyleLoaded(any()) }
     verify { mainStyleLoadedListener.onStyleLoaded(any()) }
@@ -67,7 +69,7 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val loadStyleListener = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(loadStyleListener, null)
+    styleObserver.setLoadStyleListener(null, loadStyleListener, null)
     val getStyleListener = mockk<Style.OnStyleLoaded>(relaxed = true)
     styleObserver.addGetStyleListener(getStyleListener)
     val getStyleListener2 = mockk<Style.OnStyleLoaded>(relaxed = true)
@@ -90,9 +92,9 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val styleLoadedFail = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(styleLoadedFail, null)
+    styleObserver.setLoadStyleListener(null, styleLoadedFail, null)
     val styleLoadedSuccess = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(styleLoadedSuccess, null)
+    styleObserver.setLoadStyleListener(null, styleLoadedSuccess, null)
     styleObserver.onStyleLoaded(mockk())
     verify(exactly = 0) { styleLoadedFail.onStyleLoaded(any()) }
     verify { styleLoadedSuccess.onStyleLoaded(any()) }
@@ -110,7 +112,7 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val errorListener = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.setLoadStyleListener(mockk(relaxed = true), errorListener)
+    styleObserver.setLoadStyleListener(null, mockk(relaxed = true), errorListener)
     styleObserver.onMapLoadError(mockk(relaxed = true))
     verify { errorListener.onMapLoadError(any()) }
   }
@@ -127,9 +129,9 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val errorListenerFail = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.setLoadStyleListener(mockk(relaxed = true), errorListenerFail)
+    styleObserver.setLoadStyleListener(null, mockk(relaxed = true), errorListenerFail)
     val errorListenerSuccess = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.setLoadStyleListener(mockk(relaxed = true), errorListenerSuccess)
+    styleObserver.setLoadStyleListener(null, mockk(relaxed = true), errorListenerSuccess)
     styleObserver.onMapLoadError(mockk(relaxed = true))
     verify(exactly = 0) { errorListenerFail.onMapLoadError(any()) }
     verify { errorListenerSuccess.onMapLoadError(any()) }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Introduce new function `MapboxMap.setStyleTransition` and deprecate `Style.setStyleTransition`. 

Main idea is that we need to apply transition options in the correct moment of time _during_ style is loading while our current API allows to actually operate on `Style` object when style is already fully loaded.

Please take a look at the visuals, what we do there is:
 - load first streets style with following options `TransitionOptions.Builder().duration(0).build()`
 - wait for 2 seconds and load dark style with `TransitionOptions.Builder().duration(5000).delay(3000).build()`

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

Following pseudo-code:
```
loadStyleUri(Style.MAPBOX_STREETS) { firstStyle ->
  firstStyle.styleTransition = TransitionOptions.Builder()
     .duration(0)
     .build()
}
```
should be replaced with:
```

loadStyleUri(
  styleUri = Style.MAPBOX_STREETS,
  styleTransitionOptions = TransitionOptions.Builder()
     .duration(0)
     .build()
)
```

<!--
If this PR introduces user-facing changes, please note them here.
-->

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.

 | Before | After |
 | - | - |
 | <video src="https://user-images.githubusercontent.com/15800566/155156030-3177fcde-8d0f-4473-9c21-aaf91a801bd1.mp4" width = 250/> | <video src="https://user-images.githubusercontent.com/15800566/155156272-675603b1-17dd-44d6-8155-0952dfd91b16.mp4" width = 250/> |
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Run `./gradlew apiDump` to update generated api files, if there's public API changes, otherwise the `verify-kotlin-binary-compatibility` CI will fail.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog>Add overloaded MapboxMap.loadStyleUri, MapboxMap.loadStyleJson, MapboxMap.loadStyle with `TransitionOptions` parameter allowing to apply transition style being loaded.</changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
