### PR TITLE
Fix geojson missing updates with persistent layer after style change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Mapbox welcomes participation and contributions from everyone.
 * OfflineRegion::getStatus() API added to get the completion status and the local size of the existing legacy offline regions. ([#1315](https://github.com/mapbox/mapbox-maps-android/pull/1315))
 
 ## Bug fixes 🐞
+* Fix geojson missing updates with persistent layer after style change. ([#1324](https://github.com/mapbox/mapbox-maps-android/pull/1324))
 * Fix render tasks being skipped when creating the map that could lead to missing tiles. ([#1304](https://github.com/mapbox/mapbox-maps-android/pull/1304))
 * The legacy offline region observer instance is not unnecessarily retained inside the engine. [#1315](https://github.com/mapbox/mapbox-maps-android/pull/1315)
 * Fix a bug of querying rendered feature for circle layer with map-pitch-alignment when the pitch is zero. [#1315](https://github.com/mapbox/mapbox-maps-android/pull/1315)

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/Source.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/Source.kt
@@ -6,7 +6,6 @@ import com.mapbox.maps.MapboxStyleException
 import com.mapbox.maps.extension.style.StyleContract
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.extension.style.layers.properties.PropertyValue
-import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.utils.unwrap
 import com.mapbox.maps.logE
 
@@ -93,14 +92,6 @@ abstract class Source(
   private fun updateProperty(property: PropertyValue<*>, throwRuntimeException: Boolean = true) {
     delegate?.let { styleDelegate ->
       try {
-        // checking for validness makes sense only for geojson as it uses async parsing
-        if (this is GeoJsonSource) {
-          // explicitly reset native reference and return if map is not valid anymore
-          if (!styleDelegate.isValid()) {
-            delegate = null
-            return@let
-          }
-        }
         val expected = styleDelegate.setStyleSourceProperty(
           sourceId,
           property.propertyName,

--- a/sdk/src/main/java/com/mapbox/maps/Style.kt
+++ b/sdk/src/main/java/com/mapbox/maps/Style.kt
@@ -679,7 +679,8 @@ class Style internal constructor(
    * @return The value of \p property in the source with \p sourceId.
    */
   override fun getStyleSourceProperty(sourceId: String, property: String): StylePropertyValue {
-    checkNativeStyle("getStyleSourceProperty")
+    // TODO see #1105 issue in internal repo
+//    checkNativeStyle("getStyleSourceProperty")
     return styleManager.getStyleSourceProperty(sourceId, property)
   }
 
@@ -697,7 +698,8 @@ class Style internal constructor(
     property: String,
     value: Value
   ): Expected<String, None> {
-    checkNativeStyle("setStyleSourceProperty")
+    // TODO see #1105 issue in internal repo
+//    checkNativeStyle("setStyleSourceProperty")
     return styleManager.setStyleSourceProperty(sourceId, property, value)
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Due to nulling delegate explicitly when `Style` is not valid anymore we faced the situation that geojson updates were skipped after style was changed but only _when using persistent layers_. Now that's fixed and also as the temp solution we do not write warnings for using invalid style object in order not to confuse the users - this will be revisited later as it requires a bit deeper thinking how to treat style object when using persistent layers.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
