### PR TITLE
[viewport] Fix camera jump when default transition is canceled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Add `LocationIndicatorLayer.bearingTransition` API to control transition of bearing property. ([1207](https://github.com/mapbox/mapbox-maps-android/pull/1207))
 * Add `MapboxConcurrentGeometryModificationException` with detailed information instead of `ConcurrentModificationException` that is thrown when GeoJson data is mutated. ([1248](https://github.com/mapbox/mapbox-maps-android/pull/1248))
 * Introduce `line-trim-offset` property for LineLayer. ([1252](https://github.com/mapbox/mapbox-maps-android/pull/1252))
-* Deprecate `FollowPuckViewportStateOptions.animationDurationMs`, the initial transition will be handled properly by the Viewport plugin internally. ([1256](https://github.com/mapbox/mapbox-maps-android/pull/1256), [1261](https://github.com/mapbox/mapbox-maps-android/pull/1261))
+* Deprecate `FollowPuckViewportStateOptions.animationDurationMs`, the initial transition will be handled properly by the Viewport plugin internally. ([1256](https://github.com/mapbox/mapbox-maps-android/pull/1256), [1261](https://github.com/mapbox/mapbox-maps-android/pull/1261), [1262](https://github.com/mapbox/mapbox-maps-android/pull/1262))
 * Mark `MapView#viewAnnotationManager` as non-experimental meaning View Annotation API will not have breaking changes in upcoming minor releases. ([1260](https://github.com/mapbox/mapbox-maps-android/pull/1260))
 
 ## Bug fixes 🐞

--- a/plugin-viewport/src/test/kotlin/com/mapbox/maps/plugin/viewport/transition/DefaultViewportTransitionImplTest.kt
+++ b/plugin-viewport/src/test/kotlin/com/mapbox/maps/plugin/viewport/transition/DefaultViewportTransitionImplTest.kt
@@ -120,12 +120,13 @@ class DefaultViewportTransitionImplTest {
     animatorListenerSlot.captured.onAnimationEnd(animator)
     assertTrue(dataObserverSlot.captured.onNewData(cameraOptions))
     verify(exactly = 1) { animator.setObjectValues(0.0, 0.0) }
-    verify { mapCameraManagerDelegate.setCamera(cameraOptions { bearing(cameraOptions.bearing) }) }
+    verify(exactly = 1) { mapCameraManagerDelegate.setCamera(cameraOptions { bearing(cameraOptions.bearing) }) }
 
     // try to notify if animation is finished successfully
     animatorSetListenerSlot.captured.onAnimationEnd(mockk())
     // should stop observing data source and return false
     assertFalse(dataObserverSlot.captured.onNewData(cameraOptions))
+    verify(exactly = 2) { mapCameraManagerDelegate.setCamera(cameraOptions { bearing(cameraOptions.bearing) }) }
     // verify cleanup
     verify { cameraPlugin.unregisterAnimators(animator) }
     verify { completionListener.onComplete(true) }
@@ -160,8 +161,11 @@ class DefaultViewportTransitionImplTest {
     verify { cancelable.cancel() }
     animatorSetListenerSlot.captured.onAnimationCancel(animator)
     animatorSetListenerSlot.captured.onAnimationEnd(animator)
+    animatorListenerSlot.captured.onAnimationCancel(animator)
+    animatorListenerSlot.captured.onAnimationEnd(animator)
     // should stop observing data source and return false
     assertFalse(dataObserverSlot.captured.onNewData(cameraOptions))
+    verify(exactly = 0) { mapCameraManagerDelegate.setCamera(cameraOptions { bearing(cameraOptions.bearing) }) }
     verify { cameraPlugin.unregisterAnimators(animator) }
     verify { cameraPlugin.anchor = cachedAnchor }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

This PR fixes the camera jump issue when default transition is canceled.

### User impact (optional)

| Before | After |
| ----- | ----- |
| <video src="https://user-images.githubusercontent.com/2764714/162010950-3240a6b1-f2c0-43ec-af33-b588d2ebdf33.mp4" width = 250/> | <video src="https://user-images.githubusercontent.com/2764714/162010890-b789b5f6-a4ad-4d87-bb8b-bc8044b73579.mp4" width = 250/> |


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
