### PR TITLE
Throw specific Mapbox exception when geojson data is mutated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Mapbox welcomes participation and contributions from everyone.
 * Optimize how plugins handle settings changes. Call `applySettings` only when settings value changes. ([#1189](https://github.com/mapbox/mapbox-maps-android/pull/1189))
 * Add `MapboxMap.isValid()` and `Style.isValid()` methods. `MapboxMap` becomes invalid when `MapView.onDestroy()` is called. `Style` becomes invalid when `MapView.onDestroy()` is called or new style has been loaded. Accessing any method on invalid object will print an error log. Also unsubscribe map observers automatically when `MapboxMap.onDestroy()` is invoked. ([1193](https://github.com/mapbox/mapbox-maps-android/pull/1193)) ([1202](https://github.com/mapbox/mapbox-maps-android/pull/1202) ([1230](https://github.com/mapbox/mapbox-maps-android/pull/1230)) ([1241](https://github.com/mapbox/mapbox-maps-android/pull/1241)))
 * Add `MapboxMap#coordinateBoundsForCameraUnwrapped` method for API consistency. ([1222](https://github.com/mapbox/mapbox-maps-android/pull/1222))
-* Add `LocationIndicatorLayer.bearingTransition` API to control transition of bearing property. (([1207](https://github.com/mapbox/mapbox-maps-android/pull/1207)))
+* Add `LocationIndicatorLayer.bearingTransition` API to control transition of bearing property. ([1207](https://github.com/mapbox/mapbox-maps-android/pull/1207))
+* Add `MapboxConcurrentGeometryModificationException` with detailed information instead of `ConcurrentModificationException` that is thrown when GeoJson data is mutated. ([1248](https://github.com/mapbox/mapbox-maps-android/pull/1248))
 
 ## Bug fixes 🐞
 * Fix PolygonAnnotation and PolylineAnnotation being distorted while dragging with 3D terrain. ([#1223](https://github.com/mapbox/mapbox-maps-android/pull/1223))

--- a/sdk-base/api/metalava.txt
+++ b/sdk-base/api/metalava.txt
@@ -15,6 +15,10 @@ package com.mapbox.maps {
     ctor public MapboxCameraAnimationException(String? exceptionText);
   }
 
+  public final class MapboxConcurrentGeometryModificationException extends java.util.ConcurrentModificationException {
+    ctor public MapboxConcurrentGeometryModificationException(String exceptionText, String sourceId);
+  }
+
   @kotlin.RequiresOptIn(level=kotlin.RequiresOptIn.Level, message="This API is experimental. It may be changed in the future without notice.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) @kotlin.annotation.Target(allowedTargets={kotlin.annotation.AnnotationTarget, kotlin.annotation.AnnotationTarget, kotlin.annotation.AnnotationTarget}) public @interface MapboxExperimental {
   }
 

--- a/sdk-base/api/sdk-base.api
+++ b/sdk-base/api/sdk-base.api
@@ -13,6 +13,10 @@ public final class com/mapbox/maps/MapboxCameraAnimationException : java/lang/Ru
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class com/mapbox/maps/MapboxConcurrentGeometryModificationException : java/util/ConcurrentModificationException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+}
+
 public abstract interface annotation class com/mapbox/maps/MapboxExperimental : java/lang/annotation/Annotation {
 }
 

--- a/sdk-base/src/main/java/com/mapbox/maps/MapboxExceptions.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/MapboxExceptions.kt
@@ -41,3 +41,11 @@ class MapboxCameraAnimationException(
 class MapboxStyleException(
   exceptionText: String?
 ) : RuntimeException(exceptionText)
+
+/**
+ * Mapbox exception thrown when any collection used to build GeoJson data is mutated.
+ */
+class MapboxConcurrentGeometryModificationException(
+  exceptionText: String,
+  sourceId: String
+) : ConcurrentModificationException(exceptionText)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

When applying data to geojson `ConcurrentModificationException` may occur if underlying collections are mutated. We introduce new `MapboxConcurrentGeometryModificationException` extending `ConcurrentModificationException` that contains more data helping to find out what source exactly was not updated and some instructions how that could be fixed.

Sample output:
```
2022-03-31 14:47:49.965 428-559/com.mapbox.maps.testapp E/AndroidRuntime: FATAL EXCEPTION: GEOJSON_PARSER
    Process: com.mapbox.maps.testapp, PID: 428
    com.mapbox.maps.MapboxConcurrentGeometryModificationException: While applying FeatureCollection to geojson source with id="DRIVING_ROUTE_POLYLINE_SOURCE_ID" some collection was mutated which is not allowed as data parsing happens on another thread.
            Please make sure all collections passed via `geometry`, `feature`, `featureCollection` methods are immutable.
            Easiest way to achieve this is either always pass the fresh copy or use https://developer.android.com/reference/java/util/concurrent/CopyOnWriteArrayList.
        at com.mapbox.maps.extension.style.sources.generated.GeoJsonSource.toPropertyValue(GeoJsonSource.kt:334)
        at com.mapbox.maps.extension.style.sources.generated.GeoJsonSource.applyGeoJsonData$lambda-11$lambda-10(GeoJsonSource.kt:350)
        at com.mapbox.maps.extension.style.sources.generated.GeoJsonSource.$r8$lambda$_9l_l-ZA5tTLYApH7jbY6OB3HUI(Unknown Source:0)
        at com.mapbox.maps.extension.style.sources.generated.GeoJsonSource$$ExternalSyntheticLambda1.run(Unknown Source:4)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:226)
        at android.os.Looper.loop(Looper.java:313)
        at android.os.HandlerThread.run(HandlerThread.java:67)
```

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
