### PR TITLE
Remove padding while calculating unitBarWidth; invalidateScaleBar while applySettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Bug fixes 🐞
 * Enable two finger pan gesture. ([#1280](https://github.com/mapbox/mapbox-maps-android/pull/1280))
+* Fix a bug that scale bar is shorter than it should be; trigger `invalidateScaleBar` while updating settings to make scale keep the latest status. ([#1336](https://github.com/mapbox/mapbox-maps-android/pull/1336))
 
 ## Dependencies
 * Bump Mapbox Android base library to v0.8.0. ([#1323](https://github.com/mapbox/mapbox-maps-android/pull/1323))

--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarImpl.kt
@@ -67,7 +67,8 @@ class ScaleBarImpl : ScaleBar, View {
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal fun calculateWidthAndHeight(): Pair<Float, Float> {
-    val width = mapViewWidth * settings.ratio
+    // Add padding the width to avoid texts being cut off and the end of scalebar.
+    val width = mapViewWidth * settings.ratio + INTERNAL_PADDING_DP * pixelRatio
     val height = settings.run { textBarMargin + textSize + height + (borderWidth * 2) }
     return Pair(width, height)
   }
@@ -247,7 +248,7 @@ class ScaleBarImpl : ScaleBar, View {
       if (unitDistance == 0) {
         unitDistance = 1
       } else {
-        unitBarWidth = (unitDistance / distancePerPixel) - INTERNAL_PADDING_DP * pixelRatio
+        unitBarWidth = (unitDistance / distancePerPixel)
       }
       // Drawing the surrounding borders
       barPaint.style = Paint.Style.FILL_AND_STROKE

--- a/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
+++ b/plugin-scalebar/src/main/java/com/mapbox/maps/plugin/scalebar/ScaleBarPluginImpl.kt
@@ -36,6 +36,7 @@ open class ScaleBarPluginImpl(
 
   override fun applySettings() {
     scaleBar.settings = internalSettings
+    invalidateScaleBar()
   }
 
   /**

--- a/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarImplTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/maps/plugin/scalebar/ScaleBarImplTest.kt
@@ -40,9 +40,11 @@ class ScaleBarImplTest {
 
   @Test
   fun calculateWidthAndHeight() {
+    scaleBarView.pixelRatio = 2.0f
     scaleBarView.mapViewWidth = 100f
     val viewSize = scaleBarView.calculateWidthAndHeight()
-    assertEquals(50.0f, viewSize.first)
+    // 50 + ScaleBarImpl.DEFAULT_PIXEL_RATIO * 2
+    assertEquals(70.0f, viewSize.first)
     assertEquals(22.0f, viewSize.second)
   }
 


### PR DESCRIPTION
Instead of minus `INTERNAL_PADDING_DP` while calculating unitBarWidth, now add `INTERNAL_PADDING_DP` to the width of scalebar to avoid the issue that scalebar is a litter shorter than it should be.

Invoke `invalidateScaleBar()` while updating scalebar settings to make sure it updates to the new state.

<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
