### PR TITLE
Reset nativeMap to null in onDestroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 # main
 ## Features ✨ and improvements 🏁
 * Optimize how plugins handle settings changes. Call `applySettings` only when settings value changes. ([#1189](https://github.com/mapbox/mapbox-maps-android/pull/1189))
-* Add new Exception type `MapboxMapMemoryLeakException` which will be thrown when there is a leak for nativeMap. ([1193](https://github.com/mapbox/mapbox-maps-android/pull/1193))
+* Add new exception type `MapboxMapMemoryLeakException` which will be thrown when users still try to invoke functions related with `nativeMap` in `MapboxMap` and `Style`. ([1193](https://github.com/mapbox/mapbox-maps-android/pull/1193)) ([1202](https://github.com/mapbox/mapbox-maps-android/pull/1202))
 
 ## Bug fixes 🐞
 * Fix an issue when user subscribe sdk listeners multiple times, by changing CopyOnWriteArrayList to CopyOnWriteArraySet in the sdk to hold listeners. ([1183](https://github.com/mapbox/mapbox-maps-android/pull/1183))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Mapbox welcomes participation and contributions from everyone.
 # main
 ## Features ✨ and improvements 🏁
 * Optimize how plugins handle settings changes. Call `applySettings` only when settings value changes. ([#1189](https://github.com/mapbox/mapbox-maps-android/pull/1189))
-* Add exception type `MapboxMapMemoryLeakException` which will be thrown when users try to invoke functions related with `nativeMap` in `MapboxMap` and `Style`. Automatically unsubscribe all observers in MapboxMap when `MapboxMap.onDestroy()` is invoked. ([1193](https://github.com/mapbox/mapbox-maps-android/pull/1193)) ([1202](https://github.com/mapbox/mapbox-maps-android/pull/1202))
+* Add exception type `MapboxMapMemoryLeakException` which will be thrown when users try to invoke functions related with `nativeMap` in `MapboxMap` and `Style` after onDestroy.
+  Users check the status of MapboxMap and Style by new method MapboxMap.isValid() and Style.isValid() to avoid such exception.
+  Automatically unsubscribe all observers in MapboxMap when `MapboxMap.onDestroy()` is invoked. ([1193](https://github.com/mapbox/mapbox-maps-android/pull/1193)) ([1202](https://github.com/mapbox/mapbox-maps-android/pull/1202))
 
 ## Bug fixes 🐞
 * Fix an issue when user subscribe sdk listeners multiple times, by changing CopyOnWriteArrayList to CopyOnWriteArraySet in the sdk to hold listeners. ([1183](https://github.com/mapbox/mapbox-maps-android/pull/1183))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 # main
 ## Features ✨ and improvements 🏁
 * Optimize how plugins handle settings changes. Call `applySettings` only when settings value changes. ([#1189](https://github.com/mapbox/mapbox-maps-android/pull/1189))
-* Add new exception type `MapboxMapMemoryLeakException` which will be thrown when users still try to invoke functions related with `nativeMap` in `MapboxMap` and `Style`. ([1193](https://github.com/mapbox/mapbox-maps-android/pull/1193)) ([1202](https://github.com/mapbox/mapbox-maps-android/pull/1202))
+* Add exception type `MapboxMapMemoryLeakException` which will be thrown when users try to invoke functions related with `nativeMap` in `MapboxMap` and `Style`. Automatically unsubscribe all observers in MapboxMap when `MapboxMap.onDestroy()` is invoked. ([1193](https://github.com/mapbox/mapbox-maps-android/pull/1193)) ([1202](https://github.com/mapbox/mapbox-maps-android/pull/1202))
 
 ## Bug fixes 🐞
 * Fix an issue when user subscribe sdk listeners multiple times, by changing CopyOnWriteArrayList to CopyOnWriteArraySet in the sdk to hold listeners. ([1183](https://github.com/mapbox/mapbox-maps-android/pull/1183))

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/BaseMapTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/BaseMapTest.kt
@@ -7,7 +7,6 @@ import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.mapbox.maps.*
 import com.mapbox.maps.R
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -36,21 +35,6 @@ abstract class BaseMapTest {
     pixelRatio = context.resources.displayMetrics.density
     initialiseMapView()
     loadMap()
-  }
-
-  @After
-  fun tearDown() {
-    val latch = CountDownLatch(1)
-    rule.scenario.onActivity {
-      it.runOnUiThread {
-        mapView.onStop()
-        mapView.onDestroy()
-        latch.countDown()
-      }
-    }
-    if (!latch.await(10000, TimeUnit.MILLISECONDS)) {
-      throw TimeoutException()
-    }
   }
 
   protected open fun initialiseMapView() {

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/UpdateAnnotationTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/UpdateAnnotationTest.kt
@@ -32,13 +32,12 @@ import java.util.concurrent.TimeoutException
 class UpdateAnnotationTest : BaseMapTest() {
   private val updateDelay = 100L
   private var index = 0
-  private var stopUpdate = false
   private val latch = CountDownLatch(AnnotationUtils.STYLES.size * 3)
   private lateinit var pointAnnotationManager: PointAnnotationManager
   private lateinit var pointAnnotation: PointAnnotation
   private lateinit var handler: Handler
   private val runnable = Runnable {
-    if (!stopUpdate) {
+    if (mapboxMap.isValid()) {
       mapboxMap.loadStyleUri(AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]) {
         runRunnable()
       }
@@ -60,7 +59,6 @@ class UpdateAnnotationTest : BaseMapTest() {
     if (!latch.await(30000, TimeUnit.MILLISECONDS)) {
       throw TimeoutException()
     }
-    stopUpdate = true
     handler.removeCallbacksAndMessages(null)
   }
 

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/UpdateAnnotationTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/annotation/UpdateAnnotationTest.kt
@@ -32,13 +32,16 @@ import java.util.concurrent.TimeoutException
 class UpdateAnnotationTest : BaseMapTest() {
   private val updateDelay = 100L
   private var index = 0
+  private var stopUpdate = false
   private val latch = CountDownLatch(AnnotationUtils.STYLES.size * 3)
   private lateinit var pointAnnotationManager: PointAnnotationManager
   private lateinit var pointAnnotation: PointAnnotation
   private lateinit var handler: Handler
   private val runnable = Runnable {
-    mapboxMap.loadStyleUri(AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]) {
-      runRunnable()
+    if (!stopUpdate) {
+      mapboxMap.loadStyleUri(AnnotationUtils.STYLES[index++ % AnnotationUtils.STYLES.size]) {
+        runRunnable()
+      }
     }
   }
 
@@ -57,6 +60,8 @@ class UpdateAnnotationTest : BaseMapTest() {
     if (!latch.await(30000, TimeUnit.MILLISECONDS)) {
       throw TimeoutException()
     }
+    stopUpdate = true
+    handler.removeCallbacksAndMessages(null)
   }
 
   override fun loadMap() {

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/viewport/ViewportPluginTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/viewport/ViewportPluginTest.kt
@@ -63,7 +63,6 @@ class ViewportPluginTest : BaseMapTest() {
 
   @After
   fun cleanUp() {
-    super.tearDown()
     locationProvider.locationConsumers.clear()
   }
 

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
@@ -9,7 +9,6 @@ import com.mapbox.maps.*
 import com.mapbox.maps.extension.observable.eventdata.MapLoadingErrorEventData
 import com.mapbox.maps.extension.observable.getResourceEventData
 import com.mapbox.maps.extension.observable.subscribeResourceRequest
-import com.mapbox.maps.extension.observable.unsubscribeResourceRequest
 import com.mapbox.maps.plugin.compass.compass
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.testapp.R
@@ -170,12 +169,6 @@ class DebugModeActivity : AppCompatActivity() {
         binding.fpsView.text = getString(R.string.fps, it.toInt().toString())
       }
     }
-  }
-
-  override fun onDestroy() {
-    super.onDestroy()
-    mapboxMap.unsubscribe(observable)
-    mapboxMap.unsubscribeResourceRequest(extensionObservable)
   }
 
   companion object {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/NinePatchImageActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/NinePatchImageActivity.kt
@@ -26,7 +26,7 @@ class NinePatchImageActivity : AppCompatActivity() {
   private var appendTextCounter = 1
   private lateinit var style: Style
   private lateinit var mapView: MapView
-
+  private var stopped = false
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     mapView = MapView(this)
@@ -60,22 +60,35 @@ class NinePatchImageActivity : AppCompatActivity() {
     )
   }
 
+  private val runnable = {
+    if (!stopped) {
+      val layer = (style.getLayer(LAYER_ID) as SymbolLayer)
+      layer.textField("${layer.textField?.getTextAsString()} $TEXT_BASE")
+      appendTextCounter++
+      if (appendTextCounter.rem(3) == 0) {
+        layer.textField("${layer.textField?.getTextAsString()}\n")
+      }
+      updateIconText()
+    }
+  }
+
   // start appending text in a loop, stretching icon in both X and Y
   private fun updateIconText() {
     mapView.postDelayed(
-      {
-        val layer = (style.getLayer(LAYER_ID) as SymbolLayer)
-        layer.textField("${layer.textField?.getTextAsString()} $TEXT_BASE")
-        appendTextCounter++
-        if (appendTextCounter.rem(3) == 0) {
-          layer.textField("${layer.textField?.getTextAsString()}\n")
-        }
-        updateIconText()
-      },
+      runnable,
       TEXT_UPDATE_TIME_MS
     )
   }
 
+  override fun onStart() {
+    super.onStart()
+    stopped = false
+  }
+  override fun onStop() {
+    super.onStop()
+    stopped = true
+    mapView.removeCallbacks(runnable)
+  }
   companion object {
     private const val NINE_PATCH_ID = "red"
     private const val SOURCE_ID = "source_id"

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/NinePatchImageActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/NinePatchImageActivity.kt
@@ -26,7 +26,6 @@ class NinePatchImageActivity : AppCompatActivity() {
   private var appendTextCounter = 1
   private lateinit var style: Style
   private lateinit var mapView: MapView
-  private var stopped = false
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     mapView = MapView(this)
@@ -61,7 +60,7 @@ class NinePatchImageActivity : AppCompatActivity() {
   }
 
   private val runnable = {
-    if (!stopped) {
+    if (style.isValid()) {
       val layer = (style.getLayer(LAYER_ID) as SymbolLayer)
       layer.textField("${layer.textField?.getTextAsString()} $TEXT_BASE")
       appendTextCounter++
@@ -80,13 +79,8 @@ class NinePatchImageActivity : AppCompatActivity() {
     )
   }
 
-  override fun onStart() {
-    super.onStart()
-    stopped = false
-  }
   override fun onStop() {
     super.onStop()
-    stopped = true
     mapView.removeCallbacks(runnable)
   }
   companion object {

--- a/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
+++ b/plugin-annotation/src/main/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImpl.kt
@@ -112,6 +112,7 @@ class AnnotationPluginImpl : AnnotationPlugin {
     managerList.forEach {
       it.get()?.onDestroy()
     }
+    managerList.clear()
   }
 
   /**

--- a/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImplTest.kt
+++ b/plugin-annotation/src/test/java/com/mapbox/maps/plugin/annotation/AnnotationPluginImplTest.kt
@@ -65,8 +65,9 @@ class AnnotationPluginImplTest {
 
     annotationPluginImpl.removeAnnotationManager(circleAnnotationManager)
     annotationPluginImpl.removeAnnotationManager(pointAnnotationManager)
-    annotationPluginImpl.removeAnnotationManager(polygonAnnotationManager)
-    annotationPluginImpl.removeAnnotationManager(polylineAnnotationManager)
+    assertEquals(2, annotationPluginImpl.managerList.size)
+
+    annotationPluginImpl.cleanup()
     assertEquals(0, annotationPluginImpl.managerList.size)
   }
 }

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -1624,6 +1624,8 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase {
    */
   override fun cleanup() {
     protectedCameraAnimatorOwners.clear()
+    mainHandler?.removeCallbacksAndMessages(null)
+    animationsTimeoutHandler.removeCallbacksAndMessages(null)
   }
 
   /**

--- a/sdk-base/api/metalava.txt
+++ b/sdk-base/api/metalava.txt
@@ -37,7 +37,7 @@ package com.mapbox.maps {
   }
 
   public final class MapboxMapMemoryLeakException extends java.lang.IllegalStateException {
-    ctor public MapboxMapMemoryLeakException(String exceptionText = "You are keeping reference to a destroyed view, you are leaking memory");
+    ctor public MapboxMapMemoryLeakException(String exceptionText = "You are accessing MapboxMap or Style after MapView is destroyed.");
   }
 
   public final class MapboxStyleException extends java.lang.RuntimeException {

--- a/sdk-base/src/main/java/com/mapbox/maps/MapboxExceptions.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/MapboxExceptions.kt
@@ -49,4 +49,4 @@ class MapboxMapMemoryLeakException(
   exceptionText: String = MEMORY_LEAK_EXCEPTION_TEXT
 ) : IllegalStateException(exceptionText)
 
-private const val MEMORY_LEAK_EXCEPTION_TEXT = "You are keeping reference to a destroyed view, you are leaking memory"
+private const val MEMORY_LEAK_EXCEPTION_TEXT = "You are accessing MapboxMap or Style after MapView is destroyed."

--- a/sdk/api/metalava.txt
+++ b/sdk/api/metalava.txt
@@ -203,6 +203,7 @@ package com.mapbox.maps {
     method @Deprecated public boolean isFullyLoaded();
     method public boolean isGestureInProgress();
     method public boolean isUserAnimationInProgress();
+    method public boolean isValid();
     method public void loadStyle(com.mapbox.maps.extension.style.StyleContract.StyleExtension styleExtension, com.mapbox.maps.TransitionOptions? transitionOptions = null, com.mapbox.maps.Style.OnStyleLoaded? onStyleLoaded = null, com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener? onMapLoadErrorListener = null);
     method public void loadStyle(com.mapbox.maps.extension.style.StyleContract.StyleExtension styleExtension, com.mapbox.maps.Style.OnStyleLoaded? onStyleLoaded = null, com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener? onMapLoadErrorListener = null);
     method public void loadStyle(com.mapbox.maps.extension.style.StyleContract.StyleExtension styleExtension, com.mapbox.maps.Style.OnStyleLoaded onStyleLoaded);
@@ -376,6 +377,7 @@ package com.mapbox.maps {
     method public com.mapbox.bindgen.Expected<java.lang.String,com.mapbox.bindgen.None> invalidateStyleCustomGeometrySourceTile(String sourceId, com.mapbox.maps.CanonicalTileID tileId);
     method public com.mapbox.bindgen.Expected<java.lang.String,java.lang.Boolean> isStyleLayerPersistent(String layerId);
     method public boolean isStyleLoaded();
+    method public boolean isValid();
     method public com.mapbox.bindgen.Expected<java.lang.String,com.mapbox.bindgen.None> moveStyleLayer(String layerId, com.mapbox.maps.LayerPosition? layerPosition);
     method public com.mapbox.bindgen.Expected<java.lang.String,com.mapbox.bindgen.None> removeStyleImage(String imageId);
     method public com.mapbox.bindgen.Expected<java.lang.String,com.mapbox.bindgen.None> removeStyleLayer(String layerId);

--- a/sdk/api/sdk.api
+++ b/sdk/api/sdk.api
@@ -205,6 +205,7 @@ public final class com/mapbox/maps/MapboxMap : com/mapbox/maps/ObservableInterfa
 	public fun isFullyLoaded ()Z
 	public fun isGestureInProgress ()Z
 	public fun isUserAnimationInProgress ()Z
+	public final fun isValid ()Z
 	public final fun loadStyle (Lcom/mapbox/maps/extension/style/StyleContract$StyleExtension;)V
 	public final fun loadStyle (Lcom/mapbox/maps/extension/style/StyleContract$StyleExtension;Lcom/mapbox/maps/Style$OnStyleLoaded;)V
 	public final fun loadStyle (Lcom/mapbox/maps/extension/style/StyleContract$StyleExtension;Lcom/mapbox/maps/Style$OnStyleLoaded;Lcom/mapbox/maps/plugin/delegates/listeners/OnMapLoadErrorListener;)V
@@ -408,6 +409,7 @@ public final class com/mapbox/maps/Style : com/mapbox/maps/extension/style/Style
 	public fun invalidateStyleCustomGeometrySourceTile (Ljava/lang/String;Lcom/mapbox/maps/CanonicalTileID;)Lcom/mapbox/bindgen/Expected;
 	public fun isStyleLayerPersistent (Ljava/lang/String;)Lcom/mapbox/bindgen/Expected;
 	public fun isStyleLoaded ()Z
+	public final fun isValid ()Z
 	public fun moveStyleLayer (Ljava/lang/String;Lcom/mapbox/maps/LayerPosition;)Lcom/mapbox/bindgen/Expected;
 	public fun removeStyleImage (Ljava/lang/String;)Lcom/mapbox/bindgen/Expected;
 	public fun removeStyleLayer (Ljava/lang/String;)Lcom/mapbox/bindgen/Expected;

--- a/sdk/src/androidTest/java/com/mapbox/maps/BaseAnimationMapTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/BaseAnimationMapTest.kt
@@ -75,17 +75,5 @@ abstract class BaseAnimationMapTest {
         executeShellCommand("settings put global animator_duration_scale 0")
       }
     }
-    val latch = CountDownLatch(1)
-    rule.scenario.onActivity {
-      it.runOnUiThread {
-        mapView.onStop()
-        mapView.onDestroy()
-        latch.countDown()
-      }
-    }
-
-    if (!latch.await(10000, TimeUnit.MILLISECONDS)) {
-      throw TimeoutException()
-    }
   }
 }

--- a/sdk/src/androidTest/java/com/mapbox/maps/OfflineTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/OfflineTest.kt
@@ -546,7 +546,7 @@ class OfflineTest {
           .networkRestriction(NetworkRestriction.NONE)
           .build(),
         { progress ->
-          Logger.i("TAG", "completedResourceCount: ${progress.completedResourceCount}, requiredResourceCount: ${progress.requiredResourceCount}")
+          Logger.i(TAG, "completedResourceCount: ${progress.completedResourceCount}, requiredResourceCount: ${progress.requiredResourceCount}")
         }
       ) {
         if (it.isValue) {

--- a/sdk/src/androidTest/java/com/mapbox/maps/OfflineTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/OfflineTest.kt
@@ -545,7 +545,9 @@ class OfflineTest {
           .acceptExpired(true)
           .networkRestriction(NetworkRestriction.NONE)
           .build(),
-        {}
+        { progress ->
+          Logger.i("TAG", "completedResourceCount: ${progress.completedResourceCount}, requiredResourceCount: ${progress.requiredResourceCount}")
+        }
       ) {
         if (it.isValue) {
           it.value?.let { latch.countDown() }

--- a/sdk/src/androidTest/java/com/mapbox/maps/ViewAnnotationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/ViewAnnotationTest.kt
@@ -102,18 +102,6 @@ class ViewAnnotationTest(
     }
   }
 
-  @After
-  @UiThreadTest
-  fun tearDown() {
-    val latch = CountDownLatch(1)
-    rule.scenario.onActivity {
-      mapView.onStop()
-      mapView.onDestroy()
-      latch.countDown()
-    }
-    latch.throwExceptionOnTimeoutMs()
-  }
-
   /**
    * Helper function that performs some action and verifies result after some delay
    * when view annotations are fixed in the viewport

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -158,11 +158,10 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       return
     }
     lifecycleState = LifecycleState.STATE_DESTROYED
-
-    mapboxMap.onDestroy()
+    pluginRegistry.cleanup()
     nativeObserver.onDestroy()
     renderer.onDestroy()
-    pluginRegistry.cleanup()
+    mapboxMap.onDestroy()
   }
 
   override fun onLowMemory() {

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -46,7 +46,7 @@ class MapboxMap :
   MapCameraManagerDelegate,
   MapStyleStateDelegate {
 
-  private val nativeMap: MapInterface?
+  private var nativeMap: MapInterface?
   private val nativeObserver: NativeObserver
 
   internal var style: Style? = null
@@ -58,7 +58,7 @@ class MapboxMap :
     if (nativeMap == null) {
       throw MapboxMapMemoryLeakException()
     }
-    return nativeMap
+    return nativeMap!!
   }
   /**
    * Represents current camera state.
@@ -1497,6 +1497,8 @@ class MapboxMap :
   }
 
   internal fun onDestroy() {
+    nativeMap = null
+    style?.onDestroy()
     styleObserver.onDestroy()
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -56,11 +56,17 @@ class MapboxMap :
   internal var renderHandler: Handler? = null
 
   private fun getNativeMap(): MapInterface {
-    if (nativeMap == null) {
-      throw MapboxMapMemoryLeakException()
-    }
-    return nativeMap!!
+    return nativeMap ?: throw MapboxMapMemoryLeakException()
   }
+
+  /**
+   * Whether the MapboxMap instance is valid. MapboxMap will be invalid after MapView is destroyed and
+   * accessing MapboxMap will throw [MapboxMapMemoryLeakException].
+   */
+  fun isValid(): Boolean {
+    return nativeMap != null
+  }
+
   /**
    * Represents current camera state.
    */
@@ -319,6 +325,8 @@ class MapboxMap :
     onMapLoadErrorListener: OnMapLoadErrorListener? = null,
     styleTransitionOptions: TransitionOptions? = null
   ) {
+    // Destroy the previous style when loading a new style to remove the reference to native map
+    this.style?.onDestroy()
     style = null
     styleObserver.setLoadStyleListener(
       styleTransitionOptions,

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -325,8 +325,6 @@ class MapboxMap :
     onMapLoadErrorListener: OnMapLoadErrorListener? = null,
     styleTransitionOptions: TransitionOptions? = null
   ) {
-    // Destroy the previous style when loading a new style to remove the reference to native map
-    this.style?.onDestroy()
     style = null
     styleObserver.setLoadStyleListener(
       styleTransitionOptions,
@@ -1517,7 +1515,6 @@ class MapboxMap :
     }
     observers.clear()
     nativeMap = null
-    style?.onDestroy()
     styleObserver.onDestroy()
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -20,15 +20,19 @@ import java.nio.ByteBuffer
  * @property pixelRatio the scale ratio of the style, default the device pixel ratio
  */
 class Style internal constructor(
-  private val styleManagerRef: StyleManagerInterface,
+  private var styleManager: StyleManagerInterface?,
   override val pixelRatio: Float
 ) : StyleInterface {
 
+  internal fun onDestroy() {
+    styleManager = null
+  }
+
   private fun getStyleManager(): StyleManagerInterface {
-    if (styleManagerRef == null) {
+    if (styleManager == null) {
       throw MapboxMapMemoryLeakException()
     }
-    return styleManagerRef
+    return styleManager!!
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -29,10 +29,15 @@ class Style internal constructor(
   }
 
   private fun getStyleManager(): StyleManagerInterface {
-    if (styleManager == null) {
-      throw MapboxMapMemoryLeakException()
-    }
-    return styleManager!!
+    return styleManager ?: throw MapboxMapMemoryLeakException()
+  }
+
+  /**
+   * Whether the Style instance is valid. Style will be invalid after MapView is destroyed or a new style is loaded and
+   * accessing Style will throw [MapboxMapMemoryLeakException].
+   */
+  fun isValid(): Boolean {
+    return styleManager != null
   }
 
   /**

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -131,10 +131,10 @@ class MapControllerTest {
     testMapController.onDestroy()
 
     verifySequence {
-      mockMapboxMap.onDestroy()
+      mockPluginRegistry.cleanup()
       mockNativeObserver.onDestroy()
       mockRenderer.onDestroy()
-      mockPluginRegistry.cleanup()
+      mockMapboxMap.onDestroy()
     }
   }
 

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -15,6 +15,7 @@ import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import io.mockk.*
 import junit.framework.Assert.*
+import org.junit.After
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
@@ -47,6 +48,10 @@ class MapboxMapTest {
     mapboxMap = MapboxMap(nativeMap, nativeObserver, styleObserver)
   }
 
+  @After
+  fun cleanUp() {
+    unmockkObject(MapProjectionUtils)
+  }
   @Test
   fun loadStyleUri() {
     Shadows.shadowOf(Looper.getMainLooper()).pause()
@@ -1039,6 +1044,711 @@ class MapboxMapTest {
 
   @Test
   fun setStyleTransition() {
+    val options = mockk<TransitionOptions>(relaxed = true)
+    mapboxMap.loadStyleUri(
+      "style",
+      options,
+      {},
+      object : OnMapLoadErrorListener {
+        override fun onMapLoadError(eventData: MapLoadingErrorEventData) {}
+      }
+    )
+    verify(exactly = 1) {
+      styleObserver.setLoadStyleListener(options, any(), any())
+    }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun loadStyleUriAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    assertFalse(mapboxMap.isStyleLoadInitiated)
+    mapboxMap.loadStyleUri("foo")
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    verify { nativeMap.styleURI = "foo" }
+    assertTrue(mapboxMap.isStyleLoadInitiated)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun loadStyleUriLambdaAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    assertFalse(mapboxMap.isStyleLoadInitiated)
+    mapboxMap.loadStyleUri("foo") {}
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    assertTrue(mapboxMap.isStyleLoadInitiated)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun loadStyleJSONAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    assertFalse(mapboxMap.isStyleLoadInitiated)
+    mapboxMap.loadStyleJson("foo")
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    verify { nativeMap.styleJSON = "foo" }
+    assertTrue(mapboxMap.isStyleLoadInitiated)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun loadStyleJSONLambdaAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    assertFalse(mapboxMap.isStyleLoadInitiated)
+    mapboxMap.loadStyleJson("foo") {}
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    verify { nativeMap.styleJSON = "foo" }
+    assertTrue(mapboxMap.isStyleLoadInitiated)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun loadEmptyStyleAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    assertFalse(mapboxMap.isStyleLoadInitiated)
+    mapboxMap.loadStyle(style("") {})
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    verify { nativeMap.styleJSON = "{}" }
+    assertTrue(mapboxMap.isStyleLoadInitiated)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun loadStyleAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val styleExtension = mockk<StyleContract.StyleExtension>()
+    every { styleExtension.styleUri } returns "foobar"
+    val onMapLoadError = mockk<OnMapLoadErrorListener>()
+    val onStyleLoadError = mockk<Style.OnStyleLoaded>()
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    assertFalse(mapboxMap.isStyleLoadInitiated)
+    mapboxMap.loadStyle(styleExtension, onStyleLoadError, onMapLoadError)
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    verify { nativeMap.styleURI = "foobar" }
+    assertTrue(mapboxMap.isStyleLoadInitiated)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun loadStyleLambdaAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val styleExtension = mockk<StyleContract.StyleExtension>()
+    every { styleExtension.styleUri } returns "foobar"
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    assertFalse(mapboxMap.isStyleLoadInitiated)
+    mapboxMap.loadStyle(styleExtension) {}
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    verify { nativeMap.styleURI = "foobar" }
+    assertTrue(mapboxMap.isStyleLoadInitiated)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getResourceOptionsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.getResourceOptions()
+    verify { nativeMap.resourceOptions }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setPrefetchZoomDeltaAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.setPrefetchZoomDelta(3)
+    verify { nativeMap.prefetchZoomDelta = 3 }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getPrefetchZoomDeltaAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.getPrefetchZoomDelta()
+    verify { nativeMap.prefetchZoomDelta }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setCameraAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val cameraOptions = CameraOptions.Builder().build()
+    mapboxMap.setCamera(cameraOptions)
+    verify { nativeMap.setCamera(cameraOptions) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinateBoundsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val bounds = mockk<CoordinateBounds>()
+    val edgeInsets = mockk<EdgeInsets>()
+    mapboxMap.cameraForCoordinateBounds(bounds, edgeInsets, 0.0, 1.0)
+    verify { nativeMap.cameraForCoordinateBounds(bounds, edgeInsets, 0.0, 1.0) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinateBoundsOverloadAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val bounds = mockk<CoordinateBounds>()
+    mapboxMap.cameraForCoordinateBounds(bounds)
+    verify {
+      nativeMap.cameraForCoordinateBounds(
+        bounds,
+        EdgeInsets(0.0, 0.0, 0.0, 0.0),
+        null,
+        null
+      )
+    }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinateBoundsOverloadPaddingAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val bounds = mockk<CoordinateBounds>()
+    val padding = EdgeInsets(1.1, 1.3, 1.4, 1.2)
+    mapboxMap.cameraForCoordinateBounds(bounds, padding)
+    verify { nativeMap.cameraForCoordinateBounds(bounds, padding, null, null) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinateBoundsOverloadBearingAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val bounds = mockk<CoordinateBounds>()
+    mapboxMap.cameraForCoordinateBounds(bounds, bearing = 2.0)
+    verify {
+      nativeMap.cameraForCoordinateBounds(
+        bounds,
+        EdgeInsets(0.0, 0.0, 0.0, 0.0),
+        2.0,
+        null
+      )
+    }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinateBoundsOverloadPitchAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val bounds = mockk<CoordinateBounds>()
+    mapboxMap.cameraForCoordinateBounds(bounds, pitch = 2.0)
+    verify {
+      nativeMap.cameraForCoordinateBounds(
+        bounds,
+        EdgeInsets(0.0, 0.0, 0.0, 0.0),
+        null,
+        2.0
+      )
+    }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun coordinateBoundsForCameraAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val cameraOptions = mockk<CameraOptions>()
+    mapboxMap.coordinateBoundsForCamera(cameraOptions)
+    verify { nativeMap.coordinateBoundsForCamera(cameraOptions) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun coordinateBoundsZoomForCameraAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val cameraOptions = mockk<CameraOptions>()
+    mapboxMap.coordinateBoundsZoomForCamera(cameraOptions)
+    verify { nativeMap.coordinateBoundsZoomForCamera(cameraOptions) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun coordinateBoundsZoomForCameraUnwrappedAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val cameraOptions = mockk<CameraOptions>()
+    mapboxMap.coordinateBoundsZoomForCameraUnwrapped(cameraOptions)
+    verify { nativeMap.coordinateBoundsZoomForCameraUnwrapped(cameraOptions) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinatesOneAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val points = mockk<List<Point>>()
+    val camera = mockk<CameraOptions>()
+    val box = mockk<ScreenBox>()
+    mapboxMap.cameraForCoordinates(points, camera, box)
+    verify { nativeMap.cameraForCoordinates(points, camera, box) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinatesTwoAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val points = mockk<List<Point>>()
+    val edgeInsets = mockk<EdgeInsets>()
+    mapboxMap.cameraForCoordinates(points, edgeInsets, 0.0, 1.0)
+    verify { nativeMap.cameraForCoordinates(points, edgeInsets, 0.0, 1.0) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinatesOverloadAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val points = mockk<List<Point>>()
+    mapboxMap.cameraForCoordinates(points)
+    verify { nativeMap.cameraForCoordinates(points, EdgeInsets(0.0, 0.0, 0.0, 0.0), null, null) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinatesOverloadBearingAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val points = mockk<List<Point>>()
+    mapboxMap.cameraForCoordinates(points, bearing = 2.0)
+    verify { nativeMap.cameraForCoordinates(points, EdgeInsets(0.0, 0.0, 0.0, 0.0), 2.0, null) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForCoordinatesOverloadPitchAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val points = mockk<List<Point>>()
+    mapboxMap.cameraForCoordinates(points, pitch = 2.0)
+    verify { nativeMap.cameraForCoordinates(points, EdgeInsets(0.0, 0.0, 0.0, 0.0), null, 2.0) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForGeometryAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val point = mockk<Point>()
+    val edgeInsets = mockk<EdgeInsets>()
+    mapboxMap.cameraForGeometry(point, edgeInsets, 0.0, 1.0)
+    verify { nativeMap.cameraForGeometry(point, edgeInsets, 0.0, 1.0) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForGeometryOverloadAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val point = mockk<Point>()
+    mapboxMap.cameraForGeometry(point)
+    verify { nativeMap.cameraForGeometry(point, EdgeInsets(0.0, 0.0, 0.0, 0.0), null, null) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForGeometryOverloadBearingAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val point = mockk<Point>()
+    mapboxMap.cameraForGeometry(point, bearing = 2.0)
+    verify { nativeMap.cameraForGeometry(point, EdgeInsets(0.0, 0.0, 0.0, 0.0), 2.0, null) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraForGeometryOverloadPitchAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val point = mockk<Point>()
+    mapboxMap.cameraForGeometry(point, pitch = 2.0)
+    verify { nativeMap.cameraForGeometry(point, EdgeInsets(0.0, 0.0, 0.0, 0.0), null, 2.0) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun pixelForCoordinateAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val point = mockk<Point>()
+    mapboxMap.pixelForCoordinate(point)
+    verify { nativeMap.pixelForCoordinate(point) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun coordinateForPixelAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val point = mockk<ScreenCoordinate>()
+    mapboxMap.coordinateForPixel(point)
+    verify { nativeMap.coordinateForPixel(point) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun pixelsForCoordinatesAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val points = mockk<List<Point>>()
+    mapboxMap.pixelsForCoordinates(points)
+    verify { nativeMap.pixelsForCoordinates(points) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun coordinatesForPixelsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val points = mockk<List<ScreenCoordinate>>()
+    mapboxMap.coordinatesForPixels(points)
+    verify { nativeMap.coordinatesForPixels(points) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getBoundsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.getBounds()
+    verify { nativeMap.bounds }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setBoundsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val bounds = mockk<CameraBoundsOptions>()
+    mapboxMap.setBounds(bounds)
+    verify { nativeMap.setBounds(bounds) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setGestureInProgressAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.setGestureInProgress(true)
+    verify { nativeMap.isGestureInProgress = true }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun isGestureInProgressAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.isGestureInProgress()
+    verify { nativeMap.isGestureInProgress }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setNorthOrientationAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.setNorthOrientation(NorthOrientation.DOWNWARDS)
+    verify { nativeMap.setNorthOrientation(NorthOrientation.DOWNWARDS) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setConstrainModeAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.setConstrainMode(ConstrainMode.HEIGHT_ONLY)
+    verify { nativeMap.setConstrainMode(ConstrainMode.HEIGHT_ONLY) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setViewportModeAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.setViewportMode(ViewportMode.FLIPPED_Y)
+    verify { nativeMap.setViewportMode(ViewportMode.FLIPPED_Y) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setFeatureStateAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val value = mockk<Value>()
+    mapboxMap.setFeatureState("id", "source-layer", "feature", value)
+    verify { nativeMap.setFeatureState("id", "source-layer", "feature", value) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getFeatureStateAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val value = mockk<QueryFeatureStateCallback>()
+    mapboxMap.getFeatureState("id", "source-layer", "feature", value)
+    verify { nativeMap.getFeatureState("id", "source-layer", "feature", value) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun removeFeatureStateAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.removeFeatureState("id", "source-layer", "feature", "state")
+    verify { nativeMap.removeFeatureState("id", "source-layer", "feature", "state") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun queryFeatureExtensionsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val feature = mockk<Feature>()
+    val map = mockk<HashMap<String, Value>>()
+    val callback = mockk<QueryFeatureExtensionCallback>()
+    mapboxMap.queryFeatureExtensions("id", feature, "extension", "extensionField", map, callback)
+    verify {
+      nativeMap.queryFeatureExtensions(
+        "id",
+        feature,
+        "extension",
+        "extensionField",
+        map,
+        callback
+      )
+    }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getClusterLeavesDefaultParamAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val feature = mockk<Feature>()
+    val mapSlot = slot<HashMap<String, Value>>()
+    val callback = mockk<QueryFeatureExtensionCallback>()
+    mapboxMap.getGeoJsonClusterLeaves("id", feature, callback = callback)
+    verify {
+      nativeMap.queryFeatureExtensions(
+        "id",
+        feature,
+        MapboxMap.QFE_SUPER_CLUSTER,
+        MapboxMap.QFE_LEAVES,
+        capture(mapSlot),
+        callback
+      )
+    }
+    checkCapturedMap(mapSlot, MapboxMap.QFE_DEFAULT_LIMIT.toString(), MapboxMap.QFE_DEFAULT_OFFSET.toString())
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getClusterLeavesAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val feature = mockk<Feature>()
+    val mapSlot = slot<HashMap<String, Value>>()
+    val callback = mockk<QueryFeatureExtensionCallback>()
+    mapboxMap.getGeoJsonClusterLeaves("id", feature, 1, 2, callback = callback)
+    verify {
+      nativeMap.queryFeatureExtensions(
+        "id",
+        feature,
+        MapboxMap.QFE_SUPER_CLUSTER,
+        MapboxMap.QFE_LEAVES,
+        capture(mapSlot),
+        callback
+      )
+    }
+    checkCapturedMap(mapSlot, "1", "2")
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getClusterChildrenAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val feature = mockk<Feature>()
+    val callback = mockk<QueryFeatureExtensionCallback>()
+    mapboxMap.getGeoJsonClusterChildren("id", feature, callback = callback)
+    verify {
+      nativeMap.queryFeatureExtensions(
+        "id",
+        feature,
+        MapboxMap.QFE_SUPER_CLUSTER,
+        MapboxMap.QFE_CHILDREN,
+        null,
+        callback
+      )
+    }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getClusterExpansionZoomAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val feature = mockk<Feature>()
+    val callback = mockk<QueryFeatureExtensionCallback>()
+    mapboxMap.getGeoJsonClusterExpansionZoom("id", feature, callback = callback)
+    verify {
+      nativeMap.queryFeatureExtensions(
+        "id",
+        feature,
+        MapboxMap.QFE_SUPER_CLUSTER,
+        MapboxMap.QFE_EXPANSION_ZOOM,
+        null,
+        callback
+      )
+    }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getCameraStateAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.cameraState
+    verify { nativeMap.cameraState }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setDebugAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val debugOptions = mockk<List<MapDebugOptions>>()
+    mapboxMap.setDebug(debugOptions, true)
+    verify { nativeMap.setDebug(debugOptions, true) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getDebugAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.getDebug()
+    verify { nativeMap.debug }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getMapOptionsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.getMapOptions()
+    verify { mapboxMap.getMapOptions() }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setUserAnimationInProgressAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.setUserAnimationInProgress(true)
+    verify { nativeMap.isUserAnimationInProgress = true }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun isUserAnimationInProgressAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.isUserAnimationInProgress()
+    verify { nativeMap.isUserAnimationInProgress }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun reduceMemoryUseAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.reduceMemoryUse()
+    verify { mapboxMap.reduceMemoryUse() }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun querySourceFeaturesAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val querySourceCallback = mockk<QueryFeaturesCallback>()
+    val querySourceOptions = mockk<SourceQueryOptions>()
+    mapboxMap.querySourceFeatures("id", querySourceOptions, querySourceCallback)
+    verify { nativeMap.querySourceFeatures("id", querySourceOptions, querySourceCallback) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun queryRenderedFeaturesScreenBoxAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val queryCallback = mockk<QueryFeaturesCallback>()
+    val box = mockk<ScreenBox>()
+    val renderedQueryOptions = mockk<RenderedQueryOptions>()
+    mapboxMap.queryRenderedFeatures(box, renderedQueryOptions, queryCallback)
+    verify { nativeMap.queryRenderedFeatures(box, renderedQueryOptions, queryCallback) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun queryRenderedFeaturesScreenCoordinateAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val queryCallback = mockk<QueryFeaturesCallback>()
+    val coordinate = mockk<ScreenCoordinate>()
+    val renderedQueryOptions = mockk<RenderedQueryOptions>()
+    mapboxMap.queryRenderedFeatures(coordinate, renderedQueryOptions, queryCallback)
+    verify { nativeMap.queryRenderedFeatures(coordinate, renderedQueryOptions, queryCallback) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun queryRenderedFeaturesShapeAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val queryCallback = mockk<QueryFeaturesCallback>()
+    val shape = mockk<List<ScreenCoordinate>>()
+    val renderedQueryOptions = mockk<RenderedQueryOptions>()
+    mapboxMap.queryRenderedFeatures(shape, renderedQueryOptions, queryCallback)
+    verify { nativeMap.queryRenderedFeatures(shape, renderedQueryOptions, queryCallback) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun queryRenderedFeaturesGeometryAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val queryCallback = mockk<QueryFeaturesCallback>()
+    val geometry = mockk<RenderedQueryGeometry>()
+    val renderedQueryOptions = mockk<RenderedQueryOptions>()
+    mapboxMap.queryRenderedFeatures(geometry, renderedQueryOptions, queryCallback)
+    verify { nativeMap.queryRenderedFeatures(geometry, renderedQueryOptions, queryCallback) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun queryRenderedFeaturesRenderedQueryGeometryAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val queryCallback = mockk<QueryFeaturesCallback>()
+    val geometry = mockk<RenderedQueryGeometry>()
+    val renderedQueryOptions = mockk<RenderedQueryOptions>()
+    mapboxMap.queryRenderedFeatures(geometry, renderedQueryOptions, queryCallback)
+    verify { nativeMap.queryRenderedFeatures(geometry, renderedQueryOptions, queryCallback) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getSizeAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.getSize()
+    verify { nativeMap.size }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getFreeCameraOptionsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.getFreeCameraOptions()
+    verify { nativeMap.freeCameraOptions }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setFreeCameraOptionsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val options = mockk<FreeCameraOptions>()
+    mapboxMap.setCamera(options)
+    verify { nativeMap.setCamera(options) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getElevationAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val point = mockk<Point>()
+    mapboxMap.getElevation(point)
+    verify { nativeMap.getElevation(point) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun dragStartAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val screenCoordinate = mockk<ScreenCoordinate>()
+    mapboxMap.dragStart(screenCoordinate)
+    verify { nativeMap.dragStart(screenCoordinate) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun dragEndAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.dragEnd()
+    verify { nativeMap.dragEnd() }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getDragCameraOptionsAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val fromPoint = mockk<ScreenCoordinate>()
+    val toPoint = mockk<ScreenCoordinate>()
+    mapboxMap.getDragCameraOptions(fromPoint, toPoint)
+    verify { nativeMap.getDragCameraOptions(fromPoint, toPoint) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun cameraStateAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.cameraState
+    verify { nativeMap.cameraState }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun clearDataAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val callback = mockk<AsyncOperationResultCallback>(relaxed = true)
+    mapboxMap.clearData(callback)
+    verify { Map.clearData(resourceOptions, callback) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setMapProjectionMercatorAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    verifySetMapProjection(MapProjection.Mercator, MapProjectionUtils.MERCATOR_PROJECTION_NAME)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setMapProjectionGlobeAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    verifySetMapProjection(MapProjection.Globe, MapProjectionUtils.GLOBE_PROJECTION_NAME)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getMapProjectionAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mockkObject(MapProjectionUtils)
+    every { MapProjectionUtils.fromValue(any()) } returns MapProjection.Globe
+    val projection = mapboxMap.getMapProjection()
+    verify { nativeMap.mapProjection }
+    assertEquals(MapProjection.Globe, projection)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getMapProjectionInvalidAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    mapboxMap.getMapProjection()
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setMemoryBudgetAfterOnDestroy() {
+    mapboxMap.onDestroy()
+    val memoryBudget = mockk<MapMemoryBudget>()
+    mapboxMap.setMemoryBudget(memoryBudget)
+    verify { nativeMap.setMemoryBudget(memoryBudget) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setStyleTransitionAfterOnDestroy() {
+    mapboxMap.onDestroy()
     val options = mockk<TransitionOptions>(relaxed = true)
     mapboxMap.loadStyleUri(
       "style",

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -54,6 +54,13 @@ class MapboxMapTest {
   }
 
   @Test
+  fun isValid() {
+    assertTrue(mapboxMap.isValid())
+    mapboxMap.onDestroy()
+    assertFalse(mapboxMap.isValid())
+  }
+
+  @Test
   fun loadStyleUri() {
     Shadows.shadowOf(Looper.getMainLooper()).pause()
     assertFalse(mapboxMap.isStyleLoadInitiated)

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -387,6 +387,8 @@ class MapboxMapTest {
   @Test
   fun removeObserver() {
     val observer = mockk<Observer>()
+    val debugList = arrayListOf<String>()
+    mapboxMap.subscribe(observer, debugList)
     mapboxMap.unsubscribe(observer)
     verify { (nativeMap as ObservableInterface).unsubscribe(observer) }
   }
@@ -395,6 +397,7 @@ class MapboxMapTest {
   fun removeObserverList() {
     val observer = mockk<Observer>()
     val debugList = arrayListOf<String>()
+    mapboxMap.subscribe(observer, debugList)
     mapboxMap.unsubscribe(observer, debugList)
     verify { (nativeMap as ObservableInterface).unsubscribe(observer, debugList) }
   }

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -52,6 +52,7 @@ class MapboxMapTest {
   fun cleanUp() {
     unmockkObject(MapProjectionUtils)
   }
+
   @Test
   fun loadStyleUri() {
     Shadows.shadowOf(Looper.getMainLooper()).pause()

--- a/sdk/src/test/java/com/mapbox/maps/StyleTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleTest.kt
@@ -353,4 +353,385 @@ class StyleTest {
     style.setStyleTerrainProperty("id", value)
     verify { nativeMap.setStyleTerrainProperty("id", value) }
   }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addImageAfterOnDestroy() {
+    style.onDestroy()
+    val image: Image = mockk()
+    style.addImage("foobar", image)
+    verify { nativeMap.addStyleImage("foobar", 1.0f, image, false, listOf(), listOf(), null) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addImageSdfAfterOnDestroy() {
+    style.onDestroy()
+    val image: Image = mockk()
+    style.addImage("foobar", image, true)
+    verify { nativeMap.addStyleImage("foobar", 1.0f, image, true, listOf(), listOf(), null) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addImageFullAfterOnDestroy() {
+    style.onDestroy()
+    val image: Image = mockk()
+    val stretchesLeft = listOf(ImageStretches(1.0f, 2.0f))
+    val stretchesRight = listOf(ImageStretches(3.0f, 4.0f))
+    val imageContent = ImageContent(1.0f, 2.0f, 3.0f, 4.0f)
+    style.addStyleImage("foobar", 2.0f, image, true, stretchesLeft, stretchesRight, imageContent)
+    verify {
+      nativeMap.addStyleImage(
+        "foobar",
+        2.0f,
+        image,
+        true,
+        stretchesLeft,
+        stretchesRight,
+        imageContent
+      )
+    }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun removeImageAfterOnDestroy() {
+    style.onDestroy()
+    style.removeStyleImage("id")
+    verify { nativeMap.removeStyleImage("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun hasImageAfterOnDestroy() {
+    style.onDestroy()
+    style.hasStyleImage("id")
+    verify { nativeMap.hasStyleImage("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addBitmapAfterOnDestroy() {
+    style.onDestroy()
+    val bitmap: Bitmap = mockk(relaxed = true)
+    style.addImage("foobar", bitmap)
+    verify { bitmap.height }
+    verify { bitmap.width }
+    verify { bitmap.byteCount }
+    verify { nativeMap.addStyleImage("foobar", 1.0f, any(), false, listOf(), listOf(), null) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addBitmapSdfAfterOnDestroy() {
+    style.onDestroy()
+    val bitmap: Bitmap = mockk(relaxed = true)
+    style.addImage("foobar", bitmap, true)
+    verify { bitmap.height }
+    verify { bitmap.width }
+    verify { bitmap.byteCount }
+    verify { nativeMap.addStyleImage("foobar", 1.0f, any(), true, listOf(), listOf(), null) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addLayerAfterOnDestroy() {
+    style.onDestroy()
+    val value = mockk<Value>()
+    val position = mockk<LayerPosition>()
+    style.addStyleLayer(value, position)
+    verify { nativeMap.addStyleLayer(value, position) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getLayersAfterOnDestroy() {
+    style.onDestroy()
+    style.styleLayers
+    verify { nativeMap.styleLayers }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun removeLayerAfterOnDestroy() {
+    style.onDestroy()
+    style.removeStyleLayer("id")
+    verify { nativeMap.removeStyleLayer("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun layerExistAfterOnDestroy() {
+    style.onDestroy()
+    style.styleLayerExists("id")
+    verify { nativeMap.styleLayerExists("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setLayerPropertyAfterOnDestroy() {
+    style.onDestroy()
+    val value = mockk<Value>()
+    style.setStyleLayerProperty("id", "foobar", value)
+    verify { nativeMap.setStyleLayerProperty("id", "foobar", value) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getLayerPropertyAfterOnDestroy() {
+    style.onDestroy()
+    style.getStyleLayerProperty("id", "foobar")
+    verify { nativeMap.getStyleLayerProperty("id", "foobar") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setLayerPropertiesAfterOnDestroy() {
+    style.onDestroy()
+    val properties = mockk<Value>()
+    style.setStyleLayerProperties("id", properties)
+    verify { nativeMap.setStyleLayerProperties("id", properties) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getLayerPropertiesAfterOnDestroy() {
+    style.onDestroy()
+    style.getStyleLayerProperties("id")
+    verify { nativeMap.getStyleLayerProperties("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addSourceAfterOnDestroy() {
+    style.onDestroy()
+    val properties = mockk<Value>()
+    style.addStyleSource("id", properties)
+    verify { nativeMap.addStyleSource("id", properties) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getSourcesAfterOnDestroy() {
+    style.onDestroy()
+    style.styleSources
+    verify { nativeMap.styleSources }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun removeSourceAfterOnDestroy() {
+    style.onDestroy()
+    style.removeStyleSource("id")
+    verify { style.removeStyleSource("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun sourceExistAfterOnDestroy() {
+    style.onDestroy()
+    style.styleSourceExists("id")
+    verify { nativeMap.styleSourceExists("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setSourcePropertiesAfterOnDestroy() {
+    style.onDestroy()
+    val value = mockk<Value>()
+    style.setStyleSourceProperties("id", value)
+    verify { nativeMap.setStyleSourceProperties("id", value) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getSourcePropertiesAfterOnDestroy() {
+    style.onDestroy()
+    style.getStyleSourceProperties("id")
+    verify { nativeMap.getStyleSourceProperties("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setSourcePropertyAfterOnDestroy() {
+    style.onDestroy()
+    val value = mockk<Value>()
+    style.setStyleSourceProperty("id", "foobar", value)
+    verify { nativeMap.setStyleSourceProperty("id", "foobar", value) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getSourcePropertyAfterOnDestroy() {
+    style.onDestroy()
+    style.getStyleSourceProperty("id", "foobar")
+    verify { nativeMap.getStyleSourceProperty("id", "foobar") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getSourcesAttributionAfterOnDestroy() {
+    style.onDestroy()
+    val source = mockk<StyleObjectInfo>()
+    every { source.id } returns "id"
+    every { nativeMap.styleSources } returns listOf(source)
+    val valueMap = HashMap<String, Value>()
+    valueMap.put("attribution", mockk())
+    every { nativeMap.getStyleSourceProperties(any()) } returns ExpectedFactory.createValue(Value.valueOf(valueMap))
+    style.getStyleSourcesAttribution()
+    verify { nativeMap.getStyleSourceProperties("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun updateImageSourceImageAfterOnDestroy() {
+    style.onDestroy()
+    val image = mockk<Image>()
+    style.updateStyleImageSourceImage("id", image)
+    verify { nativeMap.updateStyleImageSourceImage("id", image) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addCustomLayerAfterOnDestroy() {
+    style.onDestroy()
+    val layerHost = mockk<CustomLayerHost>()
+    val layerPosition = mockk<LayerPosition>()
+    style.addStyleCustomLayer("id", layerHost, layerPosition)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setCustomGeometrySourceTileDataAfterOnDestroy() {
+    style.onDestroy()
+    val canonicalTileID = mockk<CanonicalTileID>()
+    val features = mockk<MutableList<Feature>>()
+    style.setStyleCustomGeometrySourceTileData("id", canonicalTileID, features)
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addCustomGeometrySourceAfterOnDestroy() {
+    style.onDestroy()
+    val options = mockk<CustomGeometrySourceOptions>()
+    style.addStyleCustomGeometrySource("id", options)
+    verify { nativeMap.addStyleCustomGeometrySource("id", options) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun invalidateCustomGeometrySourceBoundsAfterOnDestroy() {
+    style.onDestroy()
+    val bounds = mockk<CoordinateBounds>()
+    style.invalidateStyleCustomGeometrySourceRegion("id", bounds)
+    verify { nativeMap.invalidateStyleCustomGeometrySourceRegion("id", bounds) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun invalidateCustomGeometrySourceIdAfterOnDestroy() {
+    style.onDestroy()
+    val tileId = mockk<CanonicalTileID>()
+    style.invalidateStyleCustomGeometrySourceTile("id", tileId)
+    verify { nativeMap.invalidateStyleCustomGeometrySourceTile("id", tileId) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addPersistentStyleLayerAfterOnDestroy() {
+    style.onDestroy()
+    val value = mockk<Value>()
+    val position = mockk<LayerPosition>()
+    style.addPersistentStyleLayer(value, position)
+    verify { nativeMap.addPersistentStyleLayer(value, position) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun addPersistentStyleCustomLayerAfterOnDestroy() {
+    style.onDestroy()
+    val layerHost = mockk<CustomLayerHost>()
+    val layerPosition = mockk<LayerPosition>()
+    style.addPersistentStyleCustomLayer("id", layerHost, layerPosition)
+    verify { nativeMap.addPersistentStyleCustomLayer("id", layerHost, layerPosition) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun isStyleLayerPersistentAfterOnDestroy() {
+    style.onDestroy()
+    style.isStyleLayerPersistent("id")
+    verify { nativeMap.isStyleLayerPersistent("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setJsonAfterOnDestroy() {
+    style.onDestroy()
+    style.styleJSON = "foobar"
+    verify { nativeMap.styleJSON = "foobar" }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getJsonAfterOnDestroy() {
+    style.onDestroy()
+    style.styleJSON
+    verify { nativeMap.styleJSON }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setUriAfterOnDestroy() {
+    style.onDestroy()
+    style.styleURI = "foobar"
+    verify { nativeMap.styleURI = "foobar" }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getUriAfterOnDestroy() {
+    style.onDestroy()
+    style.styleURI
+    verify { nativeMap.styleURI }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setTransitionAfterOnDestroy() {
+    style.onDestroy()
+    val transition = mockk<TransitionOptions>()
+    style.styleTransition = transition
+    verify { nativeMap.styleTransition = transition }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getTransitionAfterOnDestroy() {
+    style.onDestroy()
+    style.styleTransition
+    verify { nativeMap.styleTransition }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getDefaultCameraAfterOnDestroy() {
+    style.onDestroy()
+    style.styleDefaultCamera
+    verify { nativeMap.styleDefaultCamera }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getImageAfterOnDestroy() {
+    style.onDestroy()
+    style.getStyleImage("foobar")
+    verify { nativeMap.getStyleImage("foobar") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setLightAfterOnDestroy() {
+    style.onDestroy()
+    val value = mockk<Value>()
+    style.setStyleLight(value)
+    verify { nativeMap.setStyleLight(value) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getLightAfterOnDestroy() {
+    style.onDestroy()
+    style.getStyleLightProperty("id")
+    verify { nativeMap.getStyleLightProperty("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setLightPropertyAfterOnDestroy() {
+    style.onDestroy()
+    val value = mockk<Value>()
+    style.setStyleLightProperty("id", value)
+    verify { nativeMap.setStyleLightProperty("id", value) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setStyleTerrainAfterOnDestroy() {
+    style.onDestroy()
+    val value = mockk<Value>()
+    style.setStyleTerrain(value)
+    verify { nativeMap.setStyleTerrain(value) }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun getStyleTerrainPropertyAfterOnDestroy() {
+    style.onDestroy()
+    style.getStyleTerrainProperty("id")
+    verify { nativeMap.getStyleTerrainProperty("id") }
+  }
+
+  @Test(expected = MapboxMapMemoryLeakException::class)
+  fun setStyleTerrainPropertyAfterOndestroy() {
+    val value = mockk<Value>()
+    style.onDestroy()
+    style.setStyleTerrainProperty("id", value)
+    verify { nativeMap.setStyleTerrainProperty("id", value) }
+  }
 }

--- a/sdk/src/test/java/com/mapbox/maps/StyleTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleTest.kt
@@ -7,6 +7,8 @@ import com.mapbox.geojson.Feature
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -18,6 +20,13 @@ class StyleTest {
   @Before
   fun setUp() {
     style = Style(nativeMap as StyleManagerInterface, 1.0f)
+  }
+
+  @Test
+  fun isValid() {
+    assertTrue(style.isValid())
+    style.onDestroy()
+    assertFalse(style.isValid())
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
In `MapboxMap` and `Style`, the reference to `nativeMap` will be reset to null in onDestroy, so any method calls related to `nativeMap` will throw `MapboxMapMemoryLeakException`

`tearDown` method in BaseMapTest.kt is removed to avoid duplicate method call to `MapboxMap.onDestroy()` as it will be triggerd by lifecycle plugin.

Automatically unsubscribe all observers in MapboxMap when `MapboxMap.onDestroy()` is invoked.
<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-kotlin-binary-compatibility` CI will fail.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
