### PR TITLE
Deprecate FollowPuckViewportStateOptions.animationDurationMs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Add `LocationIndicatorLayer.bearingTransition` API to control transition of bearing property. ([1207](https://github.com/mapbox/mapbox-maps-android/pull/1207))
 * Add `MapboxConcurrentGeometryModificationException` with detailed information instead of `ConcurrentModificationException` that is thrown when GeoJson data is mutated. ([1248](https://github.com/mapbox/mapbox-maps-android/pull/1248))
 * Introduce `line-trim-offset` property for LineLayer. ([1252](https://github.com/mapbox/mapbox-maps-android/pull/1252))
+* Deprecate `FollowPuckViewportStateOptions.animationDurationMs`, the initial transition will will handled properly by the Viewport plugin internally. ([1256](https://github.com/mapbox/mapbox-maps-android/pull/1256))
 
 ## Bug fixes 🐞
 * Fix PolygonAnnotation and PolylineAnnotation being distorted while dragging with 3D terrain. ([#1223](https://github.com/mapbox/mapbox-maps-android/pull/1223))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Add `LocationIndicatorLayer.bearingTransition` API to control transition of bearing property. ([1207](https://github.com/mapbox/mapbox-maps-android/pull/1207))
 * Add `MapboxConcurrentGeometryModificationException` with detailed information instead of `ConcurrentModificationException` that is thrown when GeoJson data is mutated. ([1248](https://github.com/mapbox/mapbox-maps-android/pull/1248))
 * Introduce `line-trim-offset` property for LineLayer. ([1252](https://github.com/mapbox/mapbox-maps-android/pull/1252))
-* Deprecate `FollowPuckViewportStateOptions.animationDurationMs`, the initial transition will will handled properly by the Viewport plugin internally. ([1256](https://github.com/mapbox/mapbox-maps-android/pull/1256))
+* Deprecate `FollowPuckViewportStateOptions.animationDurationMs`, the initial transition will be handled properly by the Viewport plugin internally. ([1256](https://github.com/mapbox/mapbox-maps-android/pull/1256))
 
 ## Bug fixes 🐞
 * Fix PolygonAnnotation and PolylineAnnotation being distorted while dragging with 3D terrain. ([#1223](https://github.com/mapbox/mapbox-maps-android/pull/1223))

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/viewport/data/FollowPuckViewportStateOptions.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/viewport/data/FollowPuckViewportStateOptions.kt
@@ -60,6 +60,7 @@ class FollowPuckViewportStateOptions private constructor(
    *
    * Defaults to [DEFAULT_STATE_ANIMATION_DURATION_MS] milliseconds
    */
+  @Deprecated("AnimationDurationMs is not needed any more, the transition will be handled properly internally.")
   val animationDurationMs: Long
 ) {
   /**
@@ -152,6 +153,7 @@ class FollowPuckViewportStateOptions private constructor(
      *
      * Defaults to [DEFAULT_STATE_ANIMATION_DURATION_MS] milliseconds
      */
+    @Deprecated("AnimationDurationMs is not needed any more, the transition will be handled properly internally.")
     fun animationDurationMs(duration: Long) = apply {
       this.animationDurationMs = duration
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

This PR deprecates `FollowPuckViewportStateOptions.animationDurationMs`, the transition will will handled properly by the Viewport plugin internally.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
