### PR TITLE
Fix custom widget metalava incompatibility

### DIFF
--- a/sdk/api/sdk.api
+++ b/sdk/api/sdk.api
@@ -502,7 +502,6 @@ public class com/mapbox/maps/renderer/widget/BitmapWidget : com/mapbox/maps/rend
 }
 
 public abstract class com/mapbox/maps/renderer/widget/Widget {
-	public fun <init> ()V
 	public abstract fun setRotation (F)V
 	public abstract fun setTranslation (FF)V
 }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/widget/Widget.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/widget/Widget.kt
@@ -6,7 +6,7 @@ import com.mapbox.maps.MapboxExperimental
  * Base class for widgets displayed on top of the map.
  */
 @MapboxExperimental
-abstract class Widget {
+abstract class Widget internal constructor() {
   internal abstract val renderer: WidgetRenderer
 
   /**


### PR DESCRIPTION
### Summary of changes
This PR makes constructor internal to indicate more clearly that this class cannot be implemented outside of our module. Previously it was abstract and contained internal property `renderer` thus could not be implemented in the other modules anyways, but it was less explicit and metalava treated this an error. 

A bit of motivation behind `Widget` class being internal and not intended for general use. 
The only way intended for use now is to instantiate or inherit [BitmapWidget](https://github.com/mapbox/mapbox-maps-android/blob/main/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidget.kt), that provides correct [renderer](https://github.com/mapbox/mapbox-maps-android/blob/main/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt) for the Widget. 

There's no point for end user to use Widget class as is, it's error prone and requires understanding of our internal rendering logic.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `./gradlew apiDump` to update generated api files, if there's public API changes, otherwise the `verify-kotlin-binary-compatibility` CI will fail.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [x] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
