### PR TITLE
Fix issue when tasks are skipped if surface is recreated - MAPSAND-177.

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -186,7 +186,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     if (needRender) {
       renderer.queueRenderEvent(event)
     } else {
-      renderer.queueEvent(event)
+      renderer.queueNonRenderEvent(event)
     }
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/EventType.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/EventType.kt
@@ -5,14 +5,15 @@ package com.mapbox.maps.renderer
  */
 internal enum class EventType {
   /**
-   * Those events are scheduled not by the Maps SDK (most likely by the user using MapView#queueEvent)
+   * Those events are scheduled by the Maps SDK or by user.
    * Such events do not get cleared when Android provides new surface or texture.
-   * In case render thread is not fully prepared - such messages will keep being rescheduled until
+   * If render thread is not fully prepared - such messages will keep being rescheduled until
    * thread is prepared or killed.
    */
-  OTHER,
+  DEFAULT,
 
   /**
+   * Special event type to handle when renderer is being destroyed
    * TODO remove when gl-native fix will land
    */
   DESTROY_RENDERER,

--- a/sdk/src/main/java/com/mapbox/maps/renderer/EventType.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/EventType.kt
@@ -5,15 +5,10 @@ package com.mapbox.maps.renderer
  */
 internal enum class EventType {
   /**
-   * Those events are scheduled by our SDK.
-   * Such events get cleared when Android provides new surface or texture.
-   */
-  SDK,
-
-  /**
-   * Those events are scheduled by not our SDK (most likely by the user using MapView#queueEvent)
+   * Those events are scheduled not by the Maps SDK (most likely by the user using MapView#queueEvent)
    * Such events do not get cleared when Android provides new surface or texture.
-   * In case render thread is not fully prepared - such messages will keep being rescheduled until thread is prepared or killed.
+   * In case render thread is not fully prepared - such messages will keep being rescheduled until
+   * thread is prepared or killed.
    */
   OTHER,
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -328,7 +328,11 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       // at least on Android 8 devices we create surface before Activity#onStart
       // so we need to proceed to EGL creation in any case to avoid deadlock
       if (!creatingSurface) {
-        logI(TAG, "Skip render frame - NOT creating surface but renderNotSupported ($renderNotSupported) || paused ($paused)")
+        logI(
+          TAG,
+          "Skip render frame - NOT creating surface although " +
+            "renderNotSupported ($renderNotSupported) || paused ($paused)"
+        )
         return
       }
     }
@@ -336,7 +340,11 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     if (creatingSurface || !renderThreadPrepared) {
       val renderThreadPreparedOk = setUpRenderThread(creatingSurface)
       if (!renderThreadPreparedOk) {
-        logI(TAG, "Skip render frame - NOT render thread prepared but creatingSurface ($creatingSurface) || !renderThreadPrepared (${!renderThreadPrepared})")
+        logI(
+          TAG,
+          "Skip render frame - render thread NOT prepared although " +
+            "creatingSurface ($creatingSurface) || !renderThreadPrepared (${!renderThreadPrepared})"
+        )
         return
       }
     }
@@ -393,7 +401,11 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
   internal fun processAndroidSurface(surface: Surface, width: Int, height: Int) {
     if (this.surface != surface) {
       if (this.surface != null) {
-        logI(TAG, "Process android surface while current is not null, will release EGL")
+        logI(
+          TAG,
+          "Processing new android surface while current is not null, " +
+            "releasing current EGL"
+        )
         releaseEgl()
         this.surface?.release()
       }
@@ -439,7 +451,9 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       renderEvent.runnable?.let {
         renderEventQueue.add(renderEvent)
       }
-      postPrepareRenderFrame()
+      if (renderThreadPrepared) {
+        postPrepareRenderFrame()
+      }
     } else {
       postNonRenderEvent(renderEvent)
     }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -48,7 +48,7 @@ internal abstract class MapboxRenderer : MapClient {
 
   @UiThread
   fun onDestroy() {
-    logW(TAG, "onDestroy")
+    logI(TAG, "onDestroy")
     renderThread.destroy()
     renderThread.fpsChangedListener = null
   }
@@ -70,7 +70,7 @@ internal abstract class MapboxRenderer : MapClient {
       RenderEvent(
         runnable = { task.run() },
         needRender = false,
-        eventType = if (renderThread.renderDestroyCallChain) EventType.DESTROY_RENDERER else EventType.OTHER
+        eventType = if (renderThread.renderDestroyCallChain) EventType.DESTROY_RENDERER else EventType.DEFAULT
       )
     )
   }
@@ -81,7 +81,7 @@ internal abstract class MapboxRenderer : MapClient {
       RenderEvent(
         runnable = runnable,
         needRender = true,
-        eventType = EventType.OTHER
+        eventType = EventType.DEFAULT
       )
     )
   }
@@ -92,7 +92,7 @@ internal abstract class MapboxRenderer : MapClient {
       RenderEvent(
         runnable = runnable,
         needRender = false,
-        eventType = EventType.OTHER
+        eventType = EventType.DEFAULT
       )
     )
   }
@@ -114,7 +114,7 @@ internal abstract class MapboxRenderer : MapClient {
 
   @WorkerThread
   fun destroyRenderer() {
-    logW(TAG, "Destroy renderer")
+    logI(TAG, "Destroy renderer")
     map?.destroyRenderer()
     // additionally it's correct moment to release pixel reader while we still have EGL context
     pixelReader?.release()
@@ -158,7 +158,7 @@ internal abstract class MapboxRenderer : MapClient {
             }
           },
           needRender = true,
-          eventType = EventType.OTHER
+          eventType = EventType.DEFAULT
         )
       )
       waitCondition.await(1, TimeUnit.SECONDS)
@@ -176,7 +176,7 @@ internal abstract class MapboxRenderer : MapClient {
       RenderEvent(
         runnable = { listener.onSnapshotReady(performSnapshot()) },
         needRender = true,
-        eventType = EventType.OTHER
+        eventType = EventType.DEFAULT
       )
     )
   }
@@ -234,6 +234,6 @@ internal abstract class MapboxRenderer : MapClient {
   companion object {
     private const val TAG = "Mbgl-Renderer"
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal val repaintRenderEvent = RenderEvent(null, true, EventType.OTHER)
+    internal val repaintRenderEvent = RenderEvent(null, true, EventType.DEFAULT)
   }
 }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -48,6 +48,7 @@ internal abstract class MapboxRenderer : MapClient {
 
   @UiThread
   fun onDestroy() {
+    logW(TAG, "onDestroy")
     renderThread.destroy()
     renderThread.fpsChangedListener = null
   }
@@ -60,7 +61,7 @@ internal abstract class MapboxRenderer : MapClient {
 
   @AnyThread
   override fun scheduleRepaint() {
-    renderThread.queueRenderEvent(renderEventSdk)
+    renderThread.queueRenderEvent(repaintRenderEvent)
   }
 
   @AnyThread
@@ -69,7 +70,7 @@ internal abstract class MapboxRenderer : MapClient {
       RenderEvent(
         runnable = { task.run() },
         needRender = false,
-        eventType = if (renderThread.renderDestroyCallChain) EventType.DESTROY_RENDERER else EventType.SDK
+        eventType = if (renderThread.renderDestroyCallChain) EventType.DESTROY_RENDERER else EventType.OTHER
       )
     )
   }
@@ -86,7 +87,7 @@ internal abstract class MapboxRenderer : MapClient {
   }
 
   @AnyThread
-  fun queueEvent(runnable: Runnable) {
+  fun queueNonRenderEvent(runnable: Runnable) {
     renderThread.queueRenderEvent(
       RenderEvent(
         runnable = runnable,
@@ -113,6 +114,7 @@ internal abstract class MapboxRenderer : MapClient {
 
   @WorkerThread
   fun destroyRenderer() {
+    logW(TAG, "Destroy renderer")
     map?.destroyRenderer()
     // additionally it's correct moment to release pixel reader while we still have EGL context
     pixelReader?.release()
@@ -156,7 +158,7 @@ internal abstract class MapboxRenderer : MapClient {
             }
           },
           needRender = true,
-          eventType = EventType.SDK
+          eventType = EventType.OTHER
         )
       )
       waitCondition.await(1, TimeUnit.SECONDS)
@@ -174,7 +176,7 @@ internal abstract class MapboxRenderer : MapClient {
       RenderEvent(
         runnable = { listener.onSnapshotReady(performSnapshot()) },
         needRender = true,
-        eventType = EventType.SDK
+        eventType = EventType.OTHER
       )
     )
   }
@@ -232,6 +234,6 @@ internal abstract class MapboxRenderer : MapClient {
   companion object {
     private const val TAG = "Mbgl-Renderer"
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal val renderEventSdk = RenderEvent(null, true, EventType.SDK)
+    internal val repaintRenderEvent = RenderEvent(null, true, EventType.OTHER)
   }
 }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/RenderEvent.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/RenderEvent.kt
@@ -13,13 +13,16 @@ internal data class RenderEvent(
   val runnable: Runnable?,
   /**
    * Whether that event requires actual render.
-   * If set to `true` - render call will be scheduled, [runnable] will be put in a separate queue which is drained after native draw calls but before swapping buffers.
-   * If set to `false` - no render call will be scheduled, [runnable] will be either be put in a render thread message queue and executed asap if no pending VSYNC event
-   * or executed right after swapping buffers if VSYNC event is pending. Runnables are executed only if render thread is in fully prepared state.
+   * If set to `true` - render call will be scheduled, [runnable] will be put in a separate queue
+   * which is drained after native draw calls but before swapping buffers.
+   * If set to `false` - no render call will be scheduled, [runnable] will be either be put in a
+   * render thread message queue and executed asap if no pending VSYNC event
+   * or executed right after swapping buffers if VSYNC event is pending. Runnables are executed
+   * only if render thread is in fully prepared state.
    */
   val needRender: Boolean,
   /**
-   * Render event type, refer to [EventType] docs.
+   * Render event type.
    */
-  val eventType: EventType
+  val eventType: EventType,
 )

--- a/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
@@ -37,19 +37,15 @@ internal class RenderHandlerThread {
   }
 
   fun stop() {
-    // quit and wait until all the messages will be processed - DESTROY_RENDERER messages
-    // are still there
+    // quit safely to guarantee all DESTROY_RENDERER messages
+    // that may be in the queue will be executed
     handlerThread.quitSafely()
-    try {
-      handlerThread.join()
-    } catch (e: InterruptedException) {
-    } finally {
-      handler = null
-    }
+    handler = null
   }
 
   /**
-   * Clears all messages except of [EventType.DESTROY_RENDERER] messages.
+   * Clears all messages except of [EventType.DESTROY_RENDERER] messages, since they clear
+   * various resources allocated in core and we don't want to leak those resources.
    */
   fun clearDefaultMessages() {
     handler?.removeCallbacksAndMessages(EventType.DEFAULT)

--- a/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
@@ -18,10 +18,10 @@ internal class RenderHandlerThread {
     get() = handlerThread.isAlive
 
   fun post(task: () -> Unit) {
-    postDelayed(task, 0, EventType.SDK)
+    postDelayed(task, 0, EventType.OTHER)
   }
 
-  fun postDelayed(task: () -> Unit, delayMillis: Long, eventType: EventType = EventType.SDK) {
+  fun postDelayed(task: () -> Unit, delayMillis: Long, eventType: EventType = EventType.OTHER) {
     handler?.let {
       val message = Message.obtain(it, task)
       message.obj = eventType
@@ -46,12 +46,8 @@ internal class RenderHandlerThread {
     }
   }
 
-  fun clearMessageQueue(clearAll: Boolean = true) {
-    if (clearAll) {
-      handler?.removeCallbacksAndMessages(null)
-    } else {
-      handler?.removeCallbacksAndMessages(EventType.SDK)
-    }
+  fun clearMessageQueue() {
+    handler?.removeCallbacksAndMessages(null)
   }
 
   companion object {

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -218,14 +218,14 @@ class MapControllerTest {
   @Test
   fun queueEvent() {
     val event = mockk<Runnable>()
-    every { mockRenderer.queueEvent(event) } just Runs
+    every { mockRenderer.queueNonRenderEvent(event) } just Runs
     every { mockRenderer.queueRenderEvent(event) } just Runs
 
     testMapController.queueEvent(event, false)
     testMapController.queueEvent(event, true)
 
     verifySequence {
-      mockRenderer.queueEvent(event)
+      mockRenderer.queueNonRenderEvent(event)
       mockRenderer.queueRenderEvent(event)
     }
   }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -328,7 +328,7 @@ class MapboxRenderThreadTest {
       RenderEvent(
         runnable,
         true,
-        EventType.OTHER
+        EventType.DEFAULT
       )
     )
     assertEquals(1, mapboxRenderThread.renderEventQueue.size)
@@ -409,7 +409,7 @@ class MapboxRenderThreadTest {
       RenderEvent(
         runnable,
         false,
-        EventType.OTHER
+        EventType.DEFAULT
       )
     )
     // simulate render thread is not fully prepared, e.g. EGL context is lost

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -217,9 +217,9 @@ class MapboxRenderThreadTest {
     initRenderThread()
     provideValidSurface()
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     // one swap buffer for surface creation, two for not squashed render requests
     verify(exactly = 3) {
@@ -236,8 +236,8 @@ class MapboxRenderThreadTest {
     initRenderThread()
     provideValidSurface()
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     // one swap buffer for surface creation, 2 render requests squash in one swap buffers call
     verify(exactly = 2) {
@@ -257,11 +257,11 @@ class MapboxRenderThreadTest {
     initRenderThread()
     provideValidSurface()
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     mapboxRenderThread.pause()
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     // one swap buffer for surface creation, one request render after pause is omitted
     verify(exactly = 2) {
@@ -274,17 +274,17 @@ class MapboxRenderThreadTest {
     initRenderThread()
     provideValidSurface()
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     mapboxRenderThread.pause()
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     mapboxRenderThread.resume()
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     // render requests after pause do not swap buffer, we do it on resume if needed once
     verify(exactly = 4) {
@@ -297,13 +297,13 @@ class MapboxRenderThreadTest {
     initRenderThread()
     provideValidSurface()
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     mapboxRenderThread.pause()
     idleHandler()
     mapboxRenderThread.resume()
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     // we always do extra render call on resume
     verify(exactly = 4) {
@@ -389,7 +389,7 @@ class MapboxRenderThreadTest {
     mapboxRenderThread.awaitingNextVsync = false
     pauseHandler()
     // schedule render request
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     assert(mapboxRenderThread.nonRenderEventQueue.isEmpty())
     // one swap buffer from surface creation + one for render request
@@ -460,10 +460,10 @@ class MapboxRenderThreadTest {
     mapboxRenderThread.fpsChangedListener = listener
     provideValidSurface()
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     verify(exactly = 2) {
       listener.onFpsChanged(any())
@@ -517,7 +517,7 @@ class MapboxRenderThreadTest {
     provideValidSurface()
     mapboxRenderThread.onSurfaceDestroyed()
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     verifyNo {
       // we do not destroy native renderer if it's stop and not destroy
@@ -534,7 +534,7 @@ class MapboxRenderThreadTest {
     provideValidSurface()
     mapboxRenderThread.onSurfaceDestroyed()
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
 
     verifyOnce {
@@ -552,7 +552,7 @@ class MapboxRenderThreadTest {
     provideValidSurface()
     mapboxRenderThread.setMaximumFps(15)
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     // 1 swap when creating surface + 1 for request render call
     verify(exactly = 2) {
@@ -567,9 +567,9 @@ class MapboxRenderThreadTest {
     every { mapboxWidgetRenderer.needTextureUpdate } returns false
     every { mapboxWidgetRenderer.getTexture() } returns 0
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     verifyNo {
       mapboxWidgetRenderer.updateTexture()
@@ -587,9 +587,9 @@ class MapboxRenderThreadTest {
     every { mapboxWidgetRenderer.hasTexture() } returns true
     every { mapboxWidgetRenderer.getTexture() } returns textureId
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     verify(exactly = 2) {
       mapboxWidgetRenderer.updateTexture()
@@ -607,7 +607,7 @@ class MapboxRenderThreadTest {
     every { mapboxWidgetRenderer.hasTexture() } returns true
     every { mapboxWidgetRenderer.getTexture() } returns textureId
     pauseHandler()
-    mapboxRenderThread.queueRenderEvent(MapboxRenderer.renderEventSdk)
+    mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
     verifyOrder {
       mapboxWidgetRenderer.updateTexture()

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -29,6 +29,8 @@ internal abstract class MapboxRendererTest {
     renderThread = mockk(relaxUnitFun = true)
     mockkStatic("com.mapbox.maps.MapboxLogger")
     every { logE(any(), any()) } just Runs
+    every { logI(any(), any()) } just Runs
+    every { logW(any(), any()) } just Runs
   }
 
   @After
@@ -51,7 +53,7 @@ internal abstract class MapboxRendererTest {
         RenderEvent(
           null,
           true,
-          EventType.SDK
+          EventType.DEFAULT
         )
       )
     }
@@ -67,7 +69,7 @@ internal abstract class MapboxRendererTest {
       renderThread.queueRenderEvent(capture(event))
     }
     assert(!event.captured.needRender)
-    assert(event.captured.eventType == EventType.SDK)
+    assert(event.captured.eventType == EventType.DEFAULT)
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -104,7 +104,7 @@ internal abstract class MapboxRendererTest {
   @Test
   fun queueEventTest() {
     val event = mockk<Runnable>(relaxUnitFun = true)
-    mapboxRenderer.queueEvent(event)
+    mapboxRenderer.queueNonRenderEvent(event)
     verify {
       renderThread.queueRenderEvent(
         RenderEvent(

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -110,7 +110,7 @@ internal abstract class MapboxRendererTest {
         RenderEvent(
           event,
           false,
-          EventType.OTHER
+          EventType.DEFAULT
         )
       )
     }
@@ -125,7 +125,7 @@ internal abstract class MapboxRendererTest {
         RenderEvent(
           event,
           true,
-          EventType.OTHER
+          EventType.DEFAULT
         )
       )
     }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/RenderHandlerThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/RenderHandlerThreadTest.kt
@@ -51,7 +51,7 @@ class RenderHandlerThreadTest {
     renderHandlerThread.start()
     val handler = mockk<Handler>(relaxed = true)
     renderHandlerThread.handler = handler
-    renderHandlerThread.clearMessageQueue()
+    renderHandlerThread.clearDefaultMessages()
     verify { renderHandlerThread.handler?.removeCallbacksAndMessages(null) }
   }
 
@@ -60,7 +60,7 @@ class RenderHandlerThreadTest {
     renderHandlerThread.start()
     val handler = mockk<Handler>(relaxed = true)
     renderHandlerThread.handler = handler
-    renderHandlerThread.clearMessageQueue(false)
+    renderHandlerThread.clearDefaultMessages()
     verify { renderHandlerThread.handler?.removeCallbacksAndMessages(EventType.SDK) }
   }
 

--- a/sdk/src/test/java/com/mapbox/maps/renderer/RenderHandlerThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/RenderHandlerThreadTest.kt
@@ -43,7 +43,6 @@ class RenderHandlerThreadTest {
     renderHandlerThread.start()
     renderHandlerThread.stop()
     assert(renderHandlerThread.handler == null)
-    assert(!renderHandlerThread.handlerThread.isAlive)
   }
 
   @Test
@@ -61,6 +60,22 @@ class RenderHandlerThreadTest {
     renderHandlerThread.post { action() }
     Shadows.shadowOf(Looper.getMainLooper()).idle()
     verifyNo { action.invoke() }
+  }
+
+  @Test
+  fun postThreadStopped() {
+    val actionOne = mockk<() -> Unit>(relaxed = true)
+    val actionTwo = mockk<() -> Unit>(relaxed = true)
+    Shadows.shadowOf(Looper.getMainLooper()).pause()
+    renderHandlerThread.apply {
+      start()
+      post { actionOne() }
+      stop()
+      post { actionTwo() }
+    }
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    verify { actionOne.invoke() }
+    verifyNo { actionTwo.invoke() }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/renderer/RenderHandlerThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/RenderHandlerThreadTest.kt
@@ -1,8 +1,8 @@
 package com.mapbox.maps.renderer
 
-import android.os.Handler
 import android.os.Looper
 import com.mapbox.maps.logW
+import com.mapbox.verifyNo
 import io.mockk.*
 import org.junit.After
 import org.junit.Before
@@ -47,21 +47,11 @@ class RenderHandlerThreadTest {
   }
 
   @Test
-  fun clearMessageQueueAllTest() {
+  fun clearDefaultMessagesTest() {
     renderHandlerThread.start()
-    val handler = mockk<Handler>(relaxed = true)
-    renderHandlerThread.handler = handler
+    renderHandlerThread.handler = mockk(relaxed = true)
     renderHandlerThread.clearDefaultMessages()
-    verify { renderHandlerThread.handler?.removeCallbacksAndMessages(null) }
-  }
-
-  @Test
-  fun clearMessageQueueSDKTest() {
-    renderHandlerThread.start()
-    val handler = mockk<Handler>(relaxed = true)
-    renderHandlerThread.handler = handler
-    renderHandlerThread.clearDefaultMessages()
-    verify { renderHandlerThread.handler?.removeCallbacksAndMessages(EventType.SDK) }
+    verify { renderHandlerThread.handler?.removeCallbacksAndMessages(EventType.DEFAULT) }
   }
 
   @Test
@@ -70,7 +60,7 @@ class RenderHandlerThreadTest {
     Shadows.shadowOf(Looper.getMainLooper()).pause()
     renderHandlerThread.post { action() }
     Shadows.shadowOf(Looper.getMainLooper()).idle()
-    verify(exactly = 0) { action.invoke() }
+    verifyNo { action.invoke() }
   }
 
   @Test
@@ -84,7 +74,7 @@ class RenderHandlerThreadTest {
       post { actionTwo() }
     }
     Shadows.shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(50))
-    verify(exactly = 1) { actionOne.invoke() }
-    verify(exactly = 1) { actionTwo.invoke() }
+    verify { actionOne.invoke() }
+    verify { actionTwo.invoke() }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/RenderHandlerThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/RenderHandlerThreadTest.kt
@@ -66,16 +66,29 @@ class RenderHandlerThreadTest {
   fun postThreadStopped() {
     val actionOne = mockk<() -> Unit>(relaxed = true)
     val actionTwo = mockk<() -> Unit>(relaxed = true)
+    val actionThree = mockk<() -> Unit>(relaxed = true)
+    val actionFour = mockk<() -> Unit>(relaxed = true)
     Shadows.shadowOf(Looper.getMainLooper()).pause()
     renderHandlerThread.apply {
       start()
-      post { actionOne() }
+      post(actionOne)
+      postDelayed(
+        actionTwo,
+        50
+      )
+      Shadows.shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(50))
       stop()
-      post { actionTwo() }
+      post(actionThree)
+      postDelayed(
+        actionFour,
+        50
+      )
     }
-    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    Shadows.shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(50))
     verify { actionOne.invoke() }
-    verifyNo { actionTwo.invoke() }
+    verify { actionTwo.invoke() }
+    verifyNo { actionThree.invoke() }
+    verifyNo { actionFour.invoke() }
   }
 
   @Test
@@ -85,8 +98,8 @@ class RenderHandlerThreadTest {
     Shadows.shadowOf(Looper.getMainLooper()).pause()
     renderHandlerThread.apply {
       start()
-      post { actionOne() }
-      post { actionTwo() }
+      post(actionOne)
+      postDelayed(actionTwo, 50)
     }
     Shadows.shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(50))
     verify { actionOne.invoke() }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Previously we were ignoring tasks scheduled from gl-native if there was no EGL / render was not prepared fully, as well as clearing the queues with tasks when new surface arrives. 
Hence, various async tasks scheduled from gl-native could be just silently removed from the queue when new surface arrives (e.g. if activity was paused and then resumed). 
For example such behaviour caused 3d puck (and other models loaded async, potentially) not being loaded. 

With this change we will reschedule all the tasks indefinitely (with 50 millis delay), until with render thread is not fully destroyed (together with gl-native's renderer).

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
