### PR TITLE
Rework MapboxMap.loadStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Introduce pinchScrollEnabled configuration to enable/disable 2-finger map panning, default to true. ([#1343](https://github.com/mapbox/mapbox-maps-android/pull/1343))
 * Re-throw native exceptions `jni::PendingJavaException` as readable Java exceptions with detailed exception text. ([#1363](https://github.com/mapbox/mapbox-maps-android/pull/1363))
 * Add static `MapView.isTerrainRenderingSupported()` method to validate if 3D terrain rendering is supported on given device. ([1368](https://github.com/mapbox/mapbox-maps-android/pull/1368))
-* Optimize `MapView.loadStyle()` to apply styling properties earlier. [#1362](https://github.com/mapbox/mapbox-maps-android/pull/1362)
+* Optimize `MapboxMap.loadStyle()` to apply styling properties earlier. [#1362](https://github.com/mapbox/mapbox-maps-android/pull/1362)
 
 ## Bug fixes 🐞
 * Enable two finger pan gesture. ([#1280](https://github.com/mapbox/mapbox-maps-android/pull/1280))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Introduce pinchScrollEnabled configuration to enable/disable 2-finger map panning, default to true. ([#1343](https://github.com/mapbox/mapbox-maps-android/pull/1343))
 * Re-throw native exceptions `jni::PendingJavaException` as readable Java exceptions with detailed exception text. ([#1363](https://github.com/mapbox/mapbox-maps-android/pull/1363))
 * Add static `MapView.isTerrainRenderingSupported()` method to validate if 3D terrain rendering is supported on given device. ([1368](https://github.com/mapbox/mapbox-maps-android/pull/1368))
+* Optimize `MapView.loadStyle()` to apply styling properties earlier. [#1362](https://github.com/mapbox/mapbox-maps-android/pull/1362)
 
 ## Bug fixes 🐞
 * Enable two finger pan gesture. ([#1280](https://github.com/mapbox/mapbox-maps-android/pull/1280))

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/GlobeActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/GlobeActivity.kt
@@ -53,7 +53,6 @@ class GlobeActivity : AppCompatActivity() {
     infoTextView = binding.infoText
     mapboxMap = binding.mapView.getMapboxMap().apply {
       // set globe projection even before style load so that it appears immediately
-      setMapProjection(currentProjectionName.toMapProjection())
       loadStyle(
         style(Style.TRAFFIC_DAY) {
           +fillExtrusionLayer("3d-buildings", "composite") {
@@ -74,6 +73,7 @@ class GlobeActivity : AppCompatActivity() {
             skyType(SkyType.ATMOSPHERE)
             skyAtmosphereSun(listOf(15.0, 89.5))
           }
+          +projection(ProjectionName.GLOBE)
         }
       )
     }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/HeatmapLayerActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/HeatmapLayerActivity.kt
@@ -13,7 +13,6 @@ import com.mapbox.maps.extension.style.layers.generated.circleLayer
 import com.mapbox.maps.extension.style.layers.generated.heatmapLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.ProjectionName
 import com.mapbox.maps.extension.style.projection.generated.projection
-import com.mapbox.maps.extension.style.projection.generated.setProjection
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/HeatmapLayerActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/HeatmapLayerActivity.kt
@@ -17,6 +17,7 @@ import com.mapbox.maps.extension.style.projection.generated.setProjection
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
+import com.mapbox.maps.extension.style.style
 import com.mapbox.maps.testapp.databinding.ActivityHeatmapLayerBinding
 
 /**
@@ -33,11 +34,11 @@ class HeatmapLayerActivity : AppCompatActivity() {
     setContentView(binding.root)
 
     mapboxMap = binding.mapView.getMapboxMap().apply {
-      loadStyleUri(
-        styleUri = Style.DARK
+      loadStyle(
+        style(Style.DARK) {
+          +projection(ProjectionName.GLOBE)
+        }
       ) { style ->
-        // setting projection as part of runtime styling
-        style.setProjection(projection(ProjectionName.GLOBE))
         addRuntimeLayers(style)
       }
     }

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -1701,7 +1701,7 @@ class MapboxMap :
    */
   @MapboxExperimental
   @Deprecated(
-    "Use Projection style extension instead.",
+    "Use style extension instead: `loadStyle(styleUri) { +projection(projectionName) }`"
   )
   override fun setMapProjection(mapProjection: MapProjection) {
     checkNativeMap("setMapProjection")
@@ -1724,6 +1724,9 @@ class MapboxMap :
    * @return [MapProjection] map is using.
    */
   @MapboxExperimental
+  @Deprecated(
+    "Use Style.getProjection instead"
+  )
   override fun getMapProjection(): MapProjection {
     checkNativeMap("getMapProjection")
     nativeMap.getStyleProjectionProperty("name").apply {

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -276,11 +276,7 @@ class MapboxMap :
     checkNativeMap("loadStyle")
     initializeStyleLoad(
       onStyleLoaded = { style ->
-        // TODO order of styleDataSourcesLoadedListener / styleDataSpritesLoadedListener is not defined
-        // and the callbacks are optional - e.g. style without sources / sprites won't trigger those events.
-        // To make sure every style extension component is loaded
-        // we bind them in the final onStyleLoaded callback.
-        // Need to revisit in 10.6.0-beta.2
+        // TODO https://github.com/mapbox/mapbox-maps-android/issues/1371
         styleExtension.images.forEach {
           it.bindTo(style)
         }
@@ -300,7 +296,7 @@ class MapboxMap :
         transitionOptions?.let(style::setStyleTransition)
       },
       styleDataSourcesLoadedListener = { style ->
-        // TODO
+        // TODO https://github.com/mapbox/mapbox-maps-android/issues/1371
 //        styleExtension.sources.forEach {
 //          it.bindTo(style)
 //        }
@@ -309,7 +305,7 @@ class MapboxMap :
 //        }
       },
       styleDataSpritesLoadedListener = { style ->
-        // TODO
+        // TODO https://github.com/mapbox/mapbox-maps-android/issues/1371
 //        styleExtension.images.forEach {
 //          it.bindTo(style)
 //        }

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -231,10 +231,10 @@ class MapboxMap :
     checkNativeMap("loadStyleJson")
     initializeStyleLoad(
       onStyleLoaded,
-      styleDataStyleLoadedListener = if (styleTransitionOptions != null) {
-        { it.styleTransition = styleTransitionOptions }
-      } else null,
-      onMapLoadErrorListener = styleTransitionOptions
+      styleDataStyleLoadedListener = {
+        styleTransitionOptions?.let(it::setStyleTransition)
+      },
+      onMapLoadErrorListener = onMapLoadErrorListener
     )
     nativeMap.styleJSON = styleJson
   }

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -44,9 +44,9 @@ internal class StyleObserver(
    */
   fun setLoadStyleListener(
     userOnStyleLoaded: Style.OnStyleLoaded?,
-    styleDataStyleLoadedListener: Style.OnStyleLoaded? = null,
-    styleDataSpritesLoadedListener: Style.OnStyleLoaded? = null,
-    styleDataSourcesLoadedListener: Style.OnStyleLoaded? = null,
+    styleDataStyleLoadedListener: Style.OnStyleLoaded?,
+    styleDataSpritesLoadedListener: Style.OnStyleLoaded?,
+    styleDataSourcesLoadedListener: Style.OnStyleLoaded?,
     onMapLoadErrorListener: OnMapLoadErrorListener?
   ) {
     this.userStyleLoadedListener = userOnStyleLoaded
@@ -114,6 +114,9 @@ internal class StyleObserver(
 
   fun onDestroy() {
     userStyleLoadedListener = null
+    styleDataStyleLoadedListener = null
+    styleDataSpritesLoadedListener = null
+    styleDataSourcesLoadedListener = null
     loadStyleErrorListener = null
     loadedStyle?.markInvalid()
     loadedStyle = null

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -53,7 +53,7 @@ internal class StyleObserver(
     this.styleDataStyleLoadedListener = styleDataStyleLoadedListener
     this.styleDataSpritesLoadedListener = styleDataSpritesLoadedListener
     this.styleDataSourcesLoadedListener = styleDataSourcesLoadedListener
-    loadStyleErrorListener = onMapLoadErrorListener
+    this.loadStyleErrorListener = onMapLoadErrorListener
   }
 
   /**
@@ -68,8 +68,7 @@ internal class StyleObserver(
    * Invoked when a style has loaded
    */
   override fun onStyleLoaded(eventData: StyleLoadedEventData) {
-    println("OnStyleLoaded : $eventData")
-    val style = loadedStyle!!
+    val style = loadedStyle ?: throw MapboxMapException("Style is not initialized on onStyleLoaded callback!")
     styleLoadedListener.onStyleLoaded(style)
 
     userStyleLoadedListener?.onStyleLoaded(style)
@@ -90,7 +89,6 @@ internal class StyleObserver(
   }
 
   override fun onStyleDataLoaded(eventData: StyleDataLoadedEventData) {
-    println("Style data : $eventData")
     when (eventData.type) {
       StyleDataType.STYLE -> {
         loadedStyle?.markInvalid()
@@ -100,11 +98,15 @@ internal class StyleObserver(
         styleDataStyleLoadedListener = null
       }
       StyleDataType.SPRITE -> {
-        styleDataSpritesLoadedListener?.onStyleLoaded(loadedStyle!!)
+        styleDataSpritesLoadedListener?.onStyleLoaded(
+          loadedStyle ?: throw MapboxMapException("Style is not initialized but SPRITES event have arrived!")
+        )
         styleDataSpritesLoadedListener = null
       }
       StyleDataType.SOURCES -> {
-        styleDataSourcesLoadedListener?.onStyleLoaded(loadedStyle!!)
+        styleDataSourcesLoadedListener?.onStyleLoaded(
+          loadedStyle ?: throw MapboxMapException("Style is not initialized but SOURCES event have arrived!")
+        )
         styleDataSourcesLoadedListener = null
       }
     }

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -99,13 +99,13 @@ internal class StyleObserver(
       }
       StyleDataType.SPRITE -> {
         styleDataSpritesLoadedListener?.onStyleLoaded(
-          loadedStyle ?: throw MapboxMapException("Style is not initialized but SPRITES event have arrived!")
+          loadedStyle ?: throw MapboxMapException("Style is not initialized yet although SPRITES event has arrived!")
         )
         styleDataSpritesLoadedListener = null
       }
       StyleDataType.SOURCES -> {
         styleDataSourcesLoadedListener?.onStyleLoaded(
-          loadedStyle ?: throw MapboxMapException("Style is not initialized but SOURCES event have arrived!")
+          loadedStyle ?: throw MapboxMapException("Style is not initialized yet although SOURCES event has arrived!")
         )
         styleDataSourcesLoadedListener = null
       }

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -198,7 +198,7 @@ class MapboxMapTest {
     verifyNo { layer.bindTo(style, layerPosition) }
     verifyNo { styleLoadCallback.onStyleLoaded(style) }
 
-    // TODO
+    // TODO https://github.com/mapbox/mapbox-maps-android/issues/1371
 //    callbackStyleSpritesSlots.first()!!.onStyleLoaded(style)
 //
 //    verify { image.bindTo(style) }
@@ -1113,7 +1113,7 @@ class MapboxMapTest {
   @Test
   fun setsStyleTransitionAfterOnStyleDataEvent() {
     val options = mockk<TransitionOptions>(relaxed = true)
-    val style = mockk<Style>(relaxed = true)
+    val style = mockk<Style>(relaxUnitFun = true)
     mapboxMap.loadStyleUri(
       "style",
       options,

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -132,6 +132,7 @@ class MapboxMapTest {
     assertTrue(mapboxMap.isStyleLoadInitiated)
   }
 
+  // TODO fix test
   @Test
   fun bindsStyleExtensionComponentsInCorrectOrderAfterStyleDataLoadEvents() {
     val style = mockk<Style>()
@@ -166,7 +167,7 @@ class MapboxMapTest {
     val callbackStyleSpritesSlots = mutableListOf<Style.OnStyleLoaded?>()
     val callbackStyleSourcesSlots = mutableListOf<Style.OnStyleLoaded?>()
 
-    mapboxMap.loadStyle(styleExtension)
+    mapboxMap.loadStyle(styleExtension, styleLoadCallback)
 
     verify {
       styleObserver.setLoadStyleListener(
@@ -198,17 +199,24 @@ class MapboxMapTest {
     verifyNo { layer.bindTo(style, layerPosition) }
     verifyNo { styleLoadCallback.onStyleLoaded(style) }
 
-    callbackStyleSpritesSlots.first()!!.onStyleLoaded(style)
+    // TODO
+//    callbackStyleSpritesSlots.first()!!.onStyleLoaded(style)
+//
+//    verify { image.bindTo(style) }
+//    verifyNo { source.bindTo(style) }
+//    verifyNo { layer.bindTo(style, layerPosition) }
+//    verifyNo { styleLoadCallback.onStyleLoaded(style) }
+//
+//    callbackStyleSourcesSlots.first()!!.onStyleLoaded(style)
+//
+//    verify { source.bindTo(style) }
+//    verify { layer.bindTo(style, layerPosition) }
 
+    userCallbackStyleSlots.first()!!.onStyleLoaded(style)
     verify { image.bindTo(style) }
-    verifyNo { source.bindTo(style) }
-    verifyNo { layer.bindTo(style, layerPosition) }
-    verifyNo { styleLoadCallback.onStyleLoaded(style) }
-
-    callbackStyleSourcesSlots.first()!!.onStyleLoaded(style)
-
     verify { source.bindTo(style) }
     verify { layer.bindTo(style, layerPosition) }
+    verify { styleLoadCallback.onStyleLoaded(style) }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -161,19 +161,19 @@ class MapboxMapTest {
 
     val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
 
-    val userCallbackStyleSlot = CapturingSlot<Style.OnStyleLoaded>()
-    val callbackStyleSlot = CapturingSlot<Style.OnStyleLoaded>()
-    val callbackStyleSpritesSlot = CapturingSlot<Style.OnStyleLoaded>()
-    val callbackStyleSourcesSlot = CapturingSlot<Style.OnStyleLoaded>()
+    val userCallbackStyleSlots = mutableListOf<Style.OnStyleLoaded?>()
+    val callbackStyleSlots = mutableListOf<Style.OnStyleLoaded?>()
+    val callbackStyleSpritesSlots = mutableListOf<Style.OnStyleLoaded?>()
+    val callbackStyleSourcesSlots = mutableListOf<Style.OnStyleLoaded?>()
 
     mapboxMap.loadStyle(styleExtension)
 
     verify {
       styleObserver.setLoadStyleListener(
-        capture(userCallbackStyleSlot),
-        capture(callbackStyleSlot),
-        capture(callbackStyleSpritesSlot),
-        capture(callbackStyleSourcesSlot),
+        captureNullable(userCallbackStyleSlots),
+        captureNullable(callbackStyleSlots),
+        captureNullable(callbackStyleSpritesSlots),
+        captureNullable(callbackStyleSourcesSlots),
         any(),
       )
     }
@@ -187,7 +187,7 @@ class MapboxMapTest {
     verifyNo { atmosphere.bindTo(style) }
     verifyNo { styleLoadCallback.onStyleLoaded(style) }
 
-    callbackStyleSlot.captured.onStyleLoaded(style)
+    callbackStyleSlots.first()!!.onStyleLoaded(style)
 
     verify { light.bindTo(style) }
     verify { terrain.bindTo(style) }
@@ -198,14 +198,14 @@ class MapboxMapTest {
     verifyNo { layer.bindTo(style, layerPosition) }
     verifyNo { styleLoadCallback.onStyleLoaded(style) }
 
-    callbackStyleSpritesSlot.captured.onStyleLoaded(style)
+    callbackStyleSpritesSlots.first()!!.onStyleLoaded(style)
 
     verify { image.bindTo(style) }
     verifyNo { source.bindTo(style) }
     verifyNo { layer.bindTo(style, layerPosition) }
     verifyNo { styleLoadCallback.onStyleLoaded(style) }
 
-    callbackStyleSourcesSlot.captured.onStyleLoaded(style)
+    callbackStyleSourcesSlots.first()!!.onStyleLoaded(style)
 
     verify { source.bindTo(style) }
     verify { layer.bindTo(style, layerPosition) }

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -4,7 +4,6 @@ import android.os.Looper
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Point
-import com.mapbox.maps.extension.observable.eventdata.MapLoadingErrorEventData
 import com.mapbox.maps.extension.style.StyleContract
 import com.mapbox.maps.extension.style.style
 import com.mapbox.maps.plugin.MapProjection

--- a/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
@@ -647,6 +647,4 @@ class NativeObserverTest {
     assertTrue(nativeObserver.onStyleImageUnusedListeners.isEmpty())
     assertTrue(nativeObserver.onStyleDataLoadedListeners.isEmpty())
   }
-
-
 }

--- a/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
@@ -647,4 +647,6 @@ class NativeObserverTest {
     assertTrue(nativeObserver.onStyleImageUnusedListeners.isEmpty())
     assertTrue(nativeObserver.onStyleDataLoadedListeners.isEmpty())
   }
+
+
 }

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -1,7 +1,6 @@
 package com.mapbox.maps
 
 import com.mapbox.maps.extension.observable.eventdata.StyleDataLoadedEventData
-import com.mapbox.maps.extension.observable.eventdata.StyleLoadedEventData
 import com.mapbox.maps.extension.observable.model.StyleDataType
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.verifyNo

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -162,7 +162,7 @@ class StyleObserverTest {
 
   @Test
   fun onStyleDataLoadedNotifiesMapboxMap() {
-    val nativeMap = mockk<MapInterface>(relaxed = true)
+    val nativeMap = mockk<MapInterface>(relaxUnitFun = true)
     val styleObserver = StyleObserver(
       nativeMap = nativeMap,
       styleLoadedListener = mockk(relaxUnitFun = true),
@@ -318,7 +318,7 @@ class StyleObserverTest {
 
   @Test
   fun onStyleDataSpritesThrowsIfNoStyleData() {
-    val nativeMap = mockk<MapInterface>(relaxed = true)
+    val nativeMap = mockk<MapInterface>(relaxUnitFun = true)
     val styleObserver = StyleObserver(
       nativeMap = nativeMap,
       styleLoadedListener = mockk(relaxUnitFun = true),
@@ -345,11 +345,11 @@ class StyleObserverTest {
 
   @Test
   fun onStyleLoadedThrowsIfNoStyleData() {
-    val nativeMap = mockk<MapInterface>(relaxed = true)
+    val nativeMap = mockk<MapInterface>(relaxUnitFun = true)
     val styleObserver = StyleObserver(
       nativeMap = nativeMap,
       styleLoadedListener = mockk(relaxUnitFun = true),
-      nativeObserver = mockk(relaxed = true),
+      nativeObserver = mockk(relaxUnitFun = true),
       pixelRatio = 1.0f
     )
 

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -1,10 +1,13 @@
 package com.mapbox.maps
 
 import com.mapbox.maps.extension.observable.eventdata.StyleDataLoadedEventData
+import com.mapbox.maps.extension.observable.eventdata.StyleLoadedEventData
 import com.mapbox.maps.extension.observable.model.StyleDataType
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
+import com.mapbox.verifyNo
 import io.mockk.*
 import org.junit.After
+import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -63,14 +66,11 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val styleLoaded = mockk<Style.OnStyleLoaded>(relaxed = true)
-    val styleDataLoaded = mockk<StyleDataLoadedEventData>(relaxed = true)
-    every { styleDataLoaded.type } returns StyleDataType.STYLE
-    styleObserver.setLoadStyleListener(null, styleLoaded, null)
+    styleObserver.setLoadStyleListener(styleLoaded, null, null, null, null)
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE)) // needed to initialize style internally
     styleObserver.onStyleLoaded(mockk())
-    styleObserver.onStyleDataLoaded(styleDataLoaded)
     verify(exactly = 1) { styleLoaded.onStyleLoaded(any()) }
     verify(exactly = 1) { mainStyleLoadedListener.onStyleLoaded(any()) }
-    verify(exactly = 0) { nativeMap.styleTransition = any() }
   }
 
   /**
@@ -84,14 +84,21 @@ class StyleObserverTest {
       nativeObserver = mockk(relaxed = true),
       pixelRatio = 1.0f
     )
-    val loadStyleListener = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(null, loadStyleListener, null)
+    val userLoadStyleListener = mockk<Style.OnStyleLoaded>(relaxed = true)
+    styleObserver.setLoadStyleListener(
+      userLoadStyleListener,
+      null,
+      null,
+      null,
+      null
+    )
     val getStyleListener = mockk<Style.OnStyleLoaded>(relaxed = true)
     styleObserver.addGetStyleListener(getStyleListener)
     val getStyleListener2 = mockk<Style.OnStyleLoaded>(relaxed = true)
     styleObserver.addGetStyleListener(getStyleListener2)
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE)) // needed to initialize style internally
     styleObserver.onStyleLoaded(mockk())
-    verify { loadStyleListener.onStyleLoaded(any()) }
+    verify { userLoadStyleListener.onStyleLoaded(any()) }
     verify { getStyleListener.onStyleLoaded(any()) }
     verify { getStyleListener2.onStyleLoaded(any()) }
   }
@@ -108,9 +115,10 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val styleLoadedFail = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(null, styleLoadedFail, null)
+    styleObserver.setLoadStyleListener(styleLoadedFail, null, null, null, null)
     val styleLoadedSuccess = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(null, styleLoadedSuccess, null)
+    styleObserver.setLoadStyleListener(styleLoadedSuccess, null, null, null, null)
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE)) // needed to initialize style internally
     styleObserver.onStyleLoaded(mockk())
     verify(exactly = 0) { styleLoadedFail.onStyleLoaded(any()) }
     verify { styleLoadedSuccess.onStyleLoaded(any()) }
@@ -128,7 +136,7 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val errorListener = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.setLoadStyleListener(null, mockk(relaxed = true), errorListener)
+    styleObserver.setLoadStyleListener(null, null, null, null, errorListener)
     styleObserver.onMapLoadError(mockk(relaxed = true))
     verify { errorListener.onMapLoadError(any()) }
   }
@@ -145,19 +153,16 @@ class StyleObserverTest {
       pixelRatio = 1.0f
     )
     val errorListenerFail = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.setLoadStyleListener(null, mockk(relaxed = true), errorListenerFail)
+    styleObserver.setLoadStyleListener(null, null, null, null, errorListenerFail)
     val errorListenerSuccess = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.setLoadStyleListener(null, mockk(relaxed = true), errorListenerSuccess)
+    styleObserver.setLoadStyleListener(null, null, null, null, errorListenerSuccess)
     styleObserver.onMapLoadError(mockk(relaxed = true))
     verify(exactly = 0) { errorListenerFail.onMapLoadError(any()) }
     verify { errorListenerSuccess.onMapLoadError(any()) }
   }
 
-  /**
-   * Verify we trigger core set style transition when callback is triggered.
-   */
   @Test
-  fun onStyleDataLoadedCustomTransitionOptions() {
+  fun onStyleDataLoadedNotifiesMapboxMap() {
     val nativeMap = mockk<MapInterface>(relaxed = true)
     val styleObserver = StyleObserver(
       nativeMap = nativeMap,
@@ -165,18 +170,204 @@ class StyleObserverTest {
       nativeObserver = mockk(relaxed = true),
       pixelRatio = 1.0f
     )
-    val transitionOptions = mockk<TransitionOptions>()
-    styleObserver.setLoadStyleListener(transitionOptions, mockk(), null)
-    val styleDataLoaded = mockk<StyleDataLoadedEventData>()
-    every { styleDataLoaded.type } returns StyleDataType.STYLE
-    styleObserver.onStyleDataLoaded(styleDataLoaded)
-    // verify we do call native method after style
-    verify(exactly = 1) { nativeMap.styleTransition = transitionOptions }
-    every { styleDataLoaded.type } returns StyleDataType.SOURCES
-    styleObserver.onStyleDataLoaded(styleDataLoaded)
-    every { styleDataLoaded.type } returns StyleDataType.SPRITE
-    styleObserver.onStyleDataLoaded(styleDataLoaded)
-    // verify no more calls did happen (meaning there should be one method call)
-    verify(exactly = 1) { nativeMap.styleTransition = transitionOptions }
+
+    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(
+      null,
+      styleCallback,
+      styleSpritesCallback,
+      styleSourcesCallback,
+      null
+    )
+
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE))
+
+    verify { styleCallback.onStyleLoaded(any()) }
+    verifyNo { styleSpritesCallback.onStyleLoaded(any()) }
+    verifyNo { styleSourcesCallback.onStyleLoaded(any()) }
+  }
+
+  @Test
+  fun onStyleDataSpritesLoadedNotifiesMapboxMap() {
+    val nativeMap = mockk<MapInterface>(relaxed = true)
+    val styleObserver = StyleObserver(
+      nativeMap = nativeMap,
+      styleLoadedListener = mockk(relaxUnitFun = true),
+      nativeObserver = mockk(relaxed = true),
+      pixelRatio = 1.0f
+    )
+
+    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(
+      null,
+      styleCallback,
+      styleSpritesCallback,
+      styleSourcesCallback,
+      null
+    )
+
+    // STYLE event arrives first and initializes Style object internally
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE))
+
+    verify { styleCallback.onStyleLoaded(any()) }
+    verifyNo { styleSpritesCallback.onStyleLoaded(any()) }
+
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SPRITE))
+
+    verify { styleSpritesCallback.onStyleLoaded(any()) }
+    verifyNo { styleSourcesCallback.onStyleLoaded(any()) }
+  }
+
+  @Test
+  fun onStyleDataSourcesLoadedNotifiesMapboxMap() {
+    val nativeMap = mockk<MapInterface>(relaxed = true)
+    val styleObserver = StyleObserver(
+      nativeMap = nativeMap,
+      styleLoadedListener = mockk(relaxUnitFun = true),
+      nativeObserver = mockk(relaxed = true),
+      pixelRatio = 1.0f
+    )
+
+    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(
+      null,
+      styleCallback,
+      styleSpritesCallback,
+      styleSourcesCallback,
+      null
+    )
+
+    // STYLE event arrives first and initializes Style object internally
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE))
+
+    verifyNo { styleSourcesCallback.onStyleLoaded(any()) }
+
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SOURCES))
+
+    verify { styleSourcesCallback.onStyleLoaded(any()) }
+    verify { styleCallback.onStyleLoaded(any()) }
+    verifyNo { styleSpritesCallback.onStyleLoaded(any()) }
+  }
+
+  @Test
+  fun onStyleDataOverwritten() {
+    val styleObserver = StyleObserver(
+      nativeMap = mockk(relaxed = true),
+      styleLoadedListener = mockk(relaxed = true),
+      nativeObserver = mockk(relaxed = true),
+      pixelRatio = 1.0f
+    )
+    val styleNotCalled = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val spritesNotCalled = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val sourcesNotCalled = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    val styleCalled = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val spritesCalled = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val sourcesCalled = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(null, styleNotCalled, spritesNotCalled, sourcesNotCalled, null)
+    styleObserver.setLoadStyleListener(null, styleCalled, spritesCalled, sourcesCalled, null)
+
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE))
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SOURCES))
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SPRITE))
+
+    verifyNo { styleNotCalled.onStyleLoaded(any()) }
+    verifyNo { spritesNotCalled.onStyleLoaded(any()) }
+    verifyNo { sourcesNotCalled.onStyleLoaded(any()) }
+
+    verify { styleCalled.onStyleLoaded(any()) }
+    verify { spritesCalled.onStyleLoaded(any()) }
+    verify { sourcesCalled.onStyleLoaded(any()) }
+  }
+
+  @Test
+  fun onStyleDataSourcesThrowsIfNoStyleData() {
+    val nativeMap = mockk<MapInterface>(relaxed = true)
+    val styleObserver = StyleObserver(
+      nativeMap = nativeMap,
+      styleLoadedListener = mockk(relaxUnitFun = true),
+      nativeObserver = mockk(relaxed = true),
+      pixelRatio = 1.0f
+    )
+
+    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(
+      null,
+      styleCallback,
+      styleSpritesCallback,
+      styleSourcesCallback,
+      null
+    )
+
+    assertThrows(MapboxMapException::class.java) {
+      styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SOURCES))
+    }
+  }
+
+  @Test
+  fun onStyleDataSpritesThrowsIfNoStyleData() {
+    val nativeMap = mockk<MapInterface>(relaxed = true)
+    val styleObserver = StyleObserver(
+      nativeMap = nativeMap,
+      styleLoadedListener = mockk(relaxUnitFun = true),
+      nativeObserver = mockk(relaxed = true),
+      pixelRatio = 1.0f
+    )
+
+    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(
+      null,
+      styleCallback,
+      styleSpritesCallback,
+      styleSourcesCallback,
+      null
+    )
+
+    assertThrows(MapboxMapException::class.java) {
+      styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SPRITE))
+    }
+  }
+
+  @Test
+  fun onStyleLoadedThrowsIfNoStyleData() {
+    val nativeMap = mockk<MapInterface>(relaxed = true)
+    val styleObserver = StyleObserver(
+      nativeMap = nativeMap,
+      styleLoadedListener = mockk(relaxUnitFun = true),
+      nativeObserver = mockk(relaxed = true),
+      pixelRatio = 1.0f
+    )
+
+    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(
+      null,
+      styleCallback,
+      styleSpritesCallback,
+      styleSourcesCallback,
+      null
+    )
+
+    assertThrows(MapboxMapException::class.java) {
+      styleObserver.onStyleLoaded(mockk())
+    }
   }
 }


### PR DESCRIPTION
Another approach to fix #1353 - apply styleExtension properties as soon as the corresponding style data event arrives.

With this change order of styleExtension properties applied is as follows :
1. fog, light, terrain, projection - after StyleDataType.STYLE
2. images - after StyleDataType.SPRITE
3. sources and layers - after StyleDataType.SOURCES

Note that order of StyleDataType.SPRITE and StyleDataType.SOURCES events is _NOT_ guaranteed and in fact often arrives differently. However this does not seem to be a problem (discussed with @alexshalamov, but please confirm). 

Tested briefly - everything seems working, however since change can be very impactful will require more thorough manual / unit tests.

<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: #1127

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
