### PR TITLE
Add static method to validate if 3D terrain is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Mapbox welcomes participation and contributions from everyone.
 * The `TilesetDescriptorOptions.pixelRatio` parameter is now passed to the TileStore and considered for the raster tile pack loading. This enables loading of a raster tilepacks for retina displays. ([#1351](https://github.com/mapbox/mapbox-maps-android/pull/1351))
 * Introduce pinchScrollEnabled configuration to enable/disable 2-finger map panning, default to true. ([#1343](https://github.com/mapbox/mapbox-maps-android/pull/1343))
 * Re-throw native exceptions `jni::PendingJavaException` as readable Java exceptions with detailed exception text. ([#1363](https://github.com/mapbox/mapbox-maps-android/pull/1363))
+* Add static method to validate if 3D terrain is supported. ([1368](https://github.com/mapbox/mapbox-maps-android/pull/1368))
 
 ## Bug fixes 🐞
 * Enable two finger pan gesture. ([#1280](https://github.com/mapbox/mapbox-maps-android/pull/1280))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Mapbox welcomes participation and contributions from everyone.
 * The `TilesetDescriptorOptions.pixelRatio` parameter is now passed to the TileStore and considered for the raster tile pack loading. This enables loading of a raster tilepacks for retina displays. ([#1351](https://github.com/mapbox/mapbox-maps-android/pull/1351))
 * Introduce pinchScrollEnabled configuration to enable/disable 2-finger map panning, default to true. ([#1343](https://github.com/mapbox/mapbox-maps-android/pull/1343))
 * Re-throw native exceptions `jni::PendingJavaException` as readable Java exceptions with detailed exception text. ([#1363](https://github.com/mapbox/mapbox-maps-android/pull/1363))
-* Add static method to validate if 3D terrain is supported. ([1368](https://github.com/mapbox/mapbox-maps-android/pull/1368))
+* Add static `MapView.isTerrainRenderingSupported()` method to validate if 3D terrain rendering is supported on given device. ([1368](https://github.com/mapbox/mapbox-maps-android/pull/1368))
 
 ## Bug fixes 🐞
 * Enable two finger pan gesture. ([#1280](https://github.com/mapbox/mapbox-maps-android/pull/1280))

--- a/sdk/api/metalava.txt
+++ b/sdk/api/metalava.txt
@@ -112,6 +112,7 @@ package com.mapbox.maps {
     method public <T extends com.mapbox.maps.plugin.MapPlugin> T? getPlugin(String id);
     method public final com.mapbox.maps.viewannotation.ViewAnnotationManager getViewAnnotationManager();
     method public static final boolean isRenderingSupported();
+    method public static final boolean isTerrainRenderingSupported();
     method public void onDestroy();
     method public void onLowMemory();
     method public void onSizeChanged(int w, int h, int oldw, int oldh);
@@ -130,6 +131,7 @@ package com.mapbox.maps {
 
   public static final class MapView.Companion {
     method public boolean isRenderingSupported();
+    method public boolean isTerrainRenderingSupported();
   }
 
   public static fun interface MapView.OnSnapshotReady {

--- a/sdk/api/sdk.api
+++ b/sdk/api/sdk.api
@@ -110,6 +110,7 @@ public class com/mapbox/maps/MapView : android/widget/FrameLayout, com/mapbox/ma
 	public fun getPlugin (Ljava/lang/String;)Lcom/mapbox/maps/plugin/MapPlugin;
 	public final fun getViewAnnotationManager ()Lcom/mapbox/maps/viewannotation/ViewAnnotationManager;
 	public static final fun isRenderingSupported ()Z
+	public static final fun isTerrainRenderingSupported ()Z
 	protected fun onAttachedToWindow ()V
 	public fun onDestroy ()V
 	public fun onGenericMotionEvent (Landroid/view/MotionEvent;)Z
@@ -129,6 +130,7 @@ public class com/mapbox/maps/MapView : android/widget/FrameLayout, com/mapbox/ma
 
 public final class com/mapbox/maps/MapView$Companion {
 	public final fun isRenderingSupported ()Z
+	public final fun isTerrainRenderingSupported ()Z
 }
 
 public abstract interface class com/mapbox/maps/MapView$OnSnapshotReady {

--- a/sdk/src/androidTest/java/com/mapbox/maps/MapboxMapIntegrationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/MapboxMapIntegrationTest.kt
@@ -47,4 +47,10 @@ class MapboxMapIntegrationTest {
   fun testMapViewIsRenderingSupported() {
     assertEquals(true, MapView.isRenderingSupported())
   }
+
+  @UiThreadTest
+  @Test
+  fun testMapViewIsTerrainRenderingSupported() {
+    assertEquals(true, MapView.isTerrainRenderingSupported())
+  }
 }

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -373,12 +373,15 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
     @JvmStatic
     fun isTerrainRenderingSupported(): Boolean {
       EGLCore(false, DEFAULT_ANTIALIASING_SAMPLE_COUNT).apply {
-        val eglConfigOk = prepareEgl(useDefaultContext = true)
+        val eglConfigOk = prepareEgl()
+        val eglSurface = createOffscreenSurface(1, 1)
+        makeCurrent(eglSurface)
         val resultBuffer = IntBuffer.allocate(1)
         GLES20.glGetIntegerv(GLES20.GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, resultBuffer)
         resultBuffer.rewind()
         val result = resultBuffer.get()
         val terrainSupported = result > 0
+        releaseSurface(eglSurface)
         release()
         return eglConfigOk && terrainSupported
       }

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -373,7 +373,7 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
     @JvmStatic
     fun isTerrainRenderingSupported(): Boolean {
       EGLCore(false, DEFAULT_ANTIALIASING_SAMPLE_COUNT).apply {
-        val eglConfigOk = prepareEgl()
+        val eglConfigOk = prepareEgl(useDefaultContext = true)
         val resultBuffer = IntBuffer.allocate(1)
         GLES20.glGetIntegerv(GLES20.GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, resultBuffer)
         resultBuffer.rewind()

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
 import android.graphics.Bitmap
+import android.opengl.GLES20
 import android.os.Build
 import android.util.AttributeSet
 import android.view.MotionEvent
@@ -22,6 +23,7 @@ import com.mapbox.maps.renderer.OnFpsChangedListener
 import com.mapbox.maps.renderer.egl.EGLCore
 import com.mapbox.maps.renderer.widget.Widget
 import com.mapbox.maps.viewannotation.ViewAnnotationManager
+import java.nio.IntBuffer
 
 /**
  * A [MapView] provides an embeddable map interface.
@@ -359,6 +361,26 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
         val eglConfigOk = prepareEgl()
         release()
         return eglConfigOk
+      }
+    }
+
+    /**
+     * Static method to check if [MapView] could properly render 3D terrain on this device.
+     * This method may take some time on slow devices.
+     *
+     * @return true if 3D terrain could be rendered on this device and false otherwise
+     */
+    @JvmStatic
+    fun isTerrainRenderingSupported(): Boolean {
+      EGLCore(false, DEFAULT_ANTIALIASING_SAMPLE_COUNT).apply {
+        val eglConfigOk = prepareEgl()
+        val resultBuffer = IntBuffer.allocate(1)
+        GLES20.glGetIntegerv(GLES20.GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, resultBuffer)
+        resultBuffer.rewind()
+        val result = resultBuffer.get()
+        val terrainSupported = result > 0
+        release()
+        return eglConfigOk && terrainSupported
       }
     }
   }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
@@ -24,7 +24,7 @@ internal class EGLCore(
 
   internal val eglNoSurface: EGLSurface = EGL10.EGL_NO_SURFACE
 
-  fun prepareEgl(useDefaultContext: Boolean = false): Boolean {
+  fun prepareEgl(): Boolean {
     egl = EGLContext.getEGL() as EGL10
     eglDisplay = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY)
     if (eglDisplay == EGL10.EGL_NO_DISPLAY) {
@@ -64,18 +64,6 @@ internal class EGLCore(
       values
     )
     logI(TAG, "EGLContext created, client version ${values[0]}")
-    if (useDefaultContext) {
-      if (!egl.eglMakeCurrent(
-          eglDisplay,
-          EGL10.EGL_NO_SURFACE,
-          EGL10.EGL_NO_SURFACE,
-          eglContext
-        )
-      ) {
-        logE(TAG, "Making default context current failed.")
-        return false
-      }
-    }
     return true
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
@@ -24,7 +24,7 @@ internal class EGLCore(
 
   internal val eglNoSurface: EGLSurface = EGL10.EGL_NO_SURFACE
 
-  fun prepareEgl(): Boolean {
+  fun prepareEgl(useDefaultContext: Boolean = false): Boolean {
     egl = EGLContext.getEGL() as EGL10
     eglDisplay = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY)
     if (eglDisplay == EGL10.EGL_NO_DISPLAY) {
@@ -64,6 +64,17 @@ internal class EGLCore(
       values
     )
     logI(TAG, "EGLContext created, client version ${values[0]}")
+    if (useDefaultContext) {
+      if (!egl.eglMakeCurrent(
+          eglDisplay,
+          egl.eglGetCurrentSurface(EGL10.EGL_READ),
+          egl.eglGetCurrentSurface(EGL10.EGL_READ),
+          eglContext)
+      ) {
+        logE(TAG, "Making default context current failed.")
+        return false
+      }
+    }
     return true
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
@@ -67,9 +67,10 @@ internal class EGLCore(
     if (useDefaultContext) {
       if (!egl.eglMakeCurrent(
           eglDisplay,
-          egl.eglGetCurrentSurface(EGL10.EGL_READ),
-          egl.eglGetCurrentSurface(EGL10.EGL_READ),
-          eglContext)
+          EGL10.EGL_NO_SURFACE,
+          EGL10.EGL_NO_SURFACE,
+          eglContext
+        )
       ) {
         logE(TAG, "Making default context current failed.")
         return false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Even before creating an instance of `MapView` it's not possible to validate if 3D terrain will be supported on given device:
```kotlin
val supported = MapView.isTerrainRenderingSupported()
```

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
