### PR TITLE
Fix crash due to invalid focal point when panning the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix for loading gltf models with interleaved buffers. ([#1351](https://github.com/mapbox/mapbox-maps-android/pull/1351))
 * Fix a bug that `line-trim-offset` input may lose precision via shader calculation. ([#1359](https://github.com/mapbox/mapbox-maps-android/pull/1359))
 * Add mercator scale factor to 3D location puck, so that the 3D puck size won't increase as latitude increases. ([#1350](https://github.com/mapbox/mapbox-maps-android/pull/1350)
+* Fix a crash due to invalid focal point when panning the map. ([#1364](https://github.com/mapbox/mapbox-maps-android/pull/1364))
 
 ## Dependencies
 * Bump Mapbox Android base library to v0.8.0. ([#1323](https://github.com/mapbox/mapbox-maps-android/pull/1323))

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -19,6 +19,7 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.StylePropertyValueKind
 import com.mapbox.maps.extension.style.StyleInterface
+import com.mapbox.maps.logE
 import com.mapbox.maps.plugin.InvalidPluginConfigurationException
 import com.mapbox.maps.plugin.MapStyleObserverPlugin
 import com.mapbox.maps.plugin.Plugin.Companion.MAPBOX_CAMERA_PLUGIN_ID
@@ -1387,6 +1388,12 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
       val fromX = focalPoint.x.toDouble()
       val fromY = focalPoint.y.toDouble()
 
+      // Skip invalid focal points with non-finite values
+      if (!focalPoint.x.isFinite() || !focalPoint.y.isFinite()) {
+        logE(TAG, "Invalid focal point=$focalPoint to perform map panning!")
+        return false
+      }
+
       if (!dragInProgress) {
         if (isPointAboveHorizon(ScreenCoordinate(fromX, fromY))) {
           return false
@@ -1724,6 +1731,7 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
   }
 
   private companion object {
+    const val TAG = "Gestures"
     const val ROTATION_ANGLE_THRESHOLD = 3.0f
     const val MAX_SHOVE_ANGLE = 45.0f
   }

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -1731,7 +1731,7 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
   }
 
   private companion object {
-    const val TAG = "Gestures"
+    private const val TAG = "Gestures"
     const val ROTATION_ANGLE_THRESHOLD = 3.0f
     const val MAX_SHOVE_ANGLE = 45.0f
   }

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
@@ -434,11 +434,13 @@ class GesturesPluginTest {
     } returns PointF(Float.NaN, Float.NaN)
     var handled = presenter.handleMove(moveGestureDetector, 50.0f, 50.0f)
     assertFalse(handled)
+    verify(exactly = 1) { logE(any(), any()) }
     every {
       moveGestureDetector.focalPoint
     } returns PointF(Float.POSITIVE_INFINITY, Float.NaN)
     handled = presenter.handleMove(moveGestureDetector, 50.0f, 50.0f)
     assertFalse(handled)
+    verify(exactly = 2) { logE(any(), any()) }
     unmockkStatic("com.mapbox.maps.MapboxLogger")
   }
 

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
@@ -424,6 +424,25 @@ class GesturesPluginTest {
   }
 
   @Test
+  fun verifyHandleMoveExceptionFreeForInvalidFocalPoint() {
+    mockkStatic("com.mapbox.maps.MapboxLogger")
+    every { logE(any(), any()) } just Runs
+    val moveGestureDetector = mockk<MoveGestureDetector>()
+    every { moveGestureDetector.pointersCount } returns 1
+    every {
+      moveGestureDetector.focalPoint
+    } returns PointF(Float.NaN, Float.NaN)
+    var handled = presenter.handleMove(moveGestureDetector, 50.0f, 50.0f)
+    assertFalse(handled)
+    every {
+      moveGestureDetector.focalPoint
+    } returns PointF(Float.POSITIVE_INFINITY, Float.NaN)
+    handled = presenter.handleMove(moveGestureDetector, 50.0f, 50.0f)
+    assertFalse(handled)
+    unmockkStatic("com.mapbox.maps.MapboxLogger")
+  }
+
+  @Test
   fun verifyMoveListenerPinchScrollDisabled() {
     presenter.pinchScrollEnabled = false
     val listener: OnMoveListener = mockk(relaxed = true)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Fix crash due to invalid focal point when panning the map by skipping camera movement logic in case focal point returned from `MoveGestureDetector` is invalid meaning that X or Y are non-finite values.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
