### PR TITLE
Generate bearing-transition style property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
   Users check the status of MapboxMap and Style by new method MapboxMap.isValid() and Style.isValid() to avoid such exception.
   Automatically unsubscribe all observers in MapboxMap when `MapboxMap.onDestroy()` is invoked. ([1193](https://github.com/mapbox/mapbox-maps-android/pull/1193)) ([1202](https://github.com/mapbox/mapbox-maps-android/pull/1202))
 * Add `MapboxMap#coordinateBoundsForCameraUnwrapped` method for API consistency. ([1222](https://github.com/mapbox/mapbox-maps-android/pull/1222))
+* Add `LocationIndicatorLayer.bearingTransition` API to control transition of bearing property. (([1207](https://github.com/mapbox/mapbox-maps-android/pull/1207)))
 
 # 10.4.0
 

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/LocationIndicatorLayerTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/LocationIndicatorLayerTest.kt
@@ -316,6 +316,37 @@ class LocationIndicatorLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
+  fun bearingTransitionTest() {
+    val transition = transitionOptions {
+      duration(100)
+      delay(200)
+    }
+    val layer = locationIndicatorLayer("id") {
+      bearingTransition(transition)
+    }
+    setupLayer(layer)
+    assertEquals(transition, layer.bearingTransition)
+  }
+
+  @Test
+  @UiThreadTest
+  fun bearingTransitionSetDslTest() {
+    val transition = transitionOptions {
+      duration(100)
+      delay(200)
+    }
+    val layer = locationIndicatorLayer("id") {
+      bearingTransition {
+        duration(100)
+        delay(200)
+      }
+    }
+    setupLayer(layer)
+    assertEquals(transition, layer.bearingTransition)
+  }
+
+  @Test
+  @UiThreadTest
   fun bearingImageSizeTest() {
     val testValue = 1.0
     val layer = locationIndicatorLayer("id") {
@@ -745,6 +776,7 @@ class LocationIndicatorLayerTest : BaseStyleTest() {
     assertNotNull("defaultAccuracyRadiusColorTransition should not be null", LocationIndicatorLayer.defaultAccuracyRadiusColorTransition)
     assertNotNull("defaultBearing should not be null", LocationIndicatorLayer.defaultBearing)
     assertNotNull("defaultBearingAsExpression should not be null", LocationIndicatorLayer.defaultBearingAsExpression)
+    assertNotNull("defaultBearingTransition should not be null", LocationIndicatorLayer.defaultBearingTransition)
     assertNotNull("defaultBearingImageSize should not be null", LocationIndicatorLayer.defaultBearingImageSize)
     assertNotNull("defaultBearingImageSizeAsExpression should not be null", LocationIndicatorLayer.defaultBearingImageSizeAsExpression)
     assertNotNull("defaultBearingImageSizeTransition should not be null", LocationIndicatorLayer.defaultBearingImageSizeTransition)

--- a/extension-style/api/extension-style.api
+++ b/extension-style/api/extension-style.api
@@ -1917,6 +1917,8 @@ public final class com/mapbox/maps/extension/style/layers/generated/LocationIndi
 	public fun bearingImageSize (Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public fun bearingImageSizeTransition (Lcom/mapbox/maps/extension/style/types/StyleTransition;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public fun bearingImageSizeTransition (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
+	public fun bearingTransition (Lcom/mapbox/maps/extension/style/types/StyleTransition;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
+	public fun bearingTransition (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public fun emphasisCircleColor (I)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public fun emphasisCircleColor (Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public fun emphasisCircleColor (Ljava/lang/String;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
@@ -1944,6 +1946,7 @@ public final class com/mapbox/maps/extension/style/layers/generated/LocationIndi
 	public final fun getBearingImageSize ()Ljava/lang/Double;
 	public final fun getBearingImageSizeAsExpression ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun getBearingImageSizeTransition ()Lcom/mapbox/maps/extension/style/types/StyleTransition;
+	public final fun getBearingTransition ()Lcom/mapbox/maps/extension/style/types/StyleTransition;
 	public final fun getEmphasisCircleColor ()Ljava/lang/String;
 	public final fun getEmphasisCircleColorAsColorInt ()Ljava/lang/Integer;
 	public final fun getEmphasisCircleColorAsExpression ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
@@ -2019,6 +2022,7 @@ public final class com/mapbox/maps/extension/style/layers/generated/LocationIndi
 	public final fun getDefaultBearingImageSize ()Ljava/lang/Double;
 	public final fun getDefaultBearingImageSizeAsExpression ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun getDefaultBearingImageSizeTransition ()Lcom/mapbox/maps/extension/style/types/StyleTransition;
+	public final fun getDefaultBearingTransition ()Lcom/mapbox/maps/extension/style/types/StyleTransition;
 	public final fun getDefaultEmphasisCircleColor ()Ljava/lang/String;
 	public final fun getDefaultEmphasisCircleColorAsColorInt ()Ljava/lang/Integer;
 	public final fun getDefaultEmphasisCircleColorAsExpression ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
@@ -2071,6 +2075,8 @@ public abstract interface class com/mapbox/maps/extension/style/layers/generated
 	public abstract fun bearingImageSize (Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public abstract fun bearingImageSizeTransition (Lcom/mapbox/maps/extension/style/types/StyleTransition;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public abstract fun bearingImageSizeTransition (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
+	public abstract fun bearingTransition (Lcom/mapbox/maps/extension/style/types/StyleTransition;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
+	public abstract fun bearingTransition (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public abstract fun emphasisCircleColor (I)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public abstract fun emphasisCircleColor (Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;
 	public abstract fun emphasisCircleColor (Ljava/lang/String;)Lcom/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer;

--- a/extension-style/api/metalava.txt
+++ b/extension-style/api/metalava.txt
@@ -2238,6 +2238,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingImageSize(com.mapbox.maps.extension.style.expressions.generated.Expression bearingImageSize);
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingImageSizeTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingImageSizeTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer emphasisCircleColor(String emphasisCircleColor);
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer emphasisCircleColor(com.mapbox.maps.extension.style.expressions.generated.Expression emphasisCircleColor);
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer emphasisCircleColor(@ColorInt int emphasisCircleColor);
@@ -2265,6 +2267,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public Double? getBearingImageSize();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getBearingImageSizeAsExpression();
     method public com.mapbox.maps.extension.style.types.StyleTransition? getBearingImageSizeTransition();
+    method public com.mapbox.maps.extension.style.types.StyleTransition? getBearingTransition();
     method public String? getEmphasisCircleColor();
     method @ColorInt public Integer? getEmphasisCircleColorAsColorInt();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getEmphasisCircleColorAsExpression();
@@ -2335,6 +2338,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final Double? bearingImageSize;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? bearingImageSizeAsExpression;
     property public final com.mapbox.maps.extension.style.types.StyleTransition? bearingImageSizeTransition;
+    property public final com.mapbox.maps.extension.style.types.StyleTransition? bearingTransition;
     property public final String? emphasisCircleColor;
     property @ColorInt public final Integer? emphasisCircleColorAsColorInt;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? emphasisCircleColorAsExpression;
@@ -2385,6 +2389,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public Double? getDefaultBearingImageSize();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultBearingImageSizeAsExpression();
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultBearingImageSizeTransition();
+    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultBearingTransition();
     method public String? getDefaultEmphasisCircleColor();
     method @ColorInt public Integer? getDefaultEmphasisCircleColorAsColorInt();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultEmphasisCircleColorAsExpression();
@@ -2430,6 +2435,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final Double? defaultBearingImageSize;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultBearingImageSizeAsExpression;
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultBearingImageSizeTransition;
+    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultBearingTransition;
     property public final String? defaultEmphasisCircleColor;
     property @ColorInt public final Integer? defaultEmphasisCircleColorAsColorInt;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultEmphasisCircleColorAsExpression;
@@ -2482,6 +2488,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingImageSize(com.mapbox.maps.extension.style.expressions.generated.Expression bearingImageSize);
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingImageSizeTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingImageSizeTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer bearingTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer emphasisCircleColor(String emphasisCircleColor = "#ffffff");
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer emphasisCircleColor(com.mapbox.maps.extension.style.expressions.generated.Expression emphasisCircleColor);
     method public com.mapbox.maps.extension.style.layers.generated.LocationIndicatorLayer emphasisCircleColor(@ColorInt int emphasisCircleColor);

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayer.kt
@@ -632,6 +632,36 @@ class LocationIndicatorLayer(override val layerId: String) : LocationIndicatorLa
   }
 
   /**
+   * Transition options for Bearing.
+   */
+  val bearingTransition: StyleTransition?
+    /**
+     * Get the Bearing property transition options
+     *
+     * @return transition options for Double
+     */
+    get() {
+      return getPropertyValue("bearing-transition")
+    }
+
+  /**
+   * Set the Bearing property transition options
+   *
+   * @param options transition options for Double
+   */
+  override fun bearingTransition(options: StyleTransition) = apply {
+    val propertyValue = PropertyValue("bearing-transition", options)
+    setProperty(propertyValue)
+  }
+
+  /**
+   * DSL for [bearingTransition].
+   */
+  override fun bearingTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+    bearingTransition(StyleTransition.Builder().apply(block).build())
+  }
+
+  /**
    * The size of the bearing image, as a scale factor applied to the size of the specified image.
    */
   val bearingImageSize: Double?
@@ -1635,6 +1665,17 @@ class LocationIndicatorLayer(override val layerId: String) : LocationIndicatorLa
       }
 
     /**
+     * Transition options for Bearing.
+     */
+    val defaultBearingTransition: StyleTransition?
+      /**
+       * Get the Bearing property transition options
+       *
+       * @return transition options for Double
+       */
+      get() = StyleManager.getStyleLayerPropertyDefaultValue("location-indicator", "bearing-transition").silentUnwrap()
+
+    /**
      * The size of the bearing image, as a scale factor applied to the size of the specified image.
      */
     val defaultBearingImageSize: Double?
@@ -2170,6 +2211,18 @@ interface LocationIndicatorLayerDsl {
    * @param bearing value of bearing as Expression
    */
   fun bearing(bearing: Expression): LocationIndicatorLayer
+
+  /**
+   * Set the Bearing property transition options
+   *
+   * @param options transition options for Double
+   */
+  fun bearingTransition(options: StyleTransition): LocationIndicatorLayer
+
+  /**
+   * DSL for [bearingTransition].
+   */
+  fun bearingTransition(block: StyleTransition.Builder.() -> Unit): LocationIndicatorLayer
 
   /**
    * Set the BearingImageSize property

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LocationIndicatorLayerTest.kt
@@ -725,6 +725,46 @@ class LocationIndicatorLayerTest {
   }
 
   @Test
+  fun bearingTransitionSet() {
+    val layer = locationIndicatorLayer("id") {}
+    layer.bindTo(style)
+    layer.bearingTransition(
+      transitionOptions {
+        duration(100)
+        delay(200)
+      }
+    )
+    verify { style.setStyleLayerProperty("id", "bearing-transition", capture(valueSlot)) }
+    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
+  }
+
+  @Test
+  fun bearingTransitionGet() {
+    val transition = transitionOptions {
+      duration(100)
+      delay(200)
+    }
+    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
+    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
+    val layer = locationIndicatorLayer("id") {}
+    layer.bindTo(style)
+    assertEquals(transition.toValue().toString(), layer.bearingTransition?.toValue().toString())
+    verify { style.getStyleLayerProperty("id", "bearing-transition") }
+  }
+
+  @Test
+  fun bearingTransitionSetDsl() {
+    val layer = locationIndicatorLayer("id") {}
+    layer.bindTo(style)
+    layer.bearingTransition {
+      duration(100)
+      delay(200)
+    }
+    verify { style.setStyleLayerProperty("id", "bearing-transition", capture(valueSlot)) }
+    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
+  }
+
+  @Test
   fun bearingImageSizeSet() {
     val layer = locationIndicatorLayer("id") {}
     val testValue = 1.0
@@ -1904,6 +1944,19 @@ class LocationIndicatorLayerTest {
     assertEquals(1.0, LocationIndicatorLayer.defaultBearingAsExpression?.contents as Double, 1E-5)
     assertEquals(1.0, LocationIndicatorLayer.defaultBearing!!, 1E-5)
     verify { StyleManager.getStyleLayerPropertyDefaultValue("location-indicator", "bearing") }
+  }
+
+  @Test
+  fun defaultBearingTransitionTest() {
+    val transition = transitionOptions {
+      duration(100)
+      delay(200)
+    }
+    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
+    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
+
+    assertEquals(transition.toValue().toString(), LocationIndicatorLayer.defaultBearingTransition?.toValue().toString())
+    verify { StyleManager.getStyleLayerPropertyDefaultValue("location-indicator", "bearing-transition") }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Generated property bearing-transition

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-kotlin-binary-compatibility` CI will fail.
 - [x] Apply changelog label ('breaking change', 'bug :beetle:', 'build', 'docs', 'feature :green_apple:', 'performance :zap:', 'testing :100:') or use the label 'skip changelog'
 - [ ] Add an entry inside this element for inclusion in the `mapbox-maps-android` changelog: `<changelog></changelog>`.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
