### PR TITLE
Use `orientation` model source property to update the 3D puck's bearing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 #main
 ## Features ✨ and improvements 🏁
 * Optimise the bearing update frequency for the location puck animator. ([1398](https://github.com/mapbox/mapbox-maps-android/pull/1398))
+* Use `orientation` model source property to update the 3D puck's bearing, as it is more efficient than updating the `model-rotation` layer property. ([1407](https://github.com/mapbox/mapbox-maps-android/pull/1407))
 
 ## Bug fixes 🐞
 * Optimise the frequency to update location layer's visibility. ([1399](https://github.com/mapbox/mapbox-maps-android/pull/1399))

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
@@ -46,26 +46,26 @@ class Expression : Value {
     this.literalValue = value
   }
 
-  private constructor(value: DoubleArray) : super(value.map { Value(it) }) {
+  private constructor(value: DoubleArray) : super(value.map(::Value)) {
     this.literalValue = value
   }
 
-  private constructor(value: LongArray) : super(value.map { Value(it) }) {
+  private constructor(value: LongArray) : super(value.map(::Value)) {
     this.literalValue = value
   }
 
-  private constructor(value: BooleanArray) : super(value.map { Value(it) }) {
+  private constructor(value: BooleanArray) : super(value.map(::Value)) {
     this.literalValue = value
   }
 
-  private constructor(value: Array<String>) : super(value.map { Value(it) }) {
+  private constructor(value: Array<String>) : super(value.map(::Value)) {
     this.literalValue = value
   }
 
   internal constructor(value: Array<DoubleArray>) : super(
     value.map { doubleArray ->
       Value(
-        doubleArray.map { Value(it) }
+        doubleArray.map(::Value)
       )
     }
   ) {

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/TileSet.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/TileSet.kt
@@ -34,7 +34,7 @@ class TileSet private constructor(builder: Builder) : HashMap<String, Value>(bui
 
     init {
       parameters["tilejson"] = Value(tilejson)
-      parameters["tiles"] = Value(tiles.map { Value(it) })
+      parameters["tiles"] = Value(tiles.map(::Value))
     }
 
     /**
@@ -143,7 +143,7 @@ class TileSet private constructor(builder: Builder) : HashMap<String, Value>(bui
      * @param value the grids to set
      */
     fun grids(value: List<String>) = apply {
-      parameters["grids"] = Value(value.map { Value(it) })
+      parameters["grids"] = Value(value.map(::Value))
     }
 
     /**
@@ -161,7 +161,7 @@ class TileSet private constructor(builder: Builder) : HashMap<String, Value>(bui
      * @param value the data array to set
      */
     fun data(value: List<String>) = apply {
-      parameters["data"] = Value(value.map { Value(it) })
+      parameters["data"] = Value(value.map(::Value))
     }
 
     /**
@@ -191,7 +191,7 @@ class TileSet private constructor(builder: Builder) : HashMap<String, Value>(bui
      * @param value the Double list to set
      */
     fun bounds(value: List<Double> = listOf(-180.0, -90.0, 180.0, 90.0)) = apply {
-      parameters["bounds"] = Value(value.map { Value(it) })
+      parameters["bounds"] = Value(value.map(::Value))
     }
 
     /**
@@ -206,7 +206,7 @@ class TileSet private constructor(builder: Builder) : HashMap<String, Value>(bui
      * @param value the Double array to set
      */
     fun center(value: List<Double>) = apply {
-      parameters["center"] = Value(value.map { Value(it) })
+      parameters["center"] = Value(value.map(::Value))
     }
 
     /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/types/FormattedSection.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/types/FormattedSection.kt
@@ -57,7 +57,7 @@ data class FormattedSection @JvmOverloads constructor(
       params["font-scale"] = Value(it)
     }
     fontStack?.let { strings ->
-      params["text-font"] = Value(strings.map { Value(it) })
+      params["text-font"] = Value(strings.map(::Value))
     }
     textColor?.let {
       params["text-color"] = Value(it)

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/utils/TypeUtils.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/utils/TypeUtils.kt
@@ -57,11 +57,11 @@ internal object TypeUtils {
         Value(valueArray)
       }
       is BooleanArray -> {
-        val valueArray = value.map { Value(it) }
+        val valueArray = value.map(::Value)
         Value(valueArray)
       }
       is DoubleArray -> {
-        val valueArray = value.map { Value(it) }
+        val valueArray = value.map(::Value)
         Value(valueArray)
       }
       is FloatArray -> {
@@ -69,7 +69,7 @@ internal object TypeUtils {
         Value(valueArray)
       }
       is LongArray -> {
-        val valueArray = value.map { Value(it) }
+        val valueArray = value.map(::Value)
         Value(valueArray)
       }
       is Array<*> -> {

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapper.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapper.kt
@@ -22,7 +22,7 @@ internal class LocationIndicatorLayerWrapper(layerId: String) : LocationLayerWra
 
   fun bearing(bearing: Double) = updateProperty("bearing", Value(bearing))
 
-  fun location(location: List<Double>) = updateProperty("location", Value(location.map { Value(it) }))
+  fun location(location: List<Double>) = updateProperty("location", Value(location.map(::Value)))
 
   fun accuracyRadiusColor(expression: List<Value>) = updateProperty("accuracy-radius-color", Value(expression))
 

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRenderer.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRenderer.kt
@@ -80,20 +80,16 @@ internal class ModelLayerRenderer(
   }
 
   private fun setLayerLocation(latLng: Point) {
-    updateLocationOrBearing(point = latLng)
+    lastLocation = latLng
+    updateLocationOrBearing()
   }
 
   private fun setLayerBearing(bearing: Double) {
-    updateLocationOrBearing(bearing = bearing)
+    lastBearing = bearing
+    updateLocationOrBearing()
   }
 
-  private fun updateLocationOrBearing(point: Point? = null, bearing: Double? = null) {
-    point?.let {
-      lastLocation = it
-    }
-    bearing?.let {
-      lastBearing = it
-    }
+  private fun updateLocationOrBearing() {
     lastLocation?.let { location ->
       val latLng = listOf(location.longitude(), location.latitude())
       val orientation = listOf(0.0, 0.0, lastBearing)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRenderer.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRenderer.kt
@@ -91,9 +91,9 @@ internal class ModelLayerRenderer(
 
   private fun updateLocationOrBearing() {
     lastLocation?.let { location ->
-      val latLng = listOf(location.longitude(), location.latitude())
+      val lngLat = listOf(location.longitude(), location.latitude())
       val orientation = listOf(0.0, 0.0, lastBearing)
-      source.setPositionAndOrientation(latLng, orientation)
+      source.setPositionAndOrientation(lngLat, orientation)
     }
   }
 

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapper.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapper.kt
@@ -14,16 +14,16 @@ internal class ModelLayerWrapper(
     layerProperties["type"] = Value("model")
     layerProperties["source"] = Value(sourceId)
     layerProperties["model-type"] = Value("location-indicator")
-    layerProperties["model-scale"] = Value(modelScale.map { Value(it) })
-    layerProperties["model-rotation"] = Value(modelRotation.map { Value(it) })
-    layerProperties["model-translation"] = Value(modelTranslation.map { Value(it) })
+    layerProperties["model-scale"] = Value(modelScale.map(::Value))
+    layerProperties["model-rotation"] = Value(modelRotation.map(::Value))
+    layerProperties["model-translation"] = Value(modelTranslation.map(::Value))
   }
 
-  fun modelScale(scale: List<Double>) = updateProperty("model-scale", Value(scale.map { Value(it) }))
+  fun modelScale(scale: List<Double>) = updateProperty("model-scale", Value(scale.map(::Value)))
 
   fun modelScaleExpression(scaleExpression: Value) = updateProperty("model-scale", scaleExpression)
 
-  fun modelRotation(rotation: List<Double>) = updateProperty("model-rotation", Value(rotation.map { Value(it) }))
+  fun modelRotation(rotation: List<Double>) = updateProperty("model-rotation", Value(rotation.map(::Value)))
 
-  fun modelTranslation(translation: List<Double>) = updateProperty("model-translation", Value(translation.map { Value(it) }))
+  fun modelTranslation(translation: List<Double>) = updateProperty("model-translation", Value(translation.map(::Value)))
 }

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapper.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapper.kt
@@ -19,8 +19,8 @@ internal class ModelSourceWrapper(
   init {
     val modelProperties = HashMap<String, Value>()
     modelProperties[URL] = Value(url)
-    modelProperties[POSITION] = Value(position.map { Value(it) })
-    modelProperties[ORIENTATION] = Value(listOf(0.0, 0.0, 0.0).map { Value(it) })
+    modelProperties[POSITION] = Value(position.map(::Value))
+    modelProperties[ORIENTATION] = Value(listOf(0.0, 0.0, 0.0).map(::Value))
 
     val models = HashMap<String, Value>()
     models[DEFAULT_MODEL_NAME] = Value(modelProperties)
@@ -44,8 +44,8 @@ internal class ModelSourceWrapper(
 
   fun setPositionAndOrientation(latLng: List<Double>, orientation: List<Double>) {
     val property = hashMapOf(
-      Pair(POSITION, Value(latLng.map { Value(it) })),
-      Pair(ORIENTATION, Value(orientation.map { Value(it) })),
+      Pair(POSITION, Value(latLng.map(::Value))),
+      Pair(ORIENTATION, Value(orientation.map(::Value))),
       Pair(URL, Value(url))
     )
     val updateModel = hashMapOf(Pair(DEFAULT_MODEL_NAME, Value(property)))

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapper.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapper.kt
@@ -42,13 +42,13 @@ internal class ModelSourceWrapper(
     }
   }
 
-  fun setPositionAndOrientation(latLng: List<Double>, orientation: List<Double>) {
+  fun setPositionAndOrientation(lngLat: List<Double>, orientation: List<Double>) {
     val property = hashMapOf(
-      Pair(POSITION, Value(latLng.map(::Value))),
-      Pair(ORIENTATION, Value(orientation.map(::Value))),
-      Pair(URL, Value(url))
+      POSITION to Value(lngLat.map(::Value)),
+      ORIENTATION to Value(orientation.map(::Value)),
+      URL to Value(url)
     )
-    val updateModel = hashMapOf(Pair(DEFAULT_MODEL_NAME, Value(property)))
+    val updateModel = hashMapOf(DEFAULT_MODEL_NAME to Value(property))
     updateProperty(MODELS, Value(updateModel))
   }
 

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapper.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapper.kt
@@ -42,8 +42,12 @@ internal class ModelSourceWrapper(
     }
   }
 
-  fun setPosition(value: List<Double>) {
-    val property = hashMapOf(Pair(POSITION, Value(value.map { Value(it) })), Pair(URL, Value(url)))
+  fun setPositionAndOrientation(latLng: List<Double>, orientation: List<Double>) {
+    val property = hashMapOf(
+      Pair(POSITION, Value(latLng.map { Value(it) })),
+      Pair(ORIENTATION, Value(orientation.map { Value(it) })),
+      Pair(URL, Value(url))
+    )
     val updateModel = hashMapOf(Pair(DEFAULT_MODEL_NAME, Value(property)))
     updateProperty(MODELS, Value(updateModel))
   }

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapperTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationIndicatorLayerWrapperTest.kt
@@ -55,7 +55,7 @@ class LocationIndicatorLayerWrapperTest {
   fun testLocation() {
     val location = arrayListOf(1.0, 2.0)
     layer.location(location)
-    verify { style.setStyleLayerProperty(INDICATOR_LAYER_ID, "location", Value(location.map { Value(it) })) }
+    verify { style.setStyleLayerProperty(INDICATOR_LAYER_ID, "location", Value(location.map(::Value))) }
   }
 
   @Test

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRendererTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerRendererTest.kt
@@ -44,8 +44,8 @@ class ModelLayerRendererTest {
 
     locationLayerRenderer.initializeComponents(style)
 
-    verify { sourceWrapper.setPosition(listOf(10.0, 20.0)) }
-    verify { layerWrapper.modelRotation(listOf(0.0, 0.0, 11.0)) }
+    verify { sourceWrapper.setPositionAndOrientation(listOf(10.0, 20.0), listOf(0.0, 0.0, 11.0)) }
+    verify(exactly = 0) { layerWrapper.modelRotation(any()) }
   }
 
   @Test
@@ -81,16 +81,25 @@ class ModelLayerRendererTest {
     locationLayerRenderer.setLatLng(latLng)
 
     verify {
-      sourceWrapper.setPosition(listOf(10.0, 20.0))
+      sourceWrapper.setPositionAndOrientation(listOf(10.0, 20.0), listOf(0.0, 0.0, 0.0))
     }
   }
 
   @Test
-  fun setBearing() {
+  fun setBearingWithoutLastLocation() {
     val bearing = 30.0
     locationLayerRenderer.show()
     locationLayerRenderer.setBearing(bearing)
-    verify { layerWrapper.modelRotation(listOf(0.0, 0.0, bearing)) }
+    verify(exactly = 0) { sourceWrapper.setPositionAndOrientation(any(), any()) }
+  }
+
+  @Test
+  fun setBearingWithLastLocation() {
+    val bearing = 30.0
+    locationLayerRenderer.show()
+    locationLayerRenderer.lastLocation = Point.fromLngLat(0.0, 0.0)
+    locationLayerRenderer.setBearing(bearing)
+    verify(exactly = 1) { sourceWrapper.setPositionAndOrientation(any(), listOf(0.0, 0.0, bearing)) }
   }
 
   @Test

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapperTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelLayerWrapperTest.kt
@@ -50,21 +50,21 @@ class ModelLayerWrapperTest {
   fun testScale() {
     val scale = arrayListOf(1.0, 2.0)
     layer.modelScale(scale)
-    verify { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-scale", Value(scale.map { Value(it) })) }
+    verify { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-scale", Value(scale.map(::Value))) }
   }
 
   @Test
   fun testRotation() {
     val rotation = arrayListOf(1.0, 2.0)
     layer.modelRotation(rotation)
-    verify { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-rotation", Value(rotation.map { Value(it) })) }
+    verify { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-rotation", Value(rotation.map(::Value))) }
   }
 
   @Test
   fun testTranslation() {
     val translation = arrayListOf(1.0, 2.0)
     layer.modelTranslation(translation)
-    verify { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-translation", Value(translation.map { Value(it) })) }
+    verify { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-translation", Value(translation.map(::Value))) }
   }
 
   @Test
@@ -72,7 +72,7 @@ class ModelLayerWrapperTest {
     every { style.styleLayerExists(any()) } returns false
     val scale = arrayListOf(1.0, 2.0)
     layer.modelScale(scale)
-    verify(exactly = 0) { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-scale", Value(scale.map { Value(it) })) }
+    verify(exactly = 0) { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-scale", Value(scale.map(::Value))) }
   }
 
   @Test
@@ -83,8 +83,8 @@ class ModelLayerWrapperTest {
     layer.updateStyle(newStyle)
     val scale = listOf(1.0, 2.0, 3.0)
     layer.modelScale(scale)
-    verify(exactly = 0) { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-scale", Value(scale.map { Value(it) })) }
-    verify(exactly = 1) { newStyle.setStyleLayerProperty(MODEL_LAYER_ID, "model-scale", Value(scale.map { Value(it) })) }
+    verify(exactly = 0) { style.setStyleLayerProperty(MODEL_LAYER_ID, "model-scale", Value(scale.map(::Value))) }
+    verify(exactly = 1) { newStyle.setStyleLayerProperty(MODEL_LAYER_ID, "model-scale", Value(scale.map(::Value))) }
   }
 
   companion object {

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapperTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapperTest.kt
@@ -47,9 +47,14 @@ class ModelSourceWrapperTest {
     val modelSource = ModelSourceWrapper(SOURCE_ID, "uri", listOf(1.0, 2.0))
     modelSource.bindTo(style)
 
-    val position = arrayListOf(5.0)
-    modelSource.setPosition(position)
-    val property = hashMapOf(Pair(ModelSourceWrapper.POSITION, Value(position.map { Value(it) })), Pair(ModelSourceWrapper.URL, Value("uri")))
+    val position = arrayListOf(5.0, 5.0)
+    val orientation = arrayListOf(0.0, 0.0, 5.0)
+    modelSource.setPositionAndOrientation(position, orientation)
+    val property = hashMapOf(
+      Pair(ModelSourceWrapper.POSITION, Value(position.map { Value(it) })),
+      Pair(ModelSourceWrapper.ORIENTATION, Value(orientation.map { Value(it) })),
+      Pair(ModelSourceWrapper.URL, Value("uri"))
+    )
     val updateModel = hashMapOf(Pair(ModelSourceWrapper.DEFAULT_MODEL_NAME, Value(property)))
     verify { style.setStyleSourceProperty(SOURCE_ID, ModelSourceWrapper.MODELS, Value(updateModel)) }
   }
@@ -60,9 +65,14 @@ class ModelSourceWrapperTest {
     val modelSource = ModelSourceWrapper(SOURCE_ID, "uri", listOf(1.0, 2.0))
     modelSource.bindTo(style)
 
-    val position = arrayListOf(5.0)
-    modelSource.setPosition(position)
-    val property = hashMapOf(Pair(ModelSourceWrapper.POSITION, Value(position.map { Value(it) })), Pair(ModelSourceWrapper.URL, Value("uri")))
+    val position = arrayListOf(5.0, 5.0)
+    val orientation = arrayListOf(0.0, 0.0, 5.0)
+    modelSource.setPositionAndOrientation(position, orientation)
+    val property = hashMapOf(
+      Pair(ModelSourceWrapper.POSITION, Value(position.map { Value(it) })),
+      Pair(ModelSourceWrapper.ORIENTATION, Value(orientation.map { Value(it) })),
+      Pair(ModelSourceWrapper.URL, Value("uri"))
+    )
     val updateModel = hashMapOf(Pair(ModelSourceWrapper.DEFAULT_MODEL_NAME, Value(property)))
     verify(exactly = 0) { style.setStyleSourceProperty(SOURCE_ID, ModelSourceWrapper.MODELS, Value(updateModel)) }
   }
@@ -76,9 +86,14 @@ class ModelSourceWrapperTest {
     every { newStyle.addStyleSource(any(), any()) } returns expected
     every { newStyle.setStyleSourceProperty(any(), any(), any()) } returns expected
     modelSource.updateStyle(newStyle)
-    val position = arrayListOf(5.0)
-    modelSource.setPosition(position)
-    val property = hashMapOf(Pair(ModelSourceWrapper.POSITION, Value(position.map { Value(it) })), Pair(ModelSourceWrapper.URL, Value("uri")))
+    val position = arrayListOf(5.0, 5.0)
+    val orientation = arrayListOf(0.0, 0.0, 5.0)
+    modelSource.setPositionAndOrientation(position, orientation)
+    val property = hashMapOf(
+      Pair(ModelSourceWrapper.POSITION, Value(position.map { Value(it) })),
+      Pair(ModelSourceWrapper.ORIENTATION, Value(orientation.map { Value(it) })),
+      Pair(ModelSourceWrapper.URL, Value("uri"))
+    )
     val updateModel = hashMapOf(Pair(ModelSourceWrapper.DEFAULT_MODEL_NAME, Value(property)))
     verify(exactly = 0) { style.setStyleSourceProperty(SOURCE_ID, ModelSourceWrapper.MODELS, Value(updateModel)) }
     verify(exactly = 1) { newStyle.setStyleSourceProperty(SOURCE_ID, ModelSourceWrapper.MODELS, Value(updateModel)) }

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapperTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/ModelSourceWrapperTest.kt
@@ -51,8 +51,8 @@ class ModelSourceWrapperTest {
     val orientation = arrayListOf(0.0, 0.0, 5.0)
     modelSource.setPositionAndOrientation(position, orientation)
     val property = hashMapOf(
-      Pair(ModelSourceWrapper.POSITION, Value(position.map { Value(it) })),
-      Pair(ModelSourceWrapper.ORIENTATION, Value(orientation.map { Value(it) })),
+      Pair(ModelSourceWrapper.POSITION, Value(position.map(::Value))),
+      Pair(ModelSourceWrapper.ORIENTATION, Value(orientation.map(::Value))),
       Pair(ModelSourceWrapper.URL, Value("uri"))
     )
     val updateModel = hashMapOf(Pair(ModelSourceWrapper.DEFAULT_MODEL_NAME, Value(property)))
@@ -69,8 +69,8 @@ class ModelSourceWrapperTest {
     val orientation = arrayListOf(0.0, 0.0, 5.0)
     modelSource.setPositionAndOrientation(position, orientation)
     val property = hashMapOf(
-      Pair(ModelSourceWrapper.POSITION, Value(position.map { Value(it) })),
-      Pair(ModelSourceWrapper.ORIENTATION, Value(orientation.map { Value(it) })),
+      Pair(ModelSourceWrapper.POSITION, Value(position.map(::Value))),
+      Pair(ModelSourceWrapper.ORIENTATION, Value(orientation.map(::Value))),
       Pair(ModelSourceWrapper.URL, Value("uri"))
     )
     val updateModel = hashMapOf(Pair(ModelSourceWrapper.DEFAULT_MODEL_NAME, Value(property)))
@@ -90,8 +90,8 @@ class ModelSourceWrapperTest {
     val orientation = arrayListOf(0.0, 0.0, 5.0)
     modelSource.setPositionAndOrientation(position, orientation)
     val property = hashMapOf(
-      Pair(ModelSourceWrapper.POSITION, Value(position.map { Value(it) })),
-      Pair(ModelSourceWrapper.ORIENTATION, Value(orientation.map { Value(it) })),
+      Pair(ModelSourceWrapper.POSITION, Value(position.map(::Value))),
+      Pair(ModelSourceWrapper.ORIENTATION, Value(orientation.map(::Value))),
       Pair(ModelSourceWrapper.URL, Value("uri"))
     )
     val updateModel = hashMapOf(Pair(ModelSourceWrapper.DEFAULT_MODEL_NAME, Value(property)))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Use `orientation` model source property to update the 3D puck's bearing, as it is more efficient than updating the layer property.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
