### PR TITLE
Enable publish Android Auto separately from the main sdk.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ commands:
           command: |
             if [[ $CIRCLE_TAG == android-v* ]]; then
               sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${CIRCLE_TAG:9}/" gradle.properties
-            elif [[ $CIRCLE_TAG == extension-androidauto-v* ]]
+            elif [[ $CIRCLE_TAG == extension-androidauto-v* ]]; then
               sed -i -e "s/^MODULE_VERSION_NAME=.*/MODULE_VERSION_NAME=${CIRCLE_TAG:23}/" extension-androidauto/gradle.properties
             elif [[ $CIRCLE_BRANCH == main ]]; then
               COMMIT_SHA=$(git rev-parse --short HEAD)
@@ -239,8 +239,11 @@ commands:
                     make sdkRegistryPublish
                   fi
                   if [[ $CIRCLE_TAG == extension-androidauto-v* ]]; then
-                    make sdkRegistryUploadAndroidAuto
-                    make sdkRegistryPublishAndroidAuto
+                    git config --global user.email "MapboxCI@users.noreply.github.com"
+                    git config --global user.name "MapboxCI"
+                    export GITHUB_TOKEN=$(./mbx-ci github writer private token)
+                    make sdkRegistryUploadAndroidAutoExtension
+                    make sdkRegistryPublishAndroidAutoExtension
                   fi
 
   publish-sdk-registry-named-snapshot:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ commands:
                     export GITHUB_TOKEN=$(./mbx-ci github writer private token)
                     make sdkRegistryPublish
                   fi
-                  if [[ $CIRCLE_TAG == android-auto-extension-v* ]]; then
+                  if [[ $CIRCLE_TAG == extension-androidauto-v* ]]; then
                     make sdkRegistryUploadAndroidAuto
                     make sdkRegistryPublishAndroidAuto
                   fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,8 @@ commands:
           command: |
             if [[ $CIRCLE_TAG == android-v* ]]; then
               sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${CIRCLE_TAG:9}/" gradle.properties
-            elif [[ $CIRCLE_TAG == android-auto-extension-v* ]]
-              sed -i -e "s/^MODULE_VERSION_NAME=.*/MODULE_VERSION_NAME=${CIRCLE_TAG:24}/" extension-androidauto/gradle.properties
+            elif [[ $CIRCLE_TAG == extension-androidauto-v* ]]
+              sed -i -e "s/^MODULE_VERSION_NAME=.*/MODULE_VERSION_NAME=${CIRCLE_TAG:23}/" extension-androidauto/gradle.properties
             elif [[ $CIRCLE_BRANCH == main ]]; then
               COMMIT_SHA=$(git rev-parse --short HEAD)
               sed -i -e "s/-SNAPSHOT.*/-${COMMIT_SHA}-SNAPSHOT/" gradle.properties

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ workflows:
       - verify-code:
           filters:
             tags:
-              only: /android-v.*/
+              only: /(android-v.*|extension-androidauto-v.*)/
       - verify-docs:
           requires:
             - verify-code
@@ -54,7 +54,7 @@ workflows:
             - verify-code
           filters:
             tags:
-              only: /android-v.*/
+              only: /(android-v.*|extension-androidauto-v.*)/
       - run-app-instrumentation-test:
           requires:
             - build-modules-and-instrumentation-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,8 @@ commands:
           command: |
             if [[ $CIRCLE_TAG == android-v* ]]; then
               sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${CIRCLE_TAG:9}/" gradle.properties
+            elif [[ $CIRCLE_TAG == android-auto-extension-v* ]]
+              sed -i -e "s/^MODULE_VERSION_NAME=.*/MODULE_VERSION_NAME=${CIRCLE_TAG:24}/" extension-androidauto/gradle.properties
             elif [[ $CIRCLE_BRANCH == main ]]; then
               COMMIT_SHA=$(git rev-parse --short HEAD)
               sed -i -e "s/-SNAPSHOT.*/-${COMMIT_SHA}-SNAPSHOT/" gradle.properties
@@ -235,6 +237,10 @@ commands:
                     git config --global user.name "MapboxCI"
                     export GITHUB_TOKEN=$(./mbx-ci github writer private token)
                     make sdkRegistryPublish
+                  fi
+                  if [[ $CIRCLE_TAG == android-auto-extension-v* ]]; then
+                    make sdkRegistryUploadAndroidAuto
+                    make sdkRegistryPublishAndroidAuto
                   fi
 
   publish-sdk-registry-named-snapshot:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -313,6 +313,26 @@ rendering engine to our users.
 
 And as always, everyone is invited to review code.
 
+## Making releases
+
+### Versioning
+
+The SDK, the default extensions and the default plugins use the same versioning, which is defined by the
+`VERSION_NAME` variable in the root project's gradle.properties. However, the project also allows to use
+separate versioning for individual subprojects/modules. Subprojects can define the `MODULE_VERSION_NAME`
+in the subproject-level gradle.properties to overwrite the `VERSION_NAME` defined in the root project.
+
+Currently, the only module that uses its own versioning is the `extension-androidauto` and it's published
+separately from the main SDK.
+
+### Publish new releases
+
+The CI is setup to publish new releases when new tag that follows the release tag pattern is created.
+
+* To publish a Maps SDK release with all the default plugins/extensions, create a release tag `android-v*`.
+* To publish a Android Auto extension, create a release tag `extension-androidauto-v*`.
+
+
 ## Opening tickets
 
 Everyone is welcome to open issues or make feature requests on the Mapbox Maps SDK for Android

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,12 @@ sdkRegistryPublish:
 
 .PHONY: sdkRegistryUploadAndroidAutoExtension
 sdkRegistryUploadAndroidAutoExtension:
-    ./gradlew extension-androidauto:mapboxSDKRegistryUpload;
+	./gradlew extension-androidauto:mapboxSDKRegistryUpload;
 
 .PHONY: sdkRegistryPublishAndroidAutoExtension
 sdkRegistryPublishAndroidAutoExtension:
 	python3 -m pip install git-pull-request;
-    ./gradlew extension-androidauto:mapboxSDKRegistryPublish;
+	./gradlew extension-androidauto:mapboxSDKRegistryPublish;
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ sdkRegistryUploadAndroidAutoExtension:
 
 .PHONY: sdkRegistryPublishAndroidAutoExtension
 sdkRegistryPublishAndroidAutoExtension:
-    python3 -m pip install git-pull-request;
+	python3 -m pip install git-pull-request;
     ./gradlew extension-androidauto:mapboxSDKRegistryPublish;
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,21 @@ fix:
 
 .PHONY: sdkRegistryUpload
 sdkRegistryUpload:
-	./gradlew mapboxSDKRegistryUpload;
+	./gradlew mapboxSDKRegistryUpload -x extension-androidauto:mapboxSDKRegistryUpload;
 
 .PHONY: sdkRegistryPublish
 sdkRegistryPublish:
 	python3 -m pip install git-pull-request;
 	./gradlew mapboxSDKRegistryPublishAll;
+
+.PHONY: sdkRegistryUploadAndroidAutoExtension
+sdkRegistryUploadAndroidAutoExtension:
+    ./gradlew extension-androidauto:mapboxSDKRegistryUpload;
+
+.PHONY: sdkRegistryPublishAndroidAutoExtension
+sdkRegistryPublishAndroidAutoExtension:
+    python3 -m pip install git-pull-request;
+    ./gradlew extension-androidauto:mapboxSDKRegistryPublish;
 
 .PHONY: clean
 clean:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ buildscript {
   repositories {
     google()
     mavenCentral()
+    mavenLocal()
     maven {
       url = uri("https://api.mapbox.com/downloads/v2/releases/maven")
       credentials {
@@ -52,6 +53,10 @@ allprojects {
 plugins {
   id(Plugins.dokkaId) version Versions.pluginDokka
   id(Plugins.binaryCompatibilityValidatorId) version Versions.pluginBinaryCompatibilityValidator
+  // Used to print dependency tree of the task, useful to debug gradle tasks
+  // Ticket to track adding this feature to gradle officially: https://github.com/gradle/gradle/issues/980
+  id(Plugins.taskTreeId) version Versions.pluginTaskTree
+
 }
 repositories {
   maven(url = "https://dl.bintray.com/kotlin/dokka")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ buildscript {
   repositories {
     google()
     mavenCentral()
-    mavenLocal()
     maven {
       url = uri("https://api.mapbox.com/downloads/v2/releases/maven")
       credentials {

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -17,6 +17,7 @@ object Plugins {
   const val mapboxSdkVersionsPlugin = "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${Versions.mapboxSdkVersionsPlugin}"
   const val dokkaId = "org.jetbrains.dokka"
   const val binaryCompatibilityValidatorId = "org.jetbrains.kotlinx.binary-compatibility-validator"
+  const val taskTreeId = "com.dorongold.task-tree"
 }
 
 object Dependencies {
@@ -79,8 +80,9 @@ object Versions {
   const val pluginDokka =  "1.4.10.2"
   const val pluginJacoco = "0.2"
   const val pluginBinaryCompatibilityValidator = "0.8.0"
+  const val pluginTaskTree = "2.1.0"
   const val mapboxAccessToken="0.4.0"
-  const val mapboxSdkRegistry="0.7.0"
+  const val mapboxSdkRegistry="0.8.0"
   const val mapboxGestures = "0.7.0"
   const val mapboxJavaServices = "5.4.1"
   const val mapboxBase = "0.5.0"

--- a/extension-androidauto/build.gradle.kts
+++ b/extension-androidauto/build.gradle.kts
@@ -53,6 +53,6 @@ project.apply {
   from("$rootDir/gradle/ktlint.gradle")
   from("$rootDir/gradle/lint.gradle")
   from("$rootDir/gradle/jacoco.gradle")
-//  from("$rootDir/gradle/sdk-registry.gradle")
+  from("$rootDir/gradle/sdk-registry.gradle")
   from("$rootDir/gradle/track-public-apis.gradle")
 }

--- a/extension-androidauto/gradle.properties
+++ b/extension-androidauto/gradle.properties
@@ -4,3 +4,4 @@ POM_ARTIFACT_TITLE=The android auto extension for the Mapbox Maps SDK for Androi
 POM_DESCRIPTION=The android auto extension for the Mapbox Maps SDK for Android
 REGISTRY_SDK_NAME=mobile-maps-android-androidauto
 REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT=true
+MODULE_VERSION_NAME=0.1.0

--- a/extension-androidauto/gradle.properties
+++ b/extension-androidauto/gradle.properties
@@ -3,3 +3,4 @@ POM_ARTIFACT_ID=maps-androidauto
 POM_ARTIFACT_TITLE=The android auto extension for the Mapbox Maps SDK for Android
 POM_DESCRIPTION=The android auto extension for the Mapbox Maps SDK for Android
 REGISTRY_SDK_NAME=mobile-maps-android-androidauto
+REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT=true

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -12,5 +12,5 @@ ext {
     mapboxArtifactLicenseUrl = 'https://opensource.org/licenses/BSD-2-Clause'
     versionName = project.hasProperty('MODULE_VERSION_NAME') ? project.property('MODULE_VERSION_NAME') : project.property('VERSION_NAME')
     mapboxRegistrySdkName = project.hasProperty('REGISTRY_SDK_NAME') ? project.property('REGISTRY_SDK_NAME') : System.getenv('REGISTRY_SDK_NAME')
-    mapboxRegistryExcludeFromRootProject = project.hasProperty('REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT') ? project.property('REGISTRY_SDK_NAME') : false
+    mapboxRegistryExcludeFromRootProject = project.hasProperty('REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT') ? project.property('REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT').toBoolean() : false
 }

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -12,4 +12,5 @@ ext {
     mapboxArtifactLicenseUrl = 'https://opensource.org/licenses/BSD-2-Clause'
     versionName = project.property('VERSION_NAME')
     mapboxRegistrySdkName = project.hasProperty('REGISTRY_SDK_NAME') ? project.property('REGISTRY_SDK_NAME') : System.getenv('REGISTRY_SDK_NAME')
+    mapboxRegistryExcludeFromRootProject = project.hasProperty('REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT') ? true : false
 }

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -10,7 +10,7 @@ ext {
     mapboxArtifactScmUrl = 'scm:git@github.com:mapbox/mapbox-maps-android.git'
     mapboxArtifactLicenseName = 'BSD'
     mapboxArtifactLicenseUrl = 'https://opensource.org/licenses/BSD-2-Clause'
-    versionName = project.property('VERSION_NAME')
+    versionName = project.hasProperty('MODULE_VERSION_NAME') ? project.property('MODULE_VERSION_NAME') : project.property('VERSION_NAME')
     mapboxRegistrySdkName = project.hasProperty('REGISTRY_SDK_NAME') ? project.property('REGISTRY_SDK_NAME') : System.getenv('REGISTRY_SDK_NAME')
-    mapboxRegistryExcludeFromRootProject = project.hasProperty('REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT') ? true : false
+    mapboxRegistryExcludeFromRootProject = project.hasProperty('REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT') ? project.property('REGISTRY_SDK_NAME') : false
 }

--- a/gradle/sdk-registry.gradle
+++ b/gradle/sdk-registry.gradle
@@ -44,7 +44,7 @@ afterEvaluate {
 registry {
     sdkName = project.ext.mapboxRegistrySdkName
     override = project.ext.versionName.endsWith("-SNAPSHOT")
-    dryRun = true
+    dryRun = false
     publish = true
     snapshot = project.ext.versionName.endsWith("-SNAPSHOT")
     publishMessage = "cc @mapbox/maps-android"

--- a/gradle/sdk-registry.gradle
+++ b/gradle/sdk-registry.gradle
@@ -44,11 +44,12 @@ afterEvaluate {
 registry {
     sdkName = project.ext.mapboxRegistrySdkName
     override = project.ext.versionName.endsWith("-SNAPSHOT")
-    dryRun = false
+    dryRun = true
     publish = true
     snapshot = project.ext.versionName.endsWith("-SNAPSHOT")
     publishMessage = "cc @mapbox/maps-android"
     publications = ["release"]
+    excludeFromRootProject = project.ext.mapboxRegistryExcludeFromRootProject
 }
 
 task androidJavadocs(type: Javadoc) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

This PR adds scripts and CI integration to publish Android Auto separate from the main SDK.

#### Versioning
The SDK, the default extensions and the default plugins use the same versioning, which is defined by the
`VERSION_NAME` variable in the root project's gradle.properties. However, the project also allows to use
separate versioning for individual subprojects/modules. Subprojects can define the `MODULE_VERSION_NAME`
in the subproject-level gradle.properties to overwrite the `VERSION_NAME` defined in the root project.
Currently, the only module that uses its own versioning is the `extension-androidauto` and it's published
separately from the main SDK.
#### Publish new releases
The CI is setup to publish new releases when new tag that follows the release tag pattern is created.
* To publish a Maps SDK release with all the default plugins/extensions, create a release tag `android-v*`.
* To publish a Android Auto extension, create a release tag `extension-androidauto-v*`.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
