### PR TITLE
[provider] rework map providers

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -62,7 +62,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     this.renderer = renderer
     this.mapInitOptions = mapInitOptions
     AssetManagerProvider().initialize(mapInitOptions.context.assets)
-    this.nativeMap = MapProvider.getNativeMap(
+    this.nativeMap = MapProvider.getNativeMapWrapper(
       mapInitOptions,
       renderer,
     )

--- a/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
@@ -6,7 +6,7 @@ import com.mapbox.maps.plugin.MapPluginRegistry
 
 internal object MapProvider {
 
-  fun getNativeMap(
+  fun getNativeMapWrapper(
     mapInitOptions: MapInitOptions,
     mapClient: MapClient,
   ): MapInterface = NativeMapImpl(
@@ -17,8 +17,8 @@ internal object MapProvider {
     )
   )
 
-  fun getNativeMap(mapView: MapView): MapInterface {
-    return mapView.getController().getNativeMap()
+  fun getNativeMapCore(mapView: MapView): MapInterface {
+    return (mapView.getController().getNativeMap() as NativeMapImpl).map
   }
 
   fun getMapboxMap(

--- a/sdk/src/main/java/com/mapbox/maps/NativeMapImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/NativeMapImpl.kt
@@ -9,7 +9,7 @@ import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
 import java.util.*
 
-internal class NativeMapImpl(private val map: MapInterface) :
+internal class NativeMapImpl(val map: MapInterface) :
   MapInterface, StyleManagerInterface, ObservableInterface {
 
   override fun setSize(size: Size) {
@@ -285,7 +285,10 @@ internal class NativeMapImpl(private val map: MapInterface) :
     return map.isStyleLayerPersistent(layerId)
   }
 
-  override fun moveStyleLayer(layerId: String, layerPosition: LayerPosition?): Expected<String, None> {
+  override fun moveStyleLayer(
+    layerId: String,
+    layerPosition: LayerPosition?
+  ): Expected<String, None> {
     return map.moveStyleLayer(layerId, layerPosition)
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/NativeMapProvider.java
+++ b/sdk/src/main/java/com/mapbox/maps/NativeMapProvider.java
@@ -2,6 +2,6 @@ package com.mapbox.maps;
 
 class NativeMapProvider {
   static MapInterface getNativeMap(MapView mapView) {
-    return MapProvider.INSTANCE.getNativeMap(mapView);
+    return MapProvider.INSTANCE.getNativeMapCore(mapView);
   }
 }


### PR DESCRIPTION
Tailwork of #1357, a distinction needs to be made between the NativeMapImpl which as a wrapper around the native map object vs the actual native map object. This went unnoticed since they both comply to the MapInterface which is used as its return type. 