### PR TITLE
Keep the original animator owner for playAnimatorsTogether and playAnimatorsSequentially.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Bug fixes 🐞
 * Enable two finger pan gesture. ([#1280](https://github.com/mapbox/mapbox-maps-android/pull/1280))
 * Fix a bug that scale bar is shorter than it should be; trigger `invalidateScaleBar` while updating settings to make scale keep the latest status. ([#1336](https://github.com/mapbox/mapbox-maps-android/pull/1336))
+* Keep the original animator owner for `CameraAnimationsPlugin.playAnimatorsTogether` and `CameraAnimationsPlugin.playAnimatorsSequentially`. ([#1345](https://github.com/mapbox/mapbox-maps-android/pull/1345))
 
 ## Dependencies
 * Bump Mapbox Android base library to v0.8.0. ([#1323](https://github.com/mapbox/mapbox-maps-android/pull/1323))

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -782,7 +782,9 @@ class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     for (cameraAnimator in animators) {
       if (cameraAnimator is CameraAnimator<*>) {
         cameraAnimator.isInternal = true
-        cameraAnimator.owner = MapAnimationOwnerRegistry.INTERNAL
+        if (cameraAnimator.owner == null) {
+          cameraAnimator.owner = MapAnimationOwnerRegistry.INTERNAL
+        }
         cameraAnimators.add(cameraAnimator)
       } else {
         logE(TAG, "All animators must be CameraAnimator's to be played together!")
@@ -805,7 +807,9 @@ class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     for (cameraAnimator in animators) {
       if (cameraAnimator is CameraAnimator<*>) {
         cameraAnimator.isInternal = true
-        cameraAnimator.owner = MapAnimationOwnerRegistry.INTERNAL
+        if (cameraAnimator.owner == null) {
+          cameraAnimator.owner = MapAnimationOwnerRegistry.INTERNAL
+        }
         cameraAnimators.add(cameraAnimator)
       } else {
         logE(TAG, "All animators must be CameraAnimator's to be played sequentially!")

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -12,6 +12,7 @@ import com.mapbox.maps.*
 import com.mapbox.maps.plugin.animation.CameraAnimationsPluginImpl.Companion.TAG
 import com.mapbox.maps.plugin.animation.CameraAnimatorOptions.Companion.cameraAnimatorOptions
 import com.mapbox.maps.plugin.animation.MapAnimationOptions.Companion.mapAnimationOptions
+import com.mapbox.maps.plugin.animation.animator.CameraAnimator
 import com.mapbox.maps.plugin.animation.animator.CameraBearingAnimator
 import com.mapbox.maps.plugin.animation.animator.CameraCenterAnimator
 import com.mapbox.maps.plugin.animation.animator.CameraPitchAnimator
@@ -629,6 +630,30 @@ class CameraAnimationsPluginImplTest {
         assertEquals(pitchListener.started, true)
         assertEquals(pitchListener.ended, false)
         assertEquals(pitchListener.canceled, false)
+        assertEquals((it as CameraAnimator<*>).owner, MapAnimationOwnerRegistry.INTERNAL)
+      }
+    )
+
+    shadowOf(getMainLooper()).pause()
+
+    cameraAnimationsPluginImpl.playAnimatorsTogether(pitch, bearing)
+
+    shadowOf(getMainLooper()).idle()
+  }
+
+  @Test
+  fun testPlayAnimatorsTogetherCustomOwner() {
+    val pitch = createPitchAnimator(15.0, 0, 5, owner = MapAnimationOwnerRegistry.GESTURES)
+    val pitchListener = CameraAnimatorListener()
+    pitch.addListener(pitchListener)
+
+    val bearing = createBearingAnimator(10.0, 0, 5, owner = MapAnimationOwnerRegistry.GESTURES)
+    bearing.addListener(
+      onStart = {
+        assertEquals(pitchListener.started, true)
+        assertEquals(pitchListener.ended, false)
+        assertEquals(pitchListener.canceled, false)
+        assertEquals((it as CameraAnimator<*>).owner, MapAnimationOwnerRegistry.GESTURES)
       }
     )
 
@@ -1092,10 +1117,13 @@ class CameraAnimationsPluginImplTest {
     }
   }
 
-  private fun createBearingAnimator(target: Double, animatorDelay: Long, animatorDuration: Long) =
+  private fun createBearingAnimator(target: Double, animatorDelay: Long, animatorDuration: Long, owner: String? = null) =
     CameraBearingAnimator(
       cameraAnimatorOptions(target) {
         startValue(0.0)
+        owner?.let {
+          owner(it)
+        }
       },
       true
     ) {
@@ -1103,10 +1131,13 @@ class CameraAnimationsPluginImplTest {
       duration = animatorDuration
     }
 
-  private fun createPitchAnimator(target: Double, animatorDelay: Long, animatorDuration: Long) =
+  private fun createPitchAnimator(target: Double, animatorDelay: Long, animatorDuration: Long, owner: String? = null) =
     CameraPitchAnimator(
       cameraAnimatorOptions(target) {
         startValue(0.0)
+        owner?.let {
+          owner(it)
+        }
       }
     ) {
       startDelay = animatorDelay


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Fixes https://github.com/mapbox/mapbox-maps-android/issues/1312

This PR keeps the original owner for animators when using `CameraAnimationsPlugin.playAnimatorsTogether` and `CameraAnimationsPlugin.playAnimatorsSequentially`. 

The original owner is useful, as we detect whether the animation is driven by Gestures in the viewport plugin.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
