### PR TITLE
Rethrow exception on main thread for observer callback code paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Re-introduce partial tile loading feature that decreases map load times. ([#1351](https://github.com/mapbox/mapbox-maps-android/pull/1351))
 * The `TilesetDescriptorOptions.pixelRatio` parameter is now passed to the TileStore and considered for the raster tile pack loading. This enables loading of a raster tilepacks for retina displays. ([#1351](https://github.com/mapbox/mapbox-maps-android/pull/1351))
 * Introduce pinchScrollEnabled configuration to enable/disable 2-finger map panning, default to true. ([#1343](https://github.com/mapbox/mapbox-maps-android/pull/1343))
+* Re-throw native exceptions `jni::PendingJavaException` as readable Java exceptions with detailed exception text. ([#1363](https://github.com/mapbox/mapbox-maps-android/pull/1363))
 
 ## Bug fixes 🐞
 * Enable two finger pan gesture. ([#1280](https://github.com/mapbox/mapbox-maps-android/pull/1280))
@@ -805,7 +806,7 @@ mapView.location2.puckBearingEnabled = false
 
 ## Features ✨ and improvements 🏁
 * Rework setPrefetchZoomDelta to reduce loading of expensive tiles and optimize zoom use-case (#1850)
-* Send billing event when Map is loaded 
+* Send billing event when Map is loaded
 
 ## Bug fixes 🐞
 * Fixed an issue that causes OnStyleLoaded callback not fired when there's a sprite loading error. ([#358](https://github.com/mapbox/mapbox-maps-android/pull/358))
@@ -840,7 +841,7 @@ mapView.location2.puckBearingEnabled = false
 * Add API for disabling vertical/horizontal scroll gestures ([#319](https://github.com/mapbox/mapbox-maps-android/pull/319))
 * Introduce API to enable render cache feature that could bring up rendering performance improvement. ([#326](https://github.com/mapbox/mapbox-maps-android/pull/326))
 * Add `removeAnnotationManager` API. ([#330](https://github.com/mapbox/mapbox-maps-android/pull/330))
-* Improve terrain's rendering performance 
+* Improve terrain's rendering performance
 * Set `begin` and `end` timestamps for StyleLoaded and MapLoaded events, so that developers could check how much time it takes to load style and map, respectively
 * Added `tile-requests-delay` and `tile-network-requests-delay` runtime source properties - an API for tile requests delay
 * Introduce MapOptions.optimizeForTerrain option that allow style rendering optimizations for terrain rendering
@@ -925,12 +926,12 @@ mapView.location2.puckBearingEnabled = false
 * Add feature sdk initialisation ([#269](https://github.com/mapbox/mapbox-maps-android/pull/269))
   - Load the Mapbox Street style by default if user doesn't load any style before the onStart lifecycle event.
   - Introduce `CredentialsManager` to manage mapbox access token, when all `MapView`s should use same token could be handled by using `CredentialsManager.shared` static object.
-  - Introduce `MapInitOptions` to replace MapboxMapOptions. 
+  - Introduce `MapInitOptions` to replace MapboxMapOptions.
 ## Features ✨ and improvements 🏁
 * High-level animations return cancelable interface ([#262](https://github.com/mapbox/mapbox-maps-android/pull/262))
 * Introduce OfflineManager API that manages style packs and produces tileset descriptors for the tile store.
   - By default, users may download up to 250MB of data for offline use without incurring additional charges. This limit is subject to change during the beta.
-  - The new API replaces the deprecated OfflineRegionManager API. The OfflineManager API can be used to create offline style packs that contain style data, such as: style definition, sprites, fonts and other resources. Tileset descriptors created by the OfflineManager API are used to create tile packs via TileStore API. Mobile maps SDKs use tile packs for rendering map content. 
+  - The new API replaces the deprecated OfflineRegionManager API. The OfflineManager API can be used to create offline style packs that contain style data, such as: style definition, sprites, fonts and other resources. Tileset descriptors created by the OfflineManager API are used to create tile packs via TileStore API. Mobile maps SDKs use tile packs for rendering map content.
 * Add offline activity example. ([#259](https://github.com/mapbox/mapbox-maps-android/pull/259))
 * Load the Mapbox Street style by default if user doesn't load any style before the onStart lifecycle event([#248](https://github.com/mapbox/mapbox-maps-android/pull/248))
 
@@ -951,10 +952,10 @@ mapView.location2.puckBearingEnabled = false
     - Circle -> CircleAnnotation
     - Line -> PolylineAnnotation
     - Fill -> PolygonAnnotation
-* mapboxMap.queryRenderedFeatures will return a new data class QueriedFeature which will contain additional properties ([#247](https://github.com/mapbox/mapbox-maps-android/pull/247)): 
+* mapboxMap.queryRenderedFeatures will return a new data class QueriedFeature which will contain additional properties ([#247](https://github.com/mapbox/mapbox-maps-android/pull/247)):
     - source (id of the source)
     - sourceLayer (id of the source's layer)
-    - state (feature's state) 
+    - state (feature's state)
 * Rename Style#isStyleFullyLoaded to Style#isStyleLoaded
 * Remove old map#drag API and the AnimationOptions API
 * Don't emit MapIdle event when there is gesture and / or user animation in progress


### PR DESCRIPTION
### Summary of changes

Trigger exception coming from observer callback code path to trigger on the main thread. 
This avoids raising a native crash with pending java exception.

#### Before
```
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err: java.lang.RuntimeException: HELLO WORLD
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at com.mapbox.maps.testapp.examples.SimpleMapActivity.onCreate$lambda-0(SimpleMapActivity.kt:21)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at com.mapbox.maps.testapp.examples.SimpleMapActivity.$r8$lambda$XCnBnNpGBwvzAsgkwLSb_B8XL60(Unknown Source:0)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at com.mapbox.maps.testapp.examples.SimpleMapActivity$$ExternalSyntheticLambda0.onStyleLoaded(Unknown Source:0)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at com.mapbox.maps.StyleObserver.onStyleLoaded(StyleObserver.kt:68)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at com.mapbox.maps.NativeObserver.notify(NativeObserver.kt:62)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at android.os.MessageQueue.nativePollOnce(Native Method)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at android.os.MessageQueue.next(MessageQueue.java:335)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at android.os.Looper.loopOnce(Looper.java:161)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at android.os.Looper.loop(Looper.java:288)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at android.app.ActivityThread.main(ActivityThread.java:7844)
2022-05-18 09:31:50.043 21267-21267/com.mapbox.maps.testapp W/System.err:     at java.lang.reflect.Method.invoke(Native Method)
2022-05-18 09:31:50.044 21267-21267/com.mapbox.maps.testapp W/System.err:     at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
2022-05-18 09:31:50.044 21267-21267/com.mapbox.maps.testapp W/System.err:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
2022-05-18 09:31:50.045 21267-21267/com.mapbox.maps.testapp E/libc++abi: terminating with uncaught exception of type jni::PendingJavaException
2022-05-18 09:31:50.045 21267-21267/com.mapbox.maps.testapp A/libc: Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 21267 (ox.maps.testapp), pid 21267 (ox.maps.testapp)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: Build fingerprint: 'google/sunfish/sunfish:Tiramisu/TPB1.220310.029/8473704:user/release-keys'
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: Revision: 'MP1.0'
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: ABI: 'arm64'
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: Timestamp: 2022-05-18 09:31:50.104965027+0200
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: Process uptime: 6s
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: Cmdline: com.mapbox.maps.testapp
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: pid: 21267, tid: 21267, name: ox.maps.testapp  >>> com.mapbox.maps.testapp <<<
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: uid: 10385
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: Abort message: 'terminating with uncaught exception of type jni::PendingJavaException'
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:     x0  0000000000000000  x1  0000000000005313  x2  0000000000000006  x3  0000007fe94d4e40
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:     x4  736f646277641f73  x5  736f646277641f73  x6  736f646277641f73  x7  7f7f7f7f7f7f7f7f
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:     x8  00000000000000f0  x9  0000007cea0c7810  x10 0000000000000001  x11 0000007cea10593c
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:     x12 0000000000000018  x13 000000c39e3f59f6  x14 00027804f527f615  x15 0000000000253008
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:     x16 0000007cea169d20  x17 0000007cea147410  x18 0000007cf4a70000  x19 0000000000005313
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:     x20 0000000000005313  x21 00000000ffffffff  x22 ffffff80ffffffc8  x23 0000007fe94d5090
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:     x24 0000007fe94d4f70  x25 0000007fe94d4fb0  x26 000000012fb23df5  x27 00000000000003e8
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:     x28 b400007af360ed10  x29 0000007fe94d4ec0
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:     lr  0000007cea0f74f0  sp  0000007fe94d4e20  pc  0000007cea0f751c  pst 0000000000000000
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG: backtrace:
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #00 pc 000000000005151c  /apex/com.android.runtime/lib64/bionic/libc.so (abort+164) (BuildId: dfba72f5fadb31ae82d35d56425a9097)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #01 pc 000000000009ce88  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libc++_shared.so (BuildId: ece72a2ebc3774a1be9fd21271258acd3bcdfaa7)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #02 pc 000000000009d094  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libc++_shared.so (BuildId: ece72a2ebc3774a1be9fd21271258acd3bcdfaa7)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #03 pc 00000000000aead0  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libc++_shared.so (BuildId: ece72a2ebc3774a1be9fd21271258acd3bcdfaa7)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #04 pc 00000000000ae0fc  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libc++_shared.so (BuildId: ece72a2ebc3774a1be9fd21271258acd3bcdfaa7)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #05 pc 00000000000ae058  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libc++_shared.so (__cxa_throw+112) (BuildId: ece72a2ebc3774a1be9fd21271258acd3bcdfaa7)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #06 pc 00000000002161a8  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libmapbox-maps.so (BuildId: 771057a0e8fe8c88)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #07 pc 000000000024fb1c  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libmapbox-maps.so (BuildId: 771057a0e8fe8c88)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #08 pc 0000000000288650  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libmapbox-maps.so (BuildId: 771057a0e8fe8c88)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #09 pc 000000000046765c  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libmapbox-maps.so (BuildId: 771057a0e8fe8c88)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #10 pc 00000000004c5714  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libmapbox-maps.so (BuildId: 771057a0e8fe8c88)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #11 pc 00000000004c57d4  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libmapbox-maps.so (BuildId: 771057a0e8fe8c88)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #12 pc 00000000004c4a10  /data/app/~~XJhtn18yVXsf8WJqqzgEug==/com.mapbox.maps.testapp-qI3hSxCrQ4Z0k0YMzh3FSQ==/lib/arm64/libmapbox-maps.so (BuildId: 771057a0e8fe8c88)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #13 pc 0000000000012478  /system/lib64/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+832) (BuildId: 3e1f1abcd9dc2cc73d9216a768b6a9d4)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #14 pc 0000000000157420  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce(_JNIEnv*, _jobject*, long, int)+44) (BuildId: f2997e03e8a402a6cfd3f3bb82161b4b)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #15 pc 00000000001b3094  /system/framework/arm64/boot-framework.oat (art_jni_trampoline+116) (BuildId: b18c83914d1dbdad139e35f0ece7827dc9268a1e)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #16 pc 000000000020a910  /apex/com.android.art/lib64/libart.so (nterp_helper+5648) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #17 pc 00000000004839e6  /system/framework/framework.jar (android.os.MessageQueue.next+34)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #18 pc 000000000020a254  /apex/com.android.art/lib64/libart.so (nterp_helper+3924) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #19 pc 0000000000482a3c  /system/framework/framework.jar (android.os.Looper.loopOnce+12)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #20 pc 0000000000209334  /apex/com.android.art/lib64/libart.so (nterp_helper+52) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #21 pc 00000000004831c0  /system/framework/framework.jar (android.os.Looper.loop+152)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #22 pc 0000000000209334  /apex/com.android.art/lib64/libart.so (nterp_helper+52) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #23 pc 00000000001b882e  /system/framework/framework.jar (android.app.ActivityThread.main+202)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #24 pc 00000000004e9c00  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+576) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #25 pc 000000000042d1f0  /apex/com.android.art/lib64/libart.so (_jobject* art::InvokeMethod<(art::PointerSize)8>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jobject*, _jobject*, unsigned long)+2656) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #26 pc 000000000042c768  /apex/com.android.art/lib64/libart.so (art::Method_invoke(_JNIEnv*, _jobject*, _jobject*, _jobjectArray*) (.__uniq.165753521025965369065708152063621506277)+48) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #27 pc 00000000000b1128  /system/framework/arm64/boot.oat (art_jni_trampoline+120) (BuildId: 6522b645db0b46c625e546a39160b86323568545)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #28 pc 000000000020a2b0  /apex/com.android.art/lib64/libart.so (nterp_helper+4016) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #29 pc 00000000003e7a4a  /system/framework/framework.jar (com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run+22)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #30 pc 000000000080129c  /system/framework/arm64/boot-framework.oat (com.android.internal.os.ZygoteInit.main+3164) (BuildId: b18c83914d1dbdad139e35f0ece7827dc9268a1e)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #31 pc 00000000004e9c00  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+576) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #32 pc 000000000053e1c8  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeWithVarArgs<_jmethodID*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, std::__va_list)+1392) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #33 pc 00000000005a4354  /apex/com.android.art/lib64/libart.so (art::JNI<true>::CallStaticVoidMethodV(_JNIEnv*, _jclass*, _jmethodID*, std::__va_list)+164) (BuildId: 16025344946b9e6ee0a1c883fe24b1e3)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #34 pc 00000000000baad0  /system/lib64/libandroid_runtime.so (_JNIEnv::CallStaticVoidMethod(_jclass*, _jmethodID*, ...)+120) (BuildId: f2997e03e8a402a6cfd3f3bb82161b4b)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #35 pc 00000000000c62d0  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::start(char const*, android::Vector<android::String8> const&, bool)+840) (BuildId: f2997e03e8a402a6cfd3f3bb82161b4b)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #36 pc 0000000000002584  /system/bin/app_process64 (main+1328) (BuildId: dc8b28b296e395ee81bdf46fc9625b93)
2022-05-18 09:31:50.351 21335-21335/? A/DEBUG:       #37 pc 0000000000049de8  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+96) (BuildId: dfba72f5fadb31ae82d35d56425a9097)
2022-05-18 09:31:50.370 770-770/? E/tombstoned: Tombstone written to: tombstone_06
```

#### After
```
2022-05-18 09:32:49.640 21527-21527/com.mapbox.maps.testapp E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.maps.testapp, PID: 21527
    java.lang.RuntimeException: HELLO WORLD
        at com.mapbox.maps.testapp.examples.SimpleMapActivity.onCreate$lambda-0(SimpleMapActivity.kt:21)
        at com.mapbox.maps.testapp.examples.SimpleMapActivity.$r8$lambda$XCnBnNpGBwvzAsgkwLSb_B8XL60(Unknown Source:0)
        at com.mapbox.maps.testapp.examples.SimpleMapActivity$$ExternalSyntheticLambda0.onStyleLoaded(Unknown Source:0)
        at com.mapbox.maps.StyleObserver.onStyleLoaded(StyleObserver.kt:68)
        at com.mapbox.maps.NativeObserver.notify(NativeObserver.kt:64)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:335)
        at android.os.Looper.loopOnce(Looper.java:161)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7844)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: #186 

cc @anhnguyen1618 