### PR TITLE
Load sprites and sources style extensions earlier during onStyleLoad.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Features ✨ and improvements 🏁
 * Update SDK name in attribution action sheet. ([1375](https://github.com/mapbox/mapbox-maps-android/pull/1375))
 * Introduce experimental ModelLayer API to render 3D models on the map. ([#1369](https://github.com/mapbox/mapbox-maps-android/pull/1369))
+* Further optimize `MapboxMap.loadStyle()` to apply styling properties earlier. [#1378](https://github.com/mapbox/mapbox-maps-android/pull/1378)
 
 # 10.6.0-beta.1 May 19, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Features ✨ and improvements 🏁
 * Optimise the bearing update frequency for the location puck animator. ([1398](https://github.com/mapbox/mapbox-maps-android/pull/1398))
 * Use `orientation` model source property to update the 3D puck's bearing, as it is more efficient than updating the `model-rotation` layer property. ([1407](https://github.com/mapbox/mapbox-maps-android/pull/1407))
+* Optimize `MapboxMap.loadStyle()` to apply images and models earlier. [#1378](https://github.com/mapbox/mapbox-maps-android/pull/1378)
 
 ## Bug fixes 🐞
 * Optimise the frequency to update location layer's visibility. ([1399](https://github.com/mapbox/mapbox-maps-android/pull/1399))
@@ -45,7 +46,6 @@ Mapbox welcomes participation and contributions from everyone.
 ## Features ✨ and improvements 🏁
 * Update SDK name in attribution action sheet. ([1375](https://github.com/mapbox/mapbox-maps-android/pull/1375))
 * Introduce experimental ModelLayer API to render 3D models on the map. ([#1369](https://github.com/mapbox/mapbox-maps-android/pull/1369))
-* Further optimize `MapboxMap.loadStyle()` to apply styling properties earlier. [#1378](https://github.com/mapbox/mapbox-maps-android/pull/1378)
 
 # 10.6.0-beta.1 May 19, 2022
 

--- a/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
@@ -102,6 +102,7 @@ class StyleLoadTest {
 
   @Test
   fun testStyleIsLoadedOnStyleChange() {
+    countDownLatch = CountDownLatch(1)
     rule.scenario.onActivity {
       it.runOnUiThread {
         mapboxMap.loadStyleUri(
@@ -156,6 +157,7 @@ class StyleLoadTest {
         mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) { loadedStyles++ }
         mapboxMap.loadStyleUri(Style.SATELLITE) { loadedStyles++ }
         mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) { style ->
+          loadedStyles++
           assertTrue("Style should be fully loaded", style.isStyleLoaded)
           assertTrue("Style should be valid", style.isValid())
           countDownLatch.countDown()

--- a/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
@@ -4,6 +4,7 @@ import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.mapbox.maps.extension.style.style
 import junit.framework.TestCase.*
 import org.junit.*
 import org.junit.runner.RunWith
@@ -35,93 +36,113 @@ class StyleLoadTest {
   @Test
   fun testStyleNull() {
     countDownLatch = CountDownLatch(1)
-    var callbackInvoked = false
     rule.scenario.onActivity {
       it.runOnUiThread {
         mapView.onStart()
         mapboxMap.getStyle {
-          callbackInvoked = true
           countDownLatch.countDown()
         }
       }
     }
-    countDownLatch.await(5, TimeUnit.SECONDS)
-    assertTrue(callbackInvoked)
+    countDownLatch.throwExceptionOnTimeoutMs()
   }
 
   @Test
-  fun testDestroyAllStyle() {
-    countDownLatch = CountDownLatch(1)
-    var styleList = mutableListOf<Style>()
+  fun testStyleIsValid() {
+    countDownLatch = CountDownLatch(2)
+    val styles = mutableListOf<Style>()
     rule.scenario.onActivity { style ->
       style.runOnUiThread {
-        mapboxMap.getStyle { styleList.add(it) }
         mapboxMap.loadStyleUri(
           Style.MAPBOX_STREETS
         ) { newStyle ->
-          styleList.add(newStyle)
+          styles.add(newStyle)
           countDownLatch.countDown()
+
+          mapboxMap.loadStyleUri(
+            Style.MAPBOX_STREETS
+          ) { newStyle2 ->
+            styles.add(newStyle2)
+            countDownLatch.countDown()
+          }
         }
         mapView.onStart()
       }
     }
-    countDownLatch.await(10, TimeUnit.SECONDS)
-    Assert.assertEquals(2, styleList.size)
-    assertTrue(styleList[0].isValid())
-    assertTrue(styleList[1].isValid())
+    countDownLatch.throwExceptionOnTimeoutMs()
+
+    assertFalse(styles[0].isValid())
+    assertTrue(styles[1].isValid())
+
     mapboxMap.onDestroy()
-    assertFalse(styleList[0].isValid())
-    assertFalse(styleList[1].isValid())
+
+    assertFalse(styles[1].isValid())
   }
 
   @Test
   fun testStyleAsyncGetter() {
-    countDownLatch = CountDownLatch(1)
-    var styleLoadedCount = 0
+    countDownLatch = CountDownLatch(2)
     rule.scenario.onActivity {
       it.runOnUiThread {
         mapboxMap.getStyle { style ->
-          assertNotNull("Style should but non null", style)
           assertTrue("Style should be fully loaded", style.isStyleLoaded)
-          styleLoadedCount++
+          countDownLatch.countDown()
         }
 
         mapboxMap.loadStyleUri(
           Style.MAPBOX_STREETS
         ) { style ->
-          assertNotNull("Style should but non null", style)
           assertTrue("Style should be fully loaded", style.isStyleLoaded)
-          styleLoadedCount++
           countDownLatch.countDown()
         }
         mapView.onStart()
       }
     }
-    countDownLatch.await(10, TimeUnit.SECONDS)
-    Assert.assertEquals(2, styleLoadedCount)
+    countDownLatch.throwExceptionOnTimeoutMs(10_000)
   }
 
   @Test
-  fun testFullyLoadedFalse() {
+  fun testStyleIsLoadedOnStyleChange() {
     rule.scenario.onActivity {
       it.runOnUiThread {
         mapboxMap.loadStyleUri(
           Style.MAPBOX_STREETS
         ) { style ->
-          assertNotNull("Style should but non null", style)
           assertTrue("Style should be fully loaded", style.isStyleLoaded)
-          mapboxMap.loadStyleUri(Style.SATELLITE)
+          mapboxMap.loadStyleUri(Style.SATELLITE) {
+            assertTrue("Style should be fully loaded again", style.isStyleLoaded)
+            countDownLatch.countDown()
+          }
           assertFalse("Map shouldn't be fully loaded", style.isStyleLoaded)
+        }
+        mapView.onStart()
+      }
+    }
+    countDownLatch.throwExceptionOnTimeoutMs(30_000)
+  }
+
+  @Test
+  fun testLoadMultipleStylesInARow() {
+    countDownLatch = CountDownLatch(1)
+    rule.scenario.onActivity {
+      it.runOnUiThread {
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS)
+        mapboxMap.loadStyle(style("") {})
+        mapboxMap.loadStyleUri(Style.SATELLITE)
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS)
+        mapboxMap.loadStyle(style("") {})
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS)
+        mapboxMap.loadStyleUri(Style.SATELLITE)
+        mapboxMap.loadStyleUri(Style.MAPBOX_STREETS) { style ->
+          assertTrue("Style should be fully loaded", style.isStyleLoaded)
           countDownLatch.countDown()
         }
         mapView.onStart()
       }
     }
-    countDownLatch = CountDownLatch(1)
-    if (!countDownLatch.await(30, TimeUnit.SECONDS)) {
-      throw TimeoutException()
-    }
+    countDownLatch.throwExceptionOnTimeoutMs()
   }
+
 
   @After
   @UiThreadTest

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -271,22 +271,7 @@ class MapboxMap :
   ) {
     checkNativeMap("loadStyle")
     initializeStyleLoad(
-      onStyleLoaded = { style ->
-        // TODO https://github.com/mapbox/mapbox-maps-android/issues/1371
-        styleExtension.images.forEach {
-          it.bindTo(style)
-        }
-        styleExtension.models.forEach {
-          it.bindTo(style)
-        }
-        styleExtension.sources.forEach {
-          it.bindTo(style)
-        }
-        styleExtension.layers.forEach { (layer, layerPosition) ->
-          layer.bindTo(style, layerPosition)
-        }
-        onStyleLoaded?.onStyleLoaded(style)
-      },
+      onStyleLoaded = onStyleLoaded,
       styleDataStyleLoadedListener = { style ->
         styleExtension.light?.bindTo(style)
         styleExtension.terrain?.bindTo(style)
@@ -295,19 +280,21 @@ class MapboxMap :
         transitionOptions?.let(style::setStyleTransition)
       },
       styleDataSourcesLoadedListener = { style ->
-        // TODO https://github.com/mapbox/mapbox-maps-android/issues/1371
-//        styleExtension.sources.forEach {
-//          it.bindTo(style)
-//        }
-//        styleExtension.layers.forEach { (layer, layerPosition) ->
-//          layer.bindTo(style, layerPosition)
-//        }
+        styleExtension.sources.forEach {
+          it.bindTo(style)
+        }
+        styleExtension.layers.forEach { (layer, layerPosition) ->
+          layer.bindTo(style, layerPosition)
+        }
       },
       styleDataSpritesLoadedListener = { style ->
-        // TODO https://github.com/mapbox/mapbox-maps-android/issues/1371
-//        styleExtension.images.forEach {
-//          it.bindTo(style)
-//        }
+        styleExtension.images.forEach {
+          it.bindTo(style)
+        }
+        // note - it is not strictly required to load models here, models can be loaded anytime during style load flow
+        styleExtension.models.forEach {
+          it.bindTo(style)
+        }
       },
       onMapLoadErrorListener = onMapLoadErrorListener,
     )

--- a/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
@@ -265,6 +265,15 @@ internal class NativeObserver(
     }
   }
 
+  // This method is needed to prevent receiving styleLoaded events with the old style
+  // when new style is loaded. For example loading empty style and another style immediately after
+  // that will notify STYLE_LOADED event for the first style after second style has already started
+  // loading
+  fun resubscribeStyleLoadListeners() {
+    unsubscribeUnusedEvent(MapEvents.STYLE_LOADED)
+    subscribeNewEvent(MapEvents.STYLE_LOADED)
+  }
+
   fun addOnStyleDataLoadedListener(onStyleDataLoadedListener: OnStyleDataLoadedListener) {
     if (onStyleDataLoadedListeners.isEmpty()) {
       subscribeNewEvent(MapEvents.STYLE_DATA_LOADED)

--- a/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/NativeObserver.kt
@@ -272,6 +272,8 @@ internal class NativeObserver(
   fun resubscribeStyleLoadListeners() {
     unsubscribeUnusedEvent(MapEvents.STYLE_LOADED)
     subscribeNewEvent(MapEvents.STYLE_LOADED)
+    unsubscribeUnusedEvent(MapEvents.STYLE_DATA_LOADED)
+    subscribeNewEvent(MapEvents.STYLE_DATA_LOADED)
   }
 
   fun addOnStyleDataLoadedListener(onStyleDataLoadedListener: OnStyleDataLoadedListener) {

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -74,8 +74,10 @@ internal class StyleObserver(
     onStyleSourcesReady()
     styleLoadedListener.onStyleLoaded(style)
 
-    userStyleLoadedListener?.onStyleLoaded(style)
-    userStyleLoadedListener = null
+    userStyleLoadedListener?.let {
+      userStyleLoadedListener = null
+      it.onStyleLoaded(style)
+    }
 
     getStyleListeners.forEach { listener ->
       listener.onStyleLoaded(style)

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -49,6 +49,8 @@ internal class StyleObserver(
     styleDataSourcesLoadedListener: Style.OnStyleLoaded? = null,
     onMapLoadErrorListener: OnMapLoadErrorListener?
   ) {
+    // needed to prevent receiving onStyleLoaded for the old style in some rare cases
+    nativeObserver.resubscribeStyleLoadListeners()
     this.userStyleLoadedListener = userOnStyleLoaded
     this.styleDataStyleLoadedListener = styleDataStyleLoadedListener
     this.styleDataSpritesLoadedListener = styleDataSpritesLoadedListener
@@ -68,7 +70,8 @@ internal class StyleObserver(
    * Invoked when a style has loaded
    */
   override fun onStyleLoaded(eventData: StyleLoadedEventData) {
-    val style = loadedStyle ?: throw MapboxMapException("Style is not initialized on onStyleLoaded callback!")
+    val style = loadedStyle
+      ?: throw MapboxMapException("Style is not initialized on onStyleLoaded callback!")
 
     onStyleSpritesReady()
     onStyleSourcesReady()

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -111,16 +111,22 @@ internal class StyleObserver(
         styleDataStyleLoadedListener = null
       }
       StyleDataType.SPRITE -> {
-        styleDataSpritesLoadedListener?.onStyleLoaded(
-          loadedStyle ?: throw MapboxMapException("Style is not initialized yet although SPRITES event has arrived!")
-        )
-        styleDataSpritesLoadedListener = null
+        styleDataSpritesLoadedListener?.let {
+          styleDataSpritesLoadedListener = null
+          it.onStyleLoaded(
+            loadedStyle ?: throw MapboxMapException("Style is not initialized yet although SPRITES event has arrived!")
+          )
+        }
       }
       StyleDataType.SOURCES -> {
-        styleDataSourcesLoadedListener?.onStyleLoaded(
-          loadedStyle ?: throw MapboxMapException("Style is not initialized yet although SOURCES event has arrived!")
-        )
-        styleDataSourcesLoadedListener = null
+        styleDataSourcesLoadedListener?.let {
+          // reset listener first, firing onStyleLoaded
+          // may produce another StyleDataType.SOURCES event if sources are added
+          styleDataSourcesLoadedListener = null
+          it.onStyleLoaded(
+            loadedStyle ?: throw MapboxMapException("Style is not initialized yet although SOURCES event has arrived!")
+          )
+        }
       }
     }
   }

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -69,6 +69,19 @@ internal class StyleObserver(
    */
   override fun onStyleLoaded(eventData: StyleLoadedEventData) {
     val style = loadedStyle ?: throw MapboxMapException("Style is not initialized on onStyleLoaded callback!")
+
+    // sprites listener is not null - it means style does not contain them thus StyleDataType.SPRITE
+    // was not fired, explicitly call it to bind all the necessary style extensions upstream
+    if (styleDataSpritesLoadedListener != null) {
+      styleDataSpritesLoadedListener?.onStyleLoaded(style)
+      styleDataSpritesLoadedListener = null
+    }
+    // sources listener is not null - it means style does not contain them thus StyleDataType.SOURCES
+    // was not fired, explicitly call it to bind all the necessary style extensions upstream
+    if (styleDataSourcesLoadedListener != null) {
+      styleDataSourcesLoadedListener?.onStyleLoaded(style)
+      styleDataSourcesLoadedListener = null
+    }
     styleLoadedListener.onStyleLoaded(style)
 
     userStyleLoadedListener?.onStyleLoaded(style)

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -130,7 +130,6 @@ class MapboxMapTest {
     assertTrue(mapboxMap.isStyleLoadInitiated)
   }
 
-  // TODO fix test
   @Test
   fun bindsStyleExtensionComponentsInCorrectOrderAfterStyleDataLoadEvents() {
     val style = mockk<Style>()
@@ -157,6 +156,9 @@ class MapboxMapTest {
 
     val projection = mockk<StyleContract.StyleProjectionExtension>(relaxed = true)
     every { styleExtension.projection } returns projection
+
+    val model = mockk<StyleContract.StyleModelExtension>(relaxed = true)
+    every { styleExtension.models } returns listOf(model)
 
     val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
 
@@ -185,6 +187,7 @@ class MapboxMapTest {
     verifyNo { projection.bindTo(style) }
     verifyNo { atmosphere.bindTo(style) }
     verifyNo { styleLoadCallback.onStyleLoaded(style) }
+    verifyNo { model.bindTo(style) }
 
     callbackStyleSlots.first()!!.onStyleLoaded(style)
 
@@ -196,19 +199,20 @@ class MapboxMapTest {
     verifyNo { image.bindTo(style) }
     verifyNo { layer.bindTo(style, layerPosition) }
     verifyNo { styleLoadCallback.onStyleLoaded(style) }
+    verifyNo { model.bindTo(style) }
 
-    // TODO https://github.com/mapbox/mapbox-maps-android/issues/1371
-//    callbackStyleSpritesSlots.first()!!.onStyleLoaded(style)
-//
-//    verify { image.bindTo(style) }
-//    verifyNo { source.bindTo(style) }
-//    verifyNo { layer.bindTo(style, layerPosition) }
-//    verifyNo { styleLoadCallback.onStyleLoaded(style) }
-//
-//    callbackStyleSourcesSlots.first()!!.onStyleLoaded(style)
-//
-//    verify { source.bindTo(style) }
-//    verify { layer.bindTo(style, layerPosition) }
+    callbackStyleSpritesSlots.first()!!.onStyleLoaded(style)
+
+    verify { image.bindTo(style) }
+    verify { model.bindTo(style) }
+    verifyNo { source.bindTo(style) }
+    verifyNo { layer.bindTo(style, layerPosition) }
+    verifyNo { styleLoadCallback.onStyleLoaded(style) }
+
+    callbackStyleSourcesSlots.first()!!.onStyleLoaded(style)
+
+    verify { source.bindTo(style) }
+    verify { layer.bindTo(style, layerPosition) }
 
     userCallbackStyleSlots.first()!!.onStyleLoaded(style)
     verify { image.bindTo(style) }

--- a/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps
 
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.plugin.delegates.listeners.*
+import com.mapbox.verifyNo
 import io.mockk.*
 import org.junit.Assert.*
 import org.junit.Before

--- a/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/NativeObserverTest.kt
@@ -29,7 +29,7 @@ class NativeObserverTest {
     val listener = mockk<OnCameraChangeListener>(relaxUnitFun = true)
     nativeObserver.addOnCameraChangeListener(listener)
     assertEquals(1, nativeObserver.onCameraChangeListeners.size)
-    verify(exactly = 1) { observableInterface.subscribe(any(), listOf(MapEvents.CAMERA_CHANGED)) }
+    verify { observableInterface.subscribe(any(), listOf(MapEvents.CAMERA_CHANGED)) }
     assertTrue(nativeObserver.observedEvents.contains(MapEvents.CAMERA_CHANGED))
     notifyEvents(MapEvents.CAMERA_CHANGED)
     verify { listener.onCameraChanged(any()) }
@@ -37,7 +37,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnCameraChangeListener>(relaxUnitFun = true)
     nativeObserver.addOnCameraChangeListener(listener2)
     assertEquals(2, nativeObserver.onCameraChangeListeners.size)
-    verify(exactly = 1) { observableInterface.subscribe(any(), listOf(MapEvents.CAMERA_CHANGED)) }
+    verify { observableInterface.subscribe(any(), listOf(MapEvents.CAMERA_CHANGED)) }
     notifyEvents(MapEvents.CAMERA_CHANGED)
     verify { listener2.onCameraChanged(any()) }
   }
@@ -51,14 +51,14 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onCameraChangeListeners.size)
     nativeObserver.removeOnCameraChangeListener(listener)
     assertEquals(1, nativeObserver.onCameraChangeListeners.size)
-    verify(exactly = 0) { observableInterface.unsubscribe(any(), listOf(MapEvents.CAMERA_CHANGED)) }
+    verifyNo { observableInterface.unsubscribe(any(), listOf(MapEvents.CAMERA_CHANGED)) }
     nativeObserver.removeOnCameraChangeListener(listener2)
     assertEquals(0, nativeObserver.onCameraChangeListeners.size)
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.CAMERA_CHANGED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.CAMERA_CHANGED)) }
     notifyEvents(MapEvents.CAMERA_CHANGED)
-    verify(exactly = 0) { listener.onCameraChanged(any()) }
-    verify(exactly = 0) { listener2.onCameraChanged(any()) }
+    verifyNo { listener.onCameraChanged(any()) }
+    verifyNo { listener2.onCameraChanged(any()) }
   }
 
   // Map events
@@ -74,7 +74,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnMapIdleListener>(relaxUnitFun = true)
     nativeObserver.addOnMapIdleListener(listener2)
     assertEquals(2, nativeObserver.onMapIdleListeners.size)
-    verify(exactly = 1) { observableInterface.subscribe(any(), listOf(MapEvents.MAP_IDLE)) }
+    verify { observableInterface.subscribe(any(), listOf(MapEvents.MAP_IDLE)) }
     notifyEvents(MapEvents.MAP_IDLE)
     verify { listener2.onMapIdle(any()) }
   }
@@ -88,14 +88,14 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onMapIdleListeners.size)
     nativeObserver.removeOnMapIdleListener(listener)
     assertEquals(1, nativeObserver.onMapIdleListeners.size)
-    verify(exactly = 0) { observableInterface.unsubscribe(any(), listOf(MapEvents.MAP_IDLE)) }
+    verifyNo { observableInterface.unsubscribe(any(), listOf(MapEvents.MAP_IDLE)) }
     nativeObserver.removeOnMapIdleListener(listener2)
     assertEquals(0, nativeObserver.onMapIdleListeners.size)
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.MAP_IDLE))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.MAP_IDLE)) }
     notifyEvents(MapEvents.MAP_IDLE)
-    verify(exactly = 0) { listener.onMapIdle(any()) }
-    verify(exactly = 0) { listener2.onMapIdle(any()) }
+    verifyNo { listener.onMapIdle(any()) }
+    verifyNo { listener2.onMapIdle(any()) }
   }
 
   @Test
@@ -123,7 +123,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnMapLoadErrorListener>(relaxUnitFun = true)
     nativeObserver.addOnMapLoadErrorListener(listener2)
     assertEquals(2, nativeObserver.onMapLoadErrorListeners.size)
-    verify(exactly = 1) {
+    verify {
       observableInterface.subscribe(
         any(),
         listOf(MapEvents.MAP_LOADING_ERROR)
@@ -142,7 +142,7 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onMapLoadErrorListeners.size)
     nativeObserver.removeOnMapLoadErrorListener(listener)
     assertEquals(1, nativeObserver.onMapLoadErrorListeners.size)
-    verify(exactly = 0) {
+    verifyNo {
       observableInterface.unsubscribe(
         any(),
         listOf(MapEvents.MAP_LOADING_ERROR)
@@ -153,8 +153,8 @@ class NativeObserverTest {
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.MAP_LOADING_ERROR))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.MAP_LOADING_ERROR)) }
     notifyEvents(MapEvents.MAP_IDLE)
-    verify(exactly = 0) { listener.onMapLoadError(any()) }
-    verify(exactly = 0) { listener2.onMapLoadError(any()) }
+    verifyNo { listener.onMapLoadError(any()) }
+    verifyNo { listener2.onMapLoadError(any()) }
   }
 
   @Test
@@ -169,7 +169,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnMapLoadedListener>(relaxUnitFun = true)
     nativeObserver.addOnMapLoadedListener(listener2)
     assertEquals(2, nativeObserver.onMapLoadedListeners.size)
-    verify(exactly = 1) { observableInterface.subscribe(any(), listOf(MapEvents.MAP_LOADED)) }
+    verify { observableInterface.subscribe(any(), listOf(MapEvents.MAP_LOADED)) }
     notifyEvents(MapEvents.MAP_LOADED)
     verify { listener2.onMapLoaded(any()) }
   }
@@ -183,14 +183,14 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onMapLoadedListeners.size)
     nativeObserver.removeOnMapLoadedListener(listener)
     assertEquals(1, nativeObserver.onMapLoadedListeners.size)
-    verify(exactly = 0) { observableInterface.unsubscribe(any(), listOf(MapEvents.MAP_LOADED)) }
+    verifyNo { observableInterface.unsubscribe(any(), listOf(MapEvents.MAP_LOADED)) }
     nativeObserver.removeOnMapLoadedListener(listener2)
     assertEquals(0, nativeObserver.onMapLoadedListeners.size)
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.MAP_LOADED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.MAP_LOADED)) }
     notifyEvents(MapEvents.MAP_LOADED)
-    verify(exactly = 0) { listener.onMapLoaded(any()) }
-    verify(exactly = 0) { listener2.onMapLoaded(any()) }
+    verifyNo { listener.onMapLoaded(any()) }
+    verifyNo { listener2.onMapLoaded(any()) }
   }
 
   // Render frame events
@@ -213,7 +213,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnRenderFrameFinishedListener>(relaxUnitFun = true)
     nativeObserver.addOnRenderFrameFinishedListener(listener2)
     assertEquals(2, nativeObserver.onRenderFrameFinishedListeners.size)
-    verify(exactly = 1) {
+    verify {
       observableInterface.subscribe(
         any(),
         listOf(MapEvents.RENDER_FRAME_FINISHED)
@@ -232,7 +232,7 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onRenderFrameFinishedListeners.size)
     nativeObserver.removeOnRenderFrameFinishedListener(listener)
     assertEquals(1, nativeObserver.onRenderFrameFinishedListeners.size)
-    verify(exactly = 0) {
+    verifyNo {
       observableInterface.unsubscribe(
         any(),
         listOf(MapEvents.RENDER_FRAME_FINISHED)
@@ -243,8 +243,8 @@ class NativeObserverTest {
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.RENDER_FRAME_FINISHED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.RENDER_FRAME_FINISHED)) }
     notifyEvents(MapEvents.RENDER_FRAME_FINISHED)
-    verify(exactly = 0) { listener.onRenderFrameFinished(any()) }
-    verify(exactly = 0) { listener2.onRenderFrameFinished(any()) }
+    verifyNo { listener.onRenderFrameFinished(any()) }
+    verifyNo { listener2.onRenderFrameFinished(any()) }
   }
 
   @Test
@@ -259,7 +259,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnRenderFrameStartedListener>(relaxUnitFun = true)
     nativeObserver.addOnRenderFrameStartedListener(listener2)
     assertEquals(2, nativeObserver.onRenderFrameStartedListeners.size)
-    verify(exactly = 1) {
+    verify {
       observableInterface.subscribe(
         any(),
         listOf(MapEvents.RENDER_FRAME_STARTED)
@@ -278,7 +278,7 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onRenderFrameStartedListeners.size)
     nativeObserver.removeOnRenderFrameStartedListener(listener)
     assertEquals(1, nativeObserver.onRenderFrameStartedListeners.size)
-    verify(exactly = 0) {
+    verifyNo {
       observableInterface.unsubscribe(
         any(),
         listOf(MapEvents.RENDER_FRAME_STARTED)
@@ -289,8 +289,8 @@ class NativeObserverTest {
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.RENDER_FRAME_STARTED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.RENDER_FRAME_STARTED)) }
     notifyEvents(MapEvents.RENDER_FRAME_STARTED)
-    verify(exactly = 0) { listener.onRenderFrameStarted(any()) }
-    verify(exactly = 0) { listener2.onRenderFrameStarted(any()) }
+    verifyNo { listener.onRenderFrameStarted(any()) }
+    verifyNo { listener2.onRenderFrameStarted(any()) }
   }
 
   // Source events
@@ -306,7 +306,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnSourceAddedListener>(relaxUnitFun = true)
     nativeObserver.addOnSourceAddedListener(listener2)
     assertEquals(2, nativeObserver.onSourceAddedListeners.size)
-    verify(exactly = 1) { observableInterface.subscribe(any(), listOf(MapEvents.SOURCE_ADDED)) }
+    verify { observableInterface.subscribe(any(), listOf(MapEvents.SOURCE_ADDED)) }
     notifyEvents(MapEvents.SOURCE_ADDED)
     verify { listener2.onSourceAdded(any()) }
   }
@@ -320,14 +320,14 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onSourceAddedListeners.size)
     nativeObserver.removeOnSourceAddedListener(listener)
     assertEquals(1, nativeObserver.onSourceAddedListeners.size)
-    verify(exactly = 0) { observableInterface.unsubscribe(any(), listOf(MapEvents.SOURCE_ADDED)) }
+    verifyNo { observableInterface.unsubscribe(any(), listOf(MapEvents.SOURCE_ADDED)) }
     nativeObserver.removeOnSourceAddedListener(listener2)
     assertEquals(0, nativeObserver.onSourceAddedListeners.size)
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.SOURCE_ADDED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.SOURCE_ADDED)) }
     notifyEvents(MapEvents.SOURCE_ADDED)
-    verify(exactly = 0) { listener.onSourceAdded(any()) }
-    verify(exactly = 0) { listener2.onSourceAdded(any()) }
+    verifyNo { listener.onSourceAdded(any()) }
+    verifyNo { listener2.onSourceAdded(any()) }
   }
 
   @Test
@@ -355,7 +355,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnSourceDataLoadedListener>(relaxUnitFun = true)
     nativeObserver.addOnSourceDataLoadedListener(listener2)
     assertEquals(2, nativeObserver.onSourceDataLoadedListeners.size)
-    verify(exactly = 1) {
+    verify {
       observableInterface.subscribe(
         any(),
         listOf(MapEvents.SOURCE_DATA_LOADED)
@@ -374,7 +374,7 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onSourceDataLoadedListeners.size)
     nativeObserver.removeOnSourceDataLoadedListener(listener)
     assertEquals(1, nativeObserver.onSourceDataLoadedListeners.size)
-    verify(exactly = 0) {
+    verifyNo {
       observableInterface.unsubscribe(
         any(),
         listOf(MapEvents.SOURCE_DATA_LOADED)
@@ -385,8 +385,8 @@ class NativeObserverTest {
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.SOURCE_DATA_LOADED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.SOURCE_DATA_LOADED)) }
     notifyEvents(MapEvents.SOURCE_ADDED)
-    verify(exactly = 0) { listener.onSourceDataLoaded(any()) }
-    verify(exactly = 0) { listener2.onSourceDataLoaded(any()) }
+    verifyNo { listener.onSourceDataLoaded(any()) }
+    verifyNo { listener2.onSourceDataLoaded(any()) }
   }
 
   @Test
@@ -401,7 +401,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnSourceRemovedListener>(relaxUnitFun = true)
     nativeObserver.addOnSourceRemovedListener(listener2)
     assertEquals(2, nativeObserver.onSourceRemovedListeners.size)
-    verify(exactly = 1) { observableInterface.subscribe(any(), listOf(MapEvents.SOURCE_REMOVED)) }
+    verify { observableInterface.subscribe(any(), listOf(MapEvents.SOURCE_REMOVED)) }
     notifyEvents(MapEvents.SOURCE_REMOVED)
     verify { listener2.onSourceRemoved(any()) }
   }
@@ -415,14 +415,14 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onSourceRemovedListeners.size)
     nativeObserver.removeOnSourceRemovedListener(listener)
     assertEquals(1, nativeObserver.onSourceRemovedListeners.size)
-    verify(exactly = 0) { observableInterface.unsubscribe(any(), listOf(MapEvents.SOURCE_REMOVED)) }
+    verifyNo { observableInterface.unsubscribe(any(), listOf(MapEvents.SOURCE_REMOVED)) }
     nativeObserver.removeOnSourceRemovedListener(listener2)
     assertEquals(0, nativeObserver.onSourceRemovedListeners.size)
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.SOURCE_REMOVED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.SOURCE_REMOVED)) }
     notifyEvents(MapEvents.SOURCE_REMOVED)
-    verify(exactly = 0) { listener.onSourceRemoved(any()) }
-    verify(exactly = 0) { listener2.onSourceRemoved(any()) }
+    verifyNo { listener.onSourceRemoved(any()) }
+    verifyNo { listener2.onSourceRemoved(any()) }
   }
 
   // Style events
@@ -438,7 +438,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnStyleLoadedListener>(relaxUnitFun = true)
     nativeObserver.addOnStyleLoadedListener(listener2)
     assertEquals(2, nativeObserver.onStyleLoadedListeners.size)
-    verify(exactly = 1) { observableInterface.subscribe(any(), listOf(MapEvents.STYLE_LOADED)) }
+    verify { observableInterface.subscribe(any(), listOf(MapEvents.STYLE_LOADED)) }
     notifyEvents(MapEvents.STYLE_LOADED)
     verify { listener2.onStyleLoaded(any()) }
   }
@@ -452,14 +452,14 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onStyleLoadedListeners.size)
     nativeObserver.removeOnStyleLoadedListener(listener)
     assertEquals(1, nativeObserver.onStyleLoadedListeners.size)
-    verify(exactly = 0) { observableInterface.unsubscribe(any(), listOf(MapEvents.STYLE_LOADED)) }
+    verifyNo { observableInterface.unsubscribe(any(), listOf(MapEvents.STYLE_LOADED)) }
     nativeObserver.removeOnStyleLoadedListener(listener2)
     assertEquals(0, nativeObserver.onStyleLoadedListeners.size)
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.STYLE_LOADED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.STYLE_LOADED)) }
     notifyEvents(MapEvents.STYLE_LOADED)
-    verify(exactly = 0) { listener.onStyleLoaded(any()) }
-    verify(exactly = 0) { listener2.onStyleLoaded(any()) }
+    verifyNo { listener.onStyleLoaded(any()) }
+    verifyNo { listener2.onStyleLoaded(any()) }
   }
 
   @Test
@@ -474,7 +474,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnStyleImageMissingListener>(relaxUnitFun = true)
     nativeObserver.addOnStyleImageMissingListener(listener2)
     assertEquals(2, nativeObserver.onStyleImageMissingListeners.size)
-    verify(exactly = 1) {
+    verify {
       observableInterface.subscribe(
         any(),
         listOf(MapEvents.STYLE_IMAGE_MISSING)
@@ -493,7 +493,7 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onStyleImageMissingListeners.size)
     nativeObserver.removeOnStyleImageMissingListener(listener)
     assertEquals(1, nativeObserver.onStyleImageMissingListeners.size)
-    verify(exactly = 0) {
+    verifyNo {
       observableInterface.unsubscribe(
         any(),
         listOf(MapEvents.STYLE_IMAGE_MISSING)
@@ -504,8 +504,8 @@ class NativeObserverTest {
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.STYLE_IMAGE_MISSING))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.STYLE_IMAGE_MISSING)) }
     notifyEvents(MapEvents.STYLE_IMAGE_MISSING)
-    verify(exactly = 0) { listener.onStyleImageMissing(any()) }
-    verify(exactly = 0) { listener2.onStyleImageMissing(any()) }
+    verifyNo { listener.onStyleImageMissing(any()) }
+    verifyNo { listener2.onStyleImageMissing(any()) }
   }
 
   @Test
@@ -520,7 +520,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnStyleImageUnusedListener>(relaxUnitFun = true)
     nativeObserver.addOnStyleImageUnusedListener(listener2)
     assertEquals(2, nativeObserver.onStyleImageUnusedListeners.size)
-    verify(exactly = 1) {
+    verify {
       observableInterface.subscribe(
         any(),
         listOf(MapEvents.STYLE_IMAGE_REMOVE_UNUSED)
@@ -539,7 +539,7 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onStyleImageUnusedListeners.size)
     nativeObserver.removeOnStyleImageUnusedListener(listener)
     assertEquals(1, nativeObserver.onStyleImageUnusedListeners.size)
-    verify(exactly = 0) {
+    verifyNo {
       observableInterface.unsubscribe(
         any(),
         listOf(MapEvents.STYLE_IMAGE_REMOVE_UNUSED)
@@ -550,8 +550,8 @@ class NativeObserverTest {
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.STYLE_IMAGE_REMOVE_UNUSED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.STYLE_IMAGE_REMOVE_UNUSED)) }
     notifyEvents(MapEvents.STYLE_IMAGE_REMOVE_UNUSED)
-    verify(exactly = 0) { listener.onStyleImageUnused(any()) }
-    verify(exactly = 0) { listener2.onStyleImageUnused(any()) }
+    verifyNo { listener.onStyleImageUnused(any()) }
+    verifyNo { listener2.onStyleImageUnused(any()) }
   }
 
   @Test
@@ -571,7 +571,7 @@ class NativeObserverTest {
     val listener2 = mockk<OnStyleDataLoadedListener>(relaxUnitFun = true)
     nativeObserver.addOnStyleDataLoadedListener(listener2)
     assertEquals(2, nativeObserver.onStyleDataLoadedListeners.size)
-    verify(exactly = 1) {
+    verify {
       observableInterface.subscribe(
         any(),
         listOf(MapEvents.STYLE_DATA_LOADED)
@@ -590,7 +590,7 @@ class NativeObserverTest {
     assertEquals(2, nativeObserver.onStyleDataLoadedListeners.size)
     nativeObserver.removeOnStyleDataLoadedListener(listener)
     assertEquals(1, nativeObserver.onStyleDataLoadedListeners.size)
-    verify(exactly = 0) {
+    verifyNo {
       observableInterface.unsubscribe(
         any(),
         listOf(MapEvents.STYLE_DATA_LOADED)
@@ -601,8 +601,8 @@ class NativeObserverTest {
     assertFalse(nativeObserver.observedEvents.contains(MapEvents.STYLE_DATA_LOADED))
     verify { observableInterface.unsubscribe(any(), listOf(MapEvents.STYLE_DATA_LOADED)) }
     notifyEvents(MapEvents.STYLE_DATA_LOADED)
-    verify(exactly = 0) { listener.onStyleDataLoaded(any()) }
-    verify(exactly = 0) { listener2.onStyleDataLoaded(any()) }
+    verifyNo { listener.onStyleDataLoaded(any()) }
+    verifyNo { listener2.onStyleDataLoaded(any()) }
   }
 
   @Test
@@ -646,5 +646,23 @@ class NativeObserverTest {
     assertTrue(nativeObserver.onStyleImageMissingListeners.isEmpty())
     assertTrue(nativeObserver.onStyleImageUnusedListeners.isEmpty())
     assertTrue(nativeObserver.onStyleDataLoadedListeners.isEmpty())
+  }
+
+  @Test
+  fun resubscribesStyleLoadedEvents() {
+    nativeObserver.addOnStyleDataLoadedListener(mockk())
+    nativeObserver.addOnStyleLoadedListener(mockk())
+    nativeObserver.resubscribeStyleLoadListeners()
+
+    verify(exactly = 2) {
+      observableInterface.subscribe(
+        nativeObserver,
+        listOf(MapEvents.STYLE_DATA_LOADED)
+      )
+      observableInterface.subscribe(
+        nativeObserver,
+        listOf(MapEvents.STYLE_LOADED)
+      )
+    }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -15,10 +15,21 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class StyleObserverTest {
 
+  private lateinit var mainStyleLoadedListener: Style.OnStyleLoaded
+  private lateinit var styleObserver: StyleObserver
+
   @Before
   fun setUp() {
     mockkStatic("com.mapbox.maps.MapboxLogger")
     every { logE(any(), any()) } just Runs
+
+    mainStyleLoadedListener = mockk(relaxed = true)
+    styleObserver = StyleObserver(
+      nativeMap = mockk(relaxUnitFun = true),
+      styleLoadedListener = mainStyleLoadedListener,
+      nativeObserver = mockk(relaxUnitFun = true),
+      pixelRatio = 1.0f
+    )
   }
 
   @After
@@ -56,20 +67,12 @@ class StyleObserverTest {
    */
   @Test
   fun onStyleLoadSuccess() {
-    val mainStyleLoadedListener = mockk<Style.OnStyleLoaded>(relaxed = true)
-    val nativeMap = mockk<MapInterface>(relaxed = true)
-    val styleObserver = StyleObserver(
-      nativeMap = nativeMap,
-      styleLoadedListener = mainStyleLoadedListener,
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
     val styleLoaded = mockk<Style.OnStyleLoaded>(relaxed = true)
     styleObserver.setLoadStyleListener(styleLoaded, null, null, null, null)
     styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE)) // needed to initialize style internally
     styleObserver.onStyleLoaded(mockk())
-    verify(exactly = 1) { styleLoaded.onStyleLoaded(any()) }
-    verify(exactly = 1) { mainStyleLoadedListener.onStyleLoaded(any()) }
+    verify { styleLoaded.onStyleLoaded(any()) }
+    verify { mainStyleLoadedListener.onStyleLoaded(any()) }
   }
 
   /**
@@ -77,12 +80,6 @@ class StyleObserverTest {
    */
   @Test
   fun onStyleLoadSuccessMulti() {
-    val styleObserver = StyleObserver(
-      nativeMap = mockk(relaxed = true),
-      styleLoadedListener = mockk(relaxed = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
     val userLoadStyleListener = mockk<Style.OnStyleLoaded>(relaxed = true)
     styleObserver.setLoadStyleListener(
       userLoadStyleListener,
@@ -107,12 +104,6 @@ class StyleObserverTest {
    */
   @Test
   fun onStyleLoadedOverwritten() {
-    val styleObserver = StyleObserver(
-      nativeMap = mockk(relaxed = true),
-      styleLoadedListener = mockk(relaxed = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
     val styleLoadedFail = mockk<Style.OnStyleLoaded>(relaxed = true)
     styleObserver.setLoadStyleListener(styleLoadedFail, null, null, null, null)
     val styleLoadedSuccess = mockk<Style.OnStyleLoaded>(relaxed = true)
@@ -128,12 +119,6 @@ class StyleObserverTest {
    */
   @Test
   fun onStyleLoadError() {
-    val styleObserver = StyleObserver(
-      nativeMap = mockk(relaxed = true),
-      styleLoadedListener = mockk(relaxed = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
     val errorListener = mockk<OnMapLoadErrorListener>(relaxed = true)
     styleObserver.setLoadStyleListener(null, null, null, null, errorListener)
     styleObserver.onMapLoadError(mockk(relaxed = true))
@@ -145,12 +130,6 @@ class StyleObserverTest {
    */
   @Test
   fun onStyleLoadErrorNotCalled() {
-    val styleObserver = StyleObserver(
-      nativeMap = mockk(relaxed = true),
-      styleLoadedListener = mockk(relaxed = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
     val errorListenerFail = mockk<OnMapLoadErrorListener>(relaxed = true)
     styleObserver.setLoadStyleListener(null, null, null, null, errorListenerFail)
     val errorListenerSuccess = mockk<OnMapLoadErrorListener>(relaxed = true)
@@ -162,14 +141,6 @@ class StyleObserverTest {
 
   @Test
   fun onStyleDataLoadedNotifiesMapboxMap() {
-    val nativeMap = mockk<MapInterface>(relaxUnitFun = true)
-    val styleObserver = StyleObserver(
-      nativeMap = nativeMap,
-      styleLoadedListener = mockk(relaxUnitFun = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
-
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
@@ -191,14 +162,6 @@ class StyleObserverTest {
 
   @Test
   fun onStyleDataSpritesLoadedNotifiesMapboxMap() {
-    val nativeMap = mockk<MapInterface>(relaxed = true)
-    val styleObserver = StyleObserver(
-      nativeMap = nativeMap,
-      styleLoadedListener = mockk(relaxUnitFun = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
-
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
@@ -225,14 +188,6 @@ class StyleObserverTest {
 
   @Test
   fun onStyleDataSourcesLoadedNotifiesMapboxMap() {
-    val nativeMap = mockk<MapInterface>(relaxed = true)
-    val styleObserver = StyleObserver(
-      nativeMap = nativeMap,
-      styleLoadedListener = mockk(relaxUnitFun = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
-
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
@@ -259,12 +214,6 @@ class StyleObserverTest {
 
   @Test
   fun onStyleDataOverwritten() {
-    val styleObserver = StyleObserver(
-      nativeMap = mockk(relaxed = true),
-      styleLoadedListener = mockk(relaxed = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
     val styleNotCalled = mockk<Style.OnStyleLoaded>(relaxed = true)
     val spritesNotCalled = mockk<Style.OnStyleLoaded>(relaxed = true)
     val sourcesNotCalled = mockk<Style.OnStyleLoaded>(relaxed = true)
@@ -291,14 +240,6 @@ class StyleObserverTest {
 
   @Test
   fun onStyleDataSourcesThrowsIfNoStyleData() {
-    val nativeMap = mockk<MapInterface>(relaxed = true)
-    val styleObserver = StyleObserver(
-      nativeMap = nativeMap,
-      styleLoadedListener = mockk(relaxUnitFun = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
-
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
@@ -318,14 +259,6 @@ class StyleObserverTest {
 
   @Test
   fun onStyleDataSpritesThrowsIfNoStyleData() {
-    val nativeMap = mockk<MapInterface>(relaxUnitFun = true)
-    val styleObserver = StyleObserver(
-      nativeMap = nativeMap,
-      styleLoadedListener = mockk(relaxUnitFun = true),
-      nativeObserver = mockk(relaxed = true),
-      pixelRatio = 1.0f
-    )
-
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
@@ -345,14 +278,6 @@ class StyleObserverTest {
 
   @Test
   fun onStyleLoadedThrowsIfNoStyleData() {
-    val nativeMap = mockk<MapInterface>(relaxUnitFun = true)
-    val styleObserver = StyleObserver(
-      nativeMap = nativeMap,
-      styleLoadedListener = mockk(relaxUnitFun = true),
-      nativeObserver = mockk(relaxUnitFun = true),
-      pixelRatio = 1.0f
-    )
-
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
@@ -368,5 +293,51 @@ class StyleObserverTest {
     assertThrows(MapboxMapException::class.java) {
       styleObserver.onStyleLoaded(mockk())
     }
+  }
+
+  @Test
+  fun onStyleLoadedCallsSpritesListenerIfNoStyleDataSpritesLoaded() {
+    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(
+      null,
+      styleCallback,
+      styleSpritesCallback,
+      null,
+      null
+    )
+
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE))
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SOURCES))
+
+    verifyNo { styleSpritesCallback.onStyleLoaded(any()) }
+
+    styleObserver.onStyleLoaded(mockk())
+
+    verify { styleSpritesCallback.onStyleLoaded(any()) }
+  }
+
+  @Test
+  fun onStyleLoadedCallsSourcesListenerIfNoStyleDataSourcesLoaded() {
+    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(
+      null,
+      styleCallback,
+      null,
+      styleSourcesCallback,
+      null
+    )
+
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE))
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SPRITE))
+
+    verifyNo { styleSourcesCallback.onStyleLoaded(any()) }
+
+    styleObserver.onStyleLoaded(mockk())
+
+    verify { styleSourcesCallback.onStyleLoaded(any()) }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -144,9 +144,10 @@ class StyleObserverTest {
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleUserCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
 
     styleObserver.setLoadStyleListener(
-      null,
+      styleUserCallback,
       styleCallback,
       styleSpritesCallback,
       styleSourcesCallback,
@@ -158,6 +159,9 @@ class StyleObserverTest {
     verify { styleCallback.onStyleLoaded(any()) }
     verifyNo { styleSpritesCallback.onStyleLoaded(any()) }
     verifyNo { styleSourcesCallback.onStyleLoaded(any()) }
+
+    verifyNo { styleSpritesCallback.onStyleLoaded(any()) }
+    verifyNo { mainStyleLoadedListener.onStyleLoaded(any()) }
   }
 
   @Test
@@ -165,9 +169,10 @@ class StyleObserverTest {
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleUserCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
 
     styleObserver.setLoadStyleListener(
-      null,
+      styleUserCallback,
       styleCallback,
       styleSpritesCallback,
       styleSourcesCallback,
@@ -184,6 +189,9 @@ class StyleObserverTest {
 
     verify { styleSpritesCallback.onStyleLoaded(any()) }
     verifyNo { styleSourcesCallback.onStyleLoaded(any()) }
+
+    verifyNo { styleUserCallback.onStyleLoaded(any()) }
+    verifyNo { mainStyleLoadedListener.onStyleLoaded(any()) }
   }
 
   @Test
@@ -191,9 +199,10 @@ class StyleObserverTest {
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleUserCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
 
     styleObserver.setLoadStyleListener(
-      null,
+      styleUserCallback,
       styleCallback,
       styleSpritesCallback,
       styleSourcesCallback,
@@ -210,6 +219,9 @@ class StyleObserverTest {
     verify { styleSourcesCallback.onStyleLoaded(any()) }
     verify { styleCallback.onStyleLoaded(any()) }
     verifyNo { styleSpritesCallback.onStyleLoaded(any()) }
+
+    verifyNo { styleSpritesCallback.onStyleLoaded(any()) }
+    verifyNo { mainStyleLoadedListener.onStyleLoaded(any()) }
   }
 
   @Test


### PR DESCRIPTION
Fire sprite/sources loaded MapboxMap callbacks on onStyleLoad if no style data events arrived. 

<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: #1371 

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
