### PR TITLE
Metalava dependency fix for M1 Mac

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,16 +50,13 @@ android {
       path = file("src/main/cpp/CMakeLists.txt")
     }
   }
-  dexOptions {
-    javaMaxHeapSize = "4g"
-  }
 
-    packagingOptions {
-      if (buildFromSource.toBoolean()) {
-        jniLibs.pickFirsts.add("**/libc++_shared.so")
-      }
+  packagingOptions {
+    if (buildFromSource.toBoolean()) {
+      jniLibs.pickFirsts.add("**/libc++_shared.so")
     }
   }
+}
 
 dependencies {
   implementation(project(":sdk"))

--- a/gradle/metalava.gradle
+++ b/gradle/metalava.gradle
@@ -6,6 +6,9 @@ dependencies {
     // Metalava isn't released yet. Check in its jar and explicitly track its transitive deps.
     metalava files('../metalava/metalava.jar')
 
+    // this version of JNA fixes issue with warnings on M1
+    metalava "net.java.dev.jna:jna:5.7.0"
+
     metalava "com.android.tools.external.org-jetbrains:uast:27.2.0-alpha11"
     metalava "com.android.tools.external.com-intellij:kotlin-compiler:27.2.0-alpha11"
     metalava "com.android.tools.external.com-intellij:intellij-core:27.2.0-alpha11"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
Currently metalava depends on `net.java.dev.jna:jna:5.6.0` version of jna library. This leads to crashes when running gradle metalava tasks, e.g.

```WARN: Unable to load JNA library (OS: Mac OS X 11.5.1)
java.lang.UnsatisfiedLinkError: /Users/dmitryyunitsky/Library/Caches/JNA/temp/jna13508436608505727653.tmp: dlopen(/Users/dmitryyunitsky/Library/Caches/JNA/temp/jna13508436608505727653.tmp, 1): no suitable image found.  Did find:
        /Users/dmitryyunitsky/Library/Caches/JNA/temp/jna13508436608505727653.tmp: no matching architecture in universal wrapper
        /Users/dmitryyunitsky/Library/Caches/JNA/temp/jna13508436608505727653.tmp: no matching architecture in universal wrapper
        at java.base/java.lang.ClassLoader$NativeLibrary.load0(Native Method)
        at java.base/java.lang.ClassLoader$NativeLibrary.load(ClassLoader.java:2442)
        at java.base/java.lang.ClassLoader$NativeLibrary.loadLibrary(ClassLoader.java:2498)
        at java.base/java.lang.ClassLoader.loadLibrary0(ClassLoader.java:2694)
        at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2627)
        at java.base/java.lang.Runtime.load0(Runtime.java:768)
        at java.base/java.lang.System.load(System.java:1837)
        at com.sun.jna.Native.loadNativeDispatchLibraryFromClasspath(Native.java:1018)
        at com.sun.jna.Native.loadNativeDispatchLibrary(Native.java:988)
        at com.sun.jna.Native.<clinit>(Native.java:195)
        at com.intellij.jna.JnaLoader.load(JnaLoader.java:16)
        at com.intellij.jna.JnaLoader.isLoaded(JnaLoader.java:29)
        at com.intellij.openapi.util.io.FileSystemUtil.getMediator(FileSystemUtil.java:54)
        at com.intellij.openapi.util.io.FileSystemUtil.<clinit>(FileSystemUtil.java:46)
        at com.intellij.openapi.vfs.impl.ZipHandler.setFileAttributes(ZipHandler.java:48)
        at com.intellij.openapi.vfs.impl.ZipHandler$1.createAccessor(ZipHandler.java:30)
        at com.intellij.openapi.vfs.impl.ZipHandler$1.createAccessor(ZipHandler.java:25)
        at com.intellij.util.io.FileAccessorCache.createHandle(FileAccessorCache.java:62)
        at com.intellij.util.io.FileAccessorCache.get(FileAccessorCache.java:55)
        at com.intellij.openapi.vfs.impl.ZipHandler.getCachedZipFileHandle(ZipHandler.java:70)
        at com.intellij.openapi.vfs.impl.ZipHandler.acquireZipHandle(ZipHandler.java:117)
        at com.intellij.openapi.vfs.impl.ZipHandlerBase.createEntriesMap(ZipHandlerBase.java:36)
        at com.intellij.openapi.vfs.impl.ArchiveHandler.getEntriesMap(ArchiveHandler.java:179)
        at com.intellij.openapi.vfs.impl.jar.CoreJarHandler.<init>(CoreJarHandler.java:42)
        at com.intellij.openapi.vfs.impl.jar.CoreJarFileSystem.lambda$new$0(CoreJarFileSystem.java:33)
        at com.intellij.util.containers.ConcurrentFactoryMap$2.create(ConcurrentFactoryMap.java:174)
        at com.intellij.util.containers.ConcurrentFactoryMap.get(ConcurrentFactoryMap.java:40)
        at com.intellij.openapi.vfs.impl.jar.CoreJarFileSystem.findFileByPath(CoreJarFileSystem.java:44)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.findJarRoot(KotlinCoreEnvironment.kt:386)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.contentRootToVirtualFile(KotlinCoreEnvironment.kt:363)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.access$contentRootToVirtualFile(KotlinCoreEnvironment.kt:109)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$3.invoke(KotlinCoreEnvironment.kt:206)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$3.invoke(KotlinCoreEnvironment.kt:109)
        at org.jetbrains.kotlin.cli.jvm.compiler.ClasspathRootsResolver.convertClasspathRoots(ClasspathRootsResolver.kt:70)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.<init>(KotlinCoreEnvironment.kt:213)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.<init>(KotlinCoreEnvironment.kt:109)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.createForProduction(KotlinCoreEnvironment.kt:423)
        at com.android.tools.lint.UastEnvironmentKt.createKotlinCompilerEnv(UastEnvironment.kt:325)
        at com.android.tools.lint.UastEnvironmentKt.access$createKotlinCompilerEnv(UastEnvironment.kt:1)
        at com.android.tools.lint.UastEnvironment$Companion.create(UastEnvironment.kt:165)
        at com.android.tools.metalava.Driver.createProjectEnvironment(Driver.kt:952)
        at com.android.tools.metalava.Driver.parseSources(Driver.kt:901)
        at com.android.tools.metalava.Driver.parseSources$default(Driver.kt:886)
        at com.android.tools.metalava.Driver.loadFromSources(Driver.kt:814)
        at com.android.tools.metalava.Driver.processFlags(Driver.kt:257)
        at com.android.tools.metalava.Driver.run(Driver.kt:115)
        at com.android.tools.metalava.Driver.run$default(Driver.kt:97)
        at com.android.tools.metalava.Driver.main(Driver.kt:83)
```

Updated to jna version 5.7.0 which contains the fix.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-kotlin-binary-compatibility` CI will fail.
 - [ ] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
