### PR TITLE
Update robo test devices MAPSAND-268

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,12 +327,13 @@ commands:
           command: |
             if [[ -n "${GCLOUD_SERVICE_ACCOUNT_JSON}" ]]; then
               gcloud firebase test android models list
+              ### We use following devices to run robo tests:
+              ### * 1 old API (the lower the better)
+              ### * 1 new API (the higher the better)
+              ### * 1 x86-64 emulator (validation of the ABI we "never" use) - Pixel3
               gcloud firebase test android run --type robo \
                 --app app/build/outputs/apk/release/app-release.apk \
-                ### Minimum SDK level the Maps SDK support
                 --device model=hwALE-H,version=21,locale=en,orientation=portrait \
-                --device model=harpia,version=23,locale=en,orientation=portrait \
-                ### Virtual device running at API level 30
                 --device model=Pixel3,version=30,locale=en,orientation=portrait \
                 --device model=oriole,version=31,locale=en,orientation=portrait \
                 --timeout 90s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,7 @@ commands:
           no_output_timeout: 10m
           command: |
             if [[ -n "${GCLOUD_SERVICE_ACCOUNT_JSON}" ]]; then
+              gcloud firebase test android models list
               gcloud firebase test android run --type robo \
                 --app app/build/outputs/apk/release/app-release.apk \
                 --device model=harpia,version=23,locale=en,orientation=portrait \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ commands:
                 --app app/build/outputs/apk/release/app-release.apk \
                 --device model=harpia,version=23,locale=en,orientation=portrait \
                 --device model=blueline,version=28,locale=en,orientation=portrait \
-                --device model=Pixel2,version=30,locale=en,orientation=portrait \
+                --device model=Pixel3,version=30,locale=en,orientation=portrait \
                 --device model=G8142,version=25,locale=en,orientation=portrait \
                 --timeout 90s
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,8 @@ commands:
               gcloud firebase test android models list
               gcloud firebase test android run --type robo \
                 --app app/build/outputs/apk/release/app-release.apk \
+                ### Minimum SDK level the Maps SDK support
+                --device model=hwALE-H,version=21,locale=en,orientation=portrait \
                 --device model=harpia,version=23,locale=en,orientation=portrait \
                 ### Virtual device running at API level 30
                 --device model=Pixel3,version=30,locale=en,orientation=portrait \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,6 +330,7 @@ commands:
               gcloud firebase test android run --type robo \
                 --app app/build/outputs/apk/release/app-release.apk \
                 --device model=harpia,version=23,locale=en,orientation=portrait \
+                ### Virtual device running at API level 30
                 --device model=Pixel3,version=30,locale=en,orientation=portrait \
                 --device model=oriole,version=31,locale=en,orientation=portrait \
                 --timeout 90s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,10 +330,12 @@ commands:
               ### We use following devices to run robo tests:
               ### * 1 old API (the lower the better)
               ### * 1 new API (the higher the better)
-              ### * 1 x86-64 emulator (validation of the ABI we "never" use) - Pixel3
+              ### * 1 x86-64 emulator(Pixel3)
+              ### * API level 23 which is known to work weird sometimes
               gcloud firebase test android run --type robo \
                 --app app/build/outputs/apk/release/app-release.apk \
                 --device model=hwALE-H,version=21,locale=en,orientation=portrait \
+                --device model=harpia,version=23,locale=en,orientation=portrait \
                 --device model=Pixel3,version=30,locale=en,orientation=portrait \
                 --device model=oriole,version=31,locale=en,orientation=portrait \
                 --timeout 90s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,13 +330,13 @@ commands:
               ### We use following devices to run robo tests:
               ### * 1 old API (the lower the better)
               ### * 1 new API (the higher the better)
-              ### * 1 x86-64 emulator(Pixel3)
+              ### * 1 x86-64 emulator(Pixel2)
               ### * API level 23 which is known to work weird sometimes
               gcloud firebase test android run --type robo \
                 --app app/build/outputs/apk/release/app-release.apk \
                 --device model=hwALE-H,version=21,locale=en,orientation=portrait \
                 --device model=harpia,version=23,locale=en,orientation=portrait \
-                --device model=Pixel3,version=30,locale=en,orientation=portrait \
+                --device model=Pixel2,version=29,locale=en,orientation=portrait \
                 --device model=oriole,version=31,locale=en,orientation=portrait \
                 --timeout 90s
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,6 +332,7 @@ commands:
                 --device model=blueline,version=28,locale=en,orientation=portrait \
                 --device model=Pixel3,version=30,locale=en,orientation=portrait \
                 --device model=G8142,version=25,locale=en,orientation=portrait \
+                --device model=oriole,version=31,locale=en,orientation=portrait \
                 --timeout 90s
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,9 +330,7 @@ commands:
               gcloud firebase test android run --type robo \
                 --app app/build/outputs/apk/release/app-release.apk \
                 --device model=harpia,version=23,locale=en,orientation=portrait \
-                --device model=blueline,version=28,locale=en,orientation=portrait \
                 --device model=Pixel3,version=30,locale=en,orientation=portrait \
-                --device model=G8142,version=25,locale=en,orientation=portrait \
                 --device model=oriole,version=31,locale=en,orientation=portrait \
                 --timeout 90s
             fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Change robo test device from virtual Pixel2 to Pixel3 and added Pixel 6 running at API level 31.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
