### PR TITLE
Fix using arrays inside match expression dsl - MAPSAND-226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Bug fixes 🐞
 * Fix lifecycle edge cases not being handled properly by introducing internal `ViewLifecycleOwner` to have granular control over MapView's lifecycle. ([1330](https://github.com/mapbox/mapbox-maps-android/pull/1330))
+* Fix an issue when `literal` array expression is used as output inside the `match` expression. ([1444](https://github.com/mapbox/mapbox-maps-android/pull/1444))
 
 # 10.6.0 - June 16, 2022
 [Changes](https://github.com/mapbox/mapbox-maps-android/compare/android-v10.5.0...android-v10.6.0) since [Mapbox Maps SDK for Android 10.5.0](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.5.0)

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/expressions/ExpressionTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/expressions/ExpressionTest.kt
@@ -1179,8 +1179,7 @@ class ExpressionTest : BaseStyleTest() {
    * Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `["get", "building_type"]`). Each label must be either:
    * a single literal value; or
    * an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `["c", "b"]`). The input matches if any of the values in the array matches, similar to the deprecated `"in"` operator.
-
-   Each label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.
+   * Each label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.
    */
   @Test
   @UiThreadTest
@@ -1206,8 +1205,7 @@ class ExpressionTest : BaseStyleTest() {
    * Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `["get", "building_type"]`). Each label must be either:
    * a single literal value; or
    * an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `["c", "b"]`). The input matches if any of the values in the array matches, similar to the deprecated `"in"` operator.
-
-   Each label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.
+   * Each label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.
    */
   @Test
   @UiThreadTest
@@ -1227,6 +1225,37 @@ class ExpressionTest : BaseStyleTest() {
     }
     setupLayer(layer)
     assertEquals(expression.toJson(), layer.textColorAsExpression?.toJson())
+  }
+
+  /**
+   * Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `["get", "building_type"]`). Each label must be either:
+   * a single literal value; or
+   * an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `["c", "b"]`). The input matches if any of the values in the array matches, similar to the deprecated `"in"` operator.
+   * Each label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.
+   */
+  @Test
+  @UiThreadTest
+  fun matchWithOutputListTest() {
+    val expression = match {
+      mod {
+        number {
+          id()
+        }
+        literal(4.0)
+      }
+      literal(0)
+      literal(listOf(0.0, 0.0, 0.0))
+      literal(1)
+      literal(listOf(0.0, 0.0, 20.0))
+      literal(2)
+      literal(listOf(3.0, 0.0, 40.0))
+      literal(listOf(-3.0, 0.0, 60.0))
+    }
+    val layer = modelLayer("id", "source") {
+      modelRotation(expression)
+    }
+    setupLayer(layer)
+    assertEquals(expression.toJson(), layer.modelRotationAsExpression?.toJson())
   }
 
   /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
@@ -13,6 +13,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import com.mapbox.maps.extension.style.utils.take
 import com.mapbox.maps.extension.style.utils.unwrapFromLiteralArray
+import com.mapbox.maps.extension.style.utils.unwrapToExpression
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
@@ -131,15 +131,17 @@ class Expression : Value {
     open fun build(): Expression {
       if (this.operator == "match") {
         val newBuilder = ExpressionBuilder("match")
-        this.arguments.forEachIndexed { i, e ->
+        val lastIndex = this.arguments.size - 1
+        this.arguments.forEachIndexed { index, argument ->
           newBuilder.addArgument(
             // https://github.com/mapbox/mapbox-maps-android/issues/965
             // the match expression is an exception and it takes raw list instead of a list wrapped into
-            // literal expression when literal array is used as the label.
-            if (i % 2 == 1 && i != this.arguments.size - 1) {
-              e.unwrapFromLiteralArray()
+            // literal expression when literal array is used as the label, the last member of the arguments
+            // will be the default output should shouldn't be unwrapped.
+            if (index % 2 == 1 && index != lastIndex) {
+              argument.unwrapFromLiteralArray()
             } else {
-              e
+              argument
             }
           )
         }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
@@ -9,9 +9,10 @@ import com.mapbox.geojson.Geometry
 import com.mapbox.maps.MapboxStyleException
 import com.mapbox.maps.extension.style.expressions.types.FormatSection
 import com.mapbox.maps.extension.style.types.ExpressionDsl
-import com.mapbox.maps.extension.style.utils.*
+import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.extension.style.utils.TypeUtils
 import com.mapbox.maps.extension.style.utils.take
+import com.mapbox.maps.extension.style.utils.unwrapFromLiteralArray
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/utils/TypeUtils.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/utils/TypeUtils.kt
@@ -186,6 +186,29 @@ fun Value.unwrapToStyleTransition(): StyleTransition {
 }
 
 /**
+ * Unwraps an literal array to a array.
+ *
+ * e.g. translate ["literal", [0.0, 0.0, 0.0]] to [0.0, 0.0, 0.0].
+ */
+internal fun Expression.unwrapFromLiteralArray(): Expression {
+  if (this.contents is List<*>) {
+    @Suppress("UNCHECKED_CAST")
+    val listValue = this.contents as List<Value>
+    val operator = listValue.first().contents as? String
+    if ("literal" == operator) {
+      when (val literalValue = listValue.last().contents) {
+        is List<*> -> {
+          @Suppress("UNCHECKED_CAST")
+          val literalList = literalValue as List<Value>
+          return Expression(literalList)
+        }
+      }
+    }
+  }
+  return this
+}
+
+/**
  * Extension function for [Value] to unwrap Value to [Expression].
  *
  * Throws exception if couldn't convert.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/utils/TypeUtils.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/utils/TypeUtils.kt
@@ -194,8 +194,8 @@ internal fun Expression.unwrapFromLiteralArray(): Expression {
   if (this.contents is List<*>) {
     @Suppress("UNCHECKED_CAST")
     val listValue = this.contents as List<Value>
-    val operator = listValue.first().contents as? String
-    if ("literal" == operator) {
+    val expressionOperator = listValue.first().contents as? String
+    if ("literal" == expressionOperator) {
       when (val literalValue = listValue.last().contents) {
         is List<*> -> {
           @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

This PR fixes an issue when literal array is used as output inside the match expression, for example:
```
modelRotation(
    match {
        mod {
            id()
            literal(4)
        }
        literal(0)
        literal(listOf(0.0, 0.0, 0.0))
        literal(1)
        literal(listOf(0.0, 0.0, 20.0))
        literal(2)
        literal(listOf(3.0, 0.0, 40.0))
        literal(listOf(-3.0, 0.0, 60.0))
    }
)
```
will fail with error: 
```
com.mapbox.maps.MapboxStyleException: Add layer failed: Failed to set `model-rotation` property for `model-layer-id` layer. Error: [3][0]: Expression name must be a string, but found number instead. If you wanted a literal array, use [“literal”, [...]].
```

This issue is related to the fix we made previously to fix the arrays used as labels within the match expression #965. We had some issues with `match` expression when the label is a list, because `literal` shouldn’t be added to the array when it’s used to represent a `label` inside a match expression. With the fix in https://github.com/mapbox/mapbox-maps-android/pull/1204, we removed `literal` from all the arrays inside `match` expression, but as a side effect, the fix also removed the `literal` when the array is used as output of the match expression, which is incorrect.

To fix the root issue, we need to only remove `literal` from the array when used in the `label` section and keep the `literal` from the array when used in the `output` section of the `match` expression.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
