### PR TITLE
Fix latitude being NaN during flyTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Features ✨ and improvements 🏁
 
 ## Bug fixes 🐞
+* Fix NaN latitude native crash rarely happening during `MapboxMap#flyTo`. ([#1271](https://github.com/mapbox/mapbox-maps-android/pull/1271))
 
 # 10.5.0-beta.1 April 7, 2022
 ## Breaking changes ⚠️

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
@@ -319,16 +319,16 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
     val r0 = if (u1 != 0.0) {
       r(0)
     } else {
-      Double.MAX_VALUE
+      Double.POSITIVE_INFINITY
     }
     val r1 = if (u1 != 0.0) {
       r(1)
     } else {
-      Double.MAX_VALUE
+      Double.POSITIVE_INFINITY
     }
 
     // When u₀ = u₁, the optimal path doesn’t require both ascent and descent.
-    val isClose = abs(u1) < 0.000001 || r0 == Double.MAX_VALUE || r1 == Double.MAX_VALUE
+    val isClose = abs(u1) < 0.000001 || r0.isInfinite() || r1.isInfinite()
 
     /** w(s): Returns the visible span on the ground, measured in pixels with respect to the initial scale.
      * Assumes an angular field of view of 2 arctan ½ ≈ 53°.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

In some very specific cases when using paddings close to screen size and high zoom `flyTo` could have produced native exception:
```
java.lang.Error: latitude must not be NaN
```

Fix this issue by treating infinite values in algorithm properly.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
