### PR TITLE
Fix setting max fps and fps count for renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Bump gl-native to v10.8.0-beta.1, common to v23.0.0-beta.1. ([1568](https://gith
   Also bumps [WorkManager 2.7.1](https://developer.android.com/jetpack/androidx/releases/work#2.7.1) that enforces compileSdk 31 or newer.
 * Bump gl-native to v10.7.0, common to 22.1.0. ([1543](https://github.com/mapbox/mapbox-maps-android/pull/1543))
 * Fix default viewport bearing transition doesn't follow shortest path. ([1541](https://github.com/mapbox/mapbox-maps-android/pull/1541))
+* Fix `OnFpsChangedListener` listener to count number of frames rendered over the last second instead of immediate time for render call. ([1477](https://github.com/mapbox/mapbox-maps-android/pull/1477))
+* Fix `MapView.setMaximumFps` method to apply exact FPS value for rendering the map. ([1477](https://github.com/mapbox/mapbox-maps-android/pull/1477))
 
 # 10.7.0-rc.1 July 14, 2022
 ## Features ✨ and improvements 🏁

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/DebugModeActivity.kt
@@ -168,7 +168,7 @@ class DebugModeActivity : AppCompatActivity() {
     super.onStart()
     binding.mapView.setOnFpsChangedListener {
       runOnUiThread {
-        binding.fpsView.text = getString(R.string.fps, it.toInt().toString())
+        binding.fpsView.text = getString(R.string.fps, String.format("%.2f", it))
       }
     }
   }

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -207,9 +207,6 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   }
 
   override fun setMaximumFps(fps: Int) {
-    if (fps <= 0) {
-      return
-    }
     renderer.setMaximumFps(fps)
   }
 
@@ -233,6 +230,18 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     renderer.renderThread.renderHandlerThread.post {
       renderer.renderThread.eglCore.removeRendererStateListener(rendererSetupErrorListener)
     }
+  }
+
+  internal fun setScreenRefreshRate(refreshRate: Int) {
+    if (refreshRate <= 0 || refreshRate >= MapView.MAX_POSSIBLE_FPS) {
+      logE(
+        TAG,
+        "Screen refresh rate could not be <= 0 or >= ${MapView.MAX_POSSIBLE_FPS}! " +
+          "Setting max fps and fps counter will not work properly."
+      )
+      return
+    }
+    renderer.renderThread.setScreenRefreshRate(refreshRate)
   }
 
   //

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -233,10 +233,10 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   }
 
   internal fun setScreenRefreshRate(refreshRate: Int) {
-    if (refreshRate <= 0 || refreshRate >= MapView.MAX_POSSIBLE_FPS) {
+    if (refreshRate <= 0) {
       logE(
         TAG,
-        "Screen refresh rate could not be <= 0 or >= ${MapView.MAX_POSSIBLE_FPS}! " +
+        "Screen refresh rate could not be <= 0! " +
           "Setting max fps and fps counter will not work properly."
       )
       return

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -11,6 +11,7 @@ import com.mapbox.maps.renderer.MapboxSurfaceRenderer
 import com.mapbox.maps.renderer.OnFpsChangedListener
 import com.mapbox.maps.renderer.RendererSetupErrorListener
 import com.mapbox.maps.renderer.widget.Widget
+import java.lang.ref.WeakReference
 
 /**
  * A [MapSurface] provides an embeddable map interface.
@@ -29,13 +30,14 @@ import com.mapbox.maps.renderer.widget.Widget
  * @param mapInitOptions the init options to for map
  */
 class MapSurface @JvmOverloads constructor(
-  private val context: Context,
+  context: Context,
   val surface: Surface,
   mapInitOptions: MapInitOptions = MapInitOptions(context)
 ) : MapPluginProviderDelegate, MapControllable {
 
   private val mapController: MapController
   private val renderer: MapboxSurfaceRenderer = MapboxSurfaceRenderer(mapInitOptions.antialiasingSampleCount)
+  private val weakContext = WeakReference(context)
 
   init {
     this.mapController = MapController(
@@ -51,7 +53,7 @@ class MapSurface @JvmOverloads constructor(
   fun surfaceCreated() {
     renderer.surfaceCreated()
     // display should not be null at this point but to be sure we will fallback to DEFAULT_FPS
-    val screenRefreshRate = (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
+    val screenRefreshRate = (weakContext.get()?.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
       .defaultDisplay?.refreshRate?.toInt() ?: MapView.DEFAULT_FPS
     mapController.setScreenRefreshRate(screenRefreshRate)
   }

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.view.MotionEvent
 import android.view.Surface
+import android.view.WindowManager
 import com.mapbox.maps.plugin.MapPlugin
 import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
 import com.mapbox.maps.renderer.MapboxSurfaceRenderer
@@ -28,7 +29,7 @@ import com.mapbox.maps.renderer.widget.Widget
  * @param mapInitOptions the init options to for map
  */
 class MapSurface @JvmOverloads constructor(
-  context: Context,
+  private val context: Context,
   val surface: Surface,
   mapInitOptions: MapInitOptions = MapInitOptions(context)
 ) : MapPluginProviderDelegate, MapControllable {
@@ -49,6 +50,11 @@ class MapSurface @JvmOverloads constructor(
    */
   fun surfaceCreated() {
     renderer.surfaceCreated()
+    mapController.setScreenRefreshRate(
+      (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
+        .defaultDisplay
+        .refreshRate.toInt()
+    )
   }
 
   /**
@@ -139,9 +145,6 @@ class MapSurface @JvmOverloads constructor(
    * @param fps The maximum fps
    */
   override fun setMaximumFps(fps: Int) {
-    if (fps <= 0) {
-      return
-    }
     renderer.setMaximumFps(fps)
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -11,7 +11,6 @@ import com.mapbox.maps.renderer.MapboxSurfaceRenderer
 import com.mapbox.maps.renderer.OnFpsChangedListener
 import com.mapbox.maps.renderer.RendererSetupErrorListener
 import com.mapbox.maps.renderer.widget.Widget
-import java.lang.ref.WeakReference
 
 /**
  * A [MapSurface] provides an embeddable map interface.
@@ -30,14 +29,14 @@ import java.lang.ref.WeakReference
  * @param mapInitOptions the init options to for map
  */
 class MapSurface @JvmOverloads constructor(
-  context: Context,
+  // could use strong ref here as MapInitOptions have strong ref in any case
+  private val context: Context,
   val surface: Surface,
   mapInitOptions: MapInitOptions = MapInitOptions(context)
 ) : MapPluginProviderDelegate, MapControllable {
 
   private val mapController: MapController
   private val renderer: MapboxSurfaceRenderer = MapboxSurfaceRenderer(mapInitOptions.antialiasingSampleCount)
-  private val weakContext = WeakReference(context)
 
   init {
     this.mapController = MapController(
@@ -53,7 +52,7 @@ class MapSurface @JvmOverloads constructor(
   fun surfaceCreated() {
     renderer.surfaceCreated()
     // display should not be null at this point but to be sure we will fallback to DEFAULT_FPS
-    val screenRefreshRate = (weakContext.get()?.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
+    val screenRefreshRate = (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
       .defaultDisplay?.refreshRate?.toInt() ?: MapView.DEFAULT_FPS
     mapController.setScreenRefreshRate(screenRefreshRate)
   }

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -50,11 +50,10 @@ class MapSurface @JvmOverloads constructor(
    */
   fun surfaceCreated() {
     renderer.surfaceCreated()
-    mapController.setScreenRefreshRate(
-      (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
-        .defaultDisplay
-        .refreshRate.toInt()
-    )
+    // display should not be null at this point but to be sure we will fallback to DEFAULT_FPS
+    val screenRefreshRate = (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
+      .defaultDisplay?.refreshRate?.toInt() ?: MapView.DEFAULT_FPS
+    mapController.setScreenRefreshRate(screenRefreshRate)
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -264,7 +264,8 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   /**
    * Set new maximum FPS for map rendering.
    *
-   * @param fps new maximum FPS value that must be > 0 and less than [MAX_POSSIBLE_FPS].
+   * @param fps new maximum FPS value that must be > 0 and less than 1000.
+   * When setting this value higher than screen physically supports - max possible screen FPS rate will be used.
    */
   override fun setMaximumFps(@IntRange(from = 1L, to = MAX_POSSIBLE_FPS) fps: Int) {
     mapController.setMaximumFps(fps)
@@ -366,6 +367,11 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   companion object {
     internal const val DEFAULT_ANTIALIASING_SAMPLE_COUNT = 1
     internal const val MAX_POSSIBLE_FPS = 1000L
+
+    /**
+     * Fallback to this value if, for some reason, Android display is NULL.
+     * This will not affect rendering on displays with higher frame rate if [MapView.setMaximumFps] was not called.
+     */
     internal const val DEFAULT_FPS = 60
     /**
      * Static method to check if [MapView] could properly render on this device.

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -113,6 +113,7 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     mapController.onAttachedToWindow(this)
+    mapController.setScreenRefreshRate(display.refreshRate.toInt())
   }
 
   @SuppressLint("CustomViewStyleable")
@@ -261,10 +262,10 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   /**
    * Set new maximum FPS for map rendering.
    *
-   * @param maximumFps new maximum FPS value that must be > 0.
+   * @param fps new maximum FPS value that must be > 0 and less than [MAX_POSSIBLE_FPS].
    */
-  override fun setMaximumFps(@IntRange(from = 1L, to = Int.MAX_VALUE.toLong()) maximumFps: Int) {
-    mapController.setMaximumFps(maximumFps)
+  override fun setMaximumFps(@IntRange(from = 1L, to = MAX_POSSIBLE_FPS) fps: Int) {
+    mapController.setMaximumFps(fps)
   }
 
   /**
@@ -362,6 +363,7 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
    */
   companion object {
     internal const val DEFAULT_ANTIALIASING_SAMPLE_COUNT = 1
+    internal const val MAX_POSSIBLE_FPS = 1000L
     /**
      * Static method to check if [MapView] could properly render on this device.
      * This method may take some time on slow devices.

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -113,7 +113,6 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     mapController.onAttachedToWindow(this)
-    mapController.setScreenRefreshRate(display.refreshRate.toInt())
   }
 
   @SuppressLint("CustomViewStyleable")
@@ -186,6 +185,9 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
    * @see android.app.Fragment.onStart
    */
   override fun onStart() {
+    // display should not be null at this point but to be sure we will fallback to DEFAULT_FPS
+    val screenRefreshRate = display?.refreshRate?.toInt() ?: DEFAULT_FPS
+    mapController.setScreenRefreshRate(screenRefreshRate)
     mapController.onStart()
   }
 
@@ -364,6 +366,7 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   companion object {
     internal const val DEFAULT_ANTIALIASING_SAMPLE_COUNT = 1
     internal const val MAX_POSSIBLE_FPS = 1000L
+    internal const val DEFAULT_FPS = 60
     /**
      * Static method to check if [MapView] could properly render on this device.
      * This method may take some time on slow devices.

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -264,10 +264,10 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
   /**
    * Set new maximum FPS for map rendering.
    *
-   * @param fps new maximum FPS value that must be > 0 and less than 1000.
+   * @param fps new maximum FPS value that must be > 0 and less than max integer.
    * When setting this value higher than screen physically supports - max possible screen FPS rate will be used.
    */
-  override fun setMaximumFps(@IntRange(from = 1L, to = MAX_POSSIBLE_FPS) fps: Int) {
+  override fun setMaximumFps(@IntRange(from = 1, to = Int.MAX_VALUE.toLong()) fps: Int) {
     mapController.setMaximumFps(fps)
   }
 
@@ -366,7 +366,6 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
    */
   companion object {
     internal const val DEFAULT_ANTIALIASING_SAMPLE_COUNT = 1
-    internal const val MAX_POSSIBLE_FPS = 1000L
 
     /**
      * Fallback to this value if, for some reason, Android display is NULL.

--- a/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
@@ -179,15 +179,22 @@ internal class FpsManager(
     fpsChangedListener?.let { listener ->
       val droppedFps = choreographerSkips.toDouble() / choreographerTicks
       val fps = (1.0 - droppedFps) * screenRefreshRate
-      val averageRenderTimeNs = frameRenderTimeAccumulatedNs.toDouble() / (choreographerTicks - choreographerSkips)
       listener.onFpsChanged(fps)
-      logI(
-        TAG,
-        "VSYNC based FPS is $fps," +
-          " average core rendering time is ${averageRenderTimeNs / ONE_MILLISECOND_NS} ms" +
-          " (or ${String.format("%.2f", screenRefreshPeriodNs / averageRenderTimeNs * screenRefreshRate)} FPS)," +
-          " missed $choreographerSkips out of $choreographerTicks VSYNC pulses"
-      )
+      if (choreographerTicks == choreographerSkips) {
+        logI(
+          TAG,
+          "VSYNC based FPS is $fps, missed $choreographerSkips out of $choreographerTicks VSYNC pulses"
+        )
+      } else {
+        val averageRenderTimeNs = frameRenderTimeAccumulatedNs.toDouble() / (choreographerTicks - choreographerSkips)
+        logI(
+          TAG,
+          "VSYNC based FPS is $fps," +
+            " average core rendering time is ${averageRenderTimeNs / ONE_MILLISECOND_NS} ms" +
+            " (or ${String.format("%.2f", screenRefreshPeriodNs / averageRenderTimeNs * screenRefreshRate)} FPS)," +
+            " missed $choreographerSkips out of $choreographerTicks VSYNC pulses"
+        )
+      }
     }
     previousDrawnFrameIndex = 0
     frameRenderTimeAccumulatedNs = 0L

--- a/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
@@ -33,7 +33,7 @@ internal class FpsManager(
     this.screenRefreshRate = screenRefreshRate
     screenRefreshPeriodNs = ONE_SECOND_NS / screenRefreshRate
     if (userRefreshRate != USER_DEFINED_REFRESH_RATE_NOT_SET) {
-      userToScreenRefreshRateRatio = userRefreshRate.toDouble() / screenRefreshRate
+      userToScreenRefreshRateRatio = (userRefreshRate.toDouble() / screenRefreshRate).coerceIn(0.0, 1.0)
       logI(TAG, "User defined ratio is $userToScreenRefreshRateRatio")
     }
     if (LOG_STATISTICS) {
@@ -50,7 +50,7 @@ internal class FpsManager(
       userRefreshRate = refreshRate
       logI(TAG, "User set max FPS to $userRefreshRate")
       if (screenRefreshRate != SCREEN_METRICS_NOT_DEFINED) {
-        userToScreenRefreshRateRatio = userRefreshRate.toDouble() / screenRefreshRate
+        userToScreenRefreshRateRatio = (userRefreshRate.toDouble() / screenRefreshRate).coerceIn(0.0, 1.0)
         logI(TAG, "User defined ratio is $userToScreenRefreshRateRatio")
       }
     }
@@ -87,7 +87,7 @@ internal class FpsManager(
       // otherwise when updating the map after it was IDLE first update will report
       // huge delta between new frame and last frame (as we're using dirty rendering)
       handler.postDelayed(
-        VSYNC_COUNT_TILL_IDLE * (screenRefreshPeriodNs / 10.0.pow(6.0)).toLong(),
+        VSYNC_COUNT_TILL_IDLE * (screenRefreshPeriodNs / ONE_MILLISECOND_NS),
         fpsManagerToken
       ) {
         onRenderingPaused()
@@ -184,7 +184,7 @@ internal class FpsManager(
       logI(
         TAG,
         "VSYNC based FPS is $fps," +
-          " average core rendering time is ${averageRenderTimeNs / 10.0.pow(6.0)} ms" +
+          " average core rendering time is ${averageRenderTimeNs / ONE_MILLISECOND_NS} ms" +
           " (or ${String.format("%.2f", screenRefreshPeriodNs / averageRenderTimeNs * screenRefreshRate)} FPS)," +
           " missed $choreographerSkips out of $choreographerTicks VSYNC pulses"
       )

--- a/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
@@ -1,6 +1,8 @@
 package com.mapbox.maps.renderer
 
 import android.os.Handler
+import android.os.Looper
+import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import androidx.core.os.postDelayed
 import com.mapbox.maps.logI
@@ -8,9 +10,8 @@ import com.mapbox.maps.logW
 import kotlin.math.pow
 
 @WorkerThread
-internal class FpsManager(
+internal class FpsManager {
   private val handler: Handler
-) {
   private var userRefreshRate = USER_DEFINED_REFRESH_RATE_NOT_SET
   private var userToScreenRefreshRateRatio = USER_TO_SCREEN_REFRESH_RATIO_NOT_SET
 
@@ -25,6 +26,15 @@ internal class FpsManager(
   private var choreographerSkips = 0
 
   internal var fpsChangedListener: OnFpsChangedListener? = null
+
+  constructor(handler: Handler) {
+    this.handler = handler
+  }
+
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  constructor() {
+    this.handler = Handler(Looper.getMainLooper())
+  }
 
   fun setScreenRefreshRate(screenRefreshRate: Int) {
     if (this.screenRefreshRate == screenRefreshRate) {
@@ -77,28 +87,24 @@ internal class FpsManager(
   }
 
   fun postRender() {
-    fpsChangedListener?.let { listener ->
-      val frameRenderTimeNs = System.nanoTime() - preRenderTimeNs
-      frameRenderTimeAccumulatedNs += frameRenderTimeNs
-      // normally we update FPS counter once a second
-      if (choreographerTicks >= screenRefreshRate) {
-        calculateFps(listener)
-      } else {
-        // however to produce correct values we also update FPS after IDLE_TIMEOUT_MS
-        // otherwise when updating the map after it was IDLE first update will report
-        // huge delta between new frame and last frame (as we're using dirty rendering)
-        handler.postDelayed(IDLE_TIMEOUT_MS, fpsManagerToken) {
-          calculateFpsAndReset(listener)
-        }
+    val frameRenderTimeNs = System.nanoTime() - preRenderTimeNs
+    frameRenderTimeAccumulatedNs += frameRenderTimeNs
+    // normally we update FPS counter and reset counters once a second
+    if (choreographerTicks >= screenRefreshRate) {
+      calculateFpsAndReset()
+    } else {
+      // however to produce correct values we also update FPS after IDLE_TIMEOUT_MS
+      // otherwise when updating the map after it was IDLE first update will report
+      // huge delta between new frame and last frame (as we're using dirty rendering)
+      handler.postDelayed(IDLE_TIMEOUT_MS, fpsManagerToken) {
+        onRenderingPaused()
       }
-      preRenderTimeNs = -1L
     }
+    preRenderTimeNs = -1L
   }
 
   fun onSurfaceDestroyed() {
-    fpsChangedListener?.let { listener ->
-      calculateFpsAndReset(listener)
-    }
+    onRenderingPaused()
   }
 
   fun destroy() {
@@ -127,9 +133,9 @@ internal class FpsManager(
     }
   }
 
-  private fun calculateFpsAndReset(listener: OnFpsChangedListener) {
+  private fun onRenderingPaused() {
     handler.removeCallbacksAndMessages(fpsManagerToken)
-    calculateFps(listener)
+    calculateFpsAndReset()
     previousFrameTimeNs = -1
   }
 
@@ -173,39 +179,36 @@ internal class FpsManager(
     return false
   }
 
-  private fun calculateFps(listener: OnFpsChangedListener) {
+  private fun calculateFpsAndReset() {
     if (choreographerTicks == 0) {
       return
     }
-    val droppedFps = choreographerSkips.toDouble() / choreographerTicks
-    val fps = (1.0 - droppedFps) * screenRefreshRate
-    val averageRenderTimeNs = frameRenderTimeAccumulatedNs.toDouble() / (choreographerTicks - choreographerSkips)
-    listener.onFpsChanged(fps)
-    logI(
-      TAG,
-      "VSYNC based FPS is $fps," +
-        " average core rendering time is ${averageRenderTimeNs / 10.0.pow(6.0)} ms" +
-        " (or ${String.format("%.2f", screenRefreshPeriodNs / averageRenderTimeNs * screenRefreshRate)} FPS)," +
-        " missed $choreographerSkips out of $choreographerTicks VSYNC pulses"
-    )
+    fpsChangedListener?.let { listener ->
+      val droppedFps = choreographerSkips.toDouble() / choreographerTicks
+      val fps = (1.0 - droppedFps) * screenRefreshRate
+      val averageRenderTimeNs = frameRenderTimeAccumulatedNs.toDouble() / (choreographerTicks - choreographerSkips)
+      listener.onFpsChanged(fps)
+      logI(
+        TAG,
+        "VSYNC based FPS is $fps," +
+          " average core rendering time is ${averageRenderTimeNs / 10.0.pow(6.0)} ms" +
+          " (or ${String.format("%.2f", screenRefreshPeriodNs / averageRenderTimeNs * screenRefreshRate)} FPS)," +
+          " missed $choreographerSkips out of $choreographerTicks VSYNC pulses"
+      )
+    }
     previousDrawnFrameIndex = 0
     frameRenderTimeAccumulatedNs = 0L
     choreographerTicks = 0
     choreographerSkips = 0
   }
 
-  private companion object {
+  internal companion object {
     private const val TAG = "Mbgl-FpsManager"
     private const val USER_DEFINED_REFRESH_RATE_NOT_SET = -1
     private const val USER_TO_SCREEN_REFRESH_RATIO_NOT_SET = 0.0
     private const val SCREEN_METRICS_NOT_DEFINED = -1
-    private const val LOG_STATISTICS = true
-    private const val IDLE_TIMEOUT_MS = 50L
-
-    /**
-     * We use same handler and looper as our render thread and we need to make sure that
-     * we clear messages related to FPS manager only.
-     */
+    private const val LOG_STATISTICS = false
+    internal const val IDLE_TIMEOUT_MS = 50L
     private val fpsManagerToken = Any()
     private val ONE_SECOND_NS = 10.0.pow(9.0).toLong()
     private val ONE_MILLISECOND_NS = 10.0.pow(6.0).toLong()

--- a/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
@@ -1,0 +1,186 @@
+package com.mapbox.maps.renderer
+
+import android.os.Handler
+import androidx.annotation.WorkerThread
+import androidx.core.os.postDelayed
+import com.mapbox.maps.logI
+import com.mapbox.maps.logW
+import kotlin.math.pow
+
+@WorkerThread
+internal class FpsManager(
+  private val handler: Handler
+) {
+  private var userRefreshRate = USER_DEFINED_REFRESH_RATE_NOT_SET
+  private var userDefinedRatio = USER_DEFINED_RATIO_NOT_SET
+
+  private var screenRefreshRate = SCREEN_METRICS_NOT_DEFINED
+  private var screenRefreshPeriodNs = -1L
+  private var previousRefreshNs = -1L
+  private var previousDrawnFrameIndex = 0
+  private var frameRenderTimeAccumulatedNs = 0L
+
+  private var preRenderTimeNs = -1L
+  private var choreographerTicks = 0
+  private var choreographerSkips = 0
+
+  internal var fpsChangedListener: OnFpsChangedListener? = null
+
+  fun setScreenRefreshRate(screenRefreshRate: Int) {
+    if (this.screenRefreshRate == screenRefreshRate) {
+      return
+    }
+    this.screenRefreshRate = screenRefreshRate
+    screenRefreshPeriodNs = ONE_SECOND_NS / screenRefreshRate
+    if (userRefreshRate != USER_DEFINED_REFRESH_RATE_NOT_SET) {
+      userDefinedRatio = userRefreshRate.toDouble() / screenRefreshRate
+      logI(TAG, "User defined ratio is $userDefinedRatio")
+    }
+    if (LOG_STATISTICS) {
+      logI(
+        TAG,
+        "Device screen frequency is $screenRefreshRate," +
+          " user defined refresh rate is ${if (userRefreshRate == USER_DEFINED_REFRESH_RATE_NOT_SET) "not set" else userRefreshRate}"
+      )
+    }
+  }
+
+  fun setUserRefreshRate(refreshRate: Int) {
+    if (userRefreshRate != refreshRate) {
+      userRefreshRate = refreshRate
+      logI(TAG, "User set max FPS to $userRefreshRate")
+      if (screenRefreshRate != SCREEN_METRICS_NOT_DEFINED) {
+        userDefinedRatio = userRefreshRate.toDouble() / screenRefreshRate
+        logI(TAG, "User defined ratio is $userDefinedRatio")
+      }
+    }
+  }
+
+  /**
+   * Return true if rendering should happen this frame and false otherwise.
+   *
+   * @param frameTimeNs time value from Choreographer in [System.nanoTime] timebase.
+   */
+  fun preRender(frameTimeNs: Long): Boolean {
+    // no need to perform neither pacing nor FPS calculation when setMaxFps / setOnFpsChangedListener was not called by the user
+    if (userDefinedRatio == USER_DEFINED_RATIO_NOT_SET && fpsChangedListener == null) {
+      return true
+    }
+    // clear any scheduled task as new render call is about to happen
+    handler.removeCallbacksAndMessages(fpsManagerToken)
+    preRenderTimeNs = System.nanoTime()
+    var skippedNow = 0
+    // check if we did miss VSYNC deadline meaning too much work was done in previous doFrame
+    if (previousRefreshNs != -1L && frameTimeNs - previousRefreshNs > screenRefreshPeriodNs + ONE_MILLISECOND_NS) {
+      skippedNow =
+        ((frameTimeNs - previousRefreshNs) / (screenRefreshPeriodNs + ONE_MILLISECOND_NS)).toInt()
+      choreographerSkips += skippedNow
+    }
+    previousRefreshNs = frameTimeNs
+    // we always increase choreographer tick by one + add number of skipped frames for consistent results
+    choreographerTicks += skippedNow + 1
+    if (skippedNow > 0 && LOG_STATISTICS) {
+      logW(
+        TAG,
+        "Skipped $skippedNow VSYNC pulses since last actual render," +
+          " total skipped in measurement period $choreographerSkips / $choreographerTicks"
+      )
+    }
+    if (userDefinedRatio != USER_DEFINED_RATIO_NOT_SET) {
+      return performPacing()
+    }
+    return true
+  }
+
+  fun postRender() {
+    fpsChangedListener?.let { listener ->
+      val frameRenderTimeNs = System.nanoTime() - preRenderTimeNs
+      frameRenderTimeAccumulatedNs += frameRenderTimeNs
+      // normally we update FPS counter once a second
+      if (choreographerTicks >= screenRefreshRate) {
+        calculateFps(listener)
+      } else {
+        // however to produce correct values we also update FPS after IDLE_TIMEOUT_MS
+        // otherwise when updating the map after it was IDLE first update will report
+        // huge delta between new frame and last frame (as we're using dirty rendering)
+        handler.postDelayed(IDLE_TIMEOUT_MS, fpsManagerToken) {
+          calculateFpsAndReset(listener)
+        }
+      }
+      preRenderTimeNs = -1L
+    }
+  }
+
+  fun onSurfaceDestroyed() {
+    fpsChangedListener?.let { listener ->
+      calculateFpsAndReset(listener)
+    }
+  }
+
+  fun destroy() {
+    handler.removeCallbacksAndMessages(fpsManagerToken)
+    fpsChangedListener = null
+  }
+
+  private fun calculateFpsAndReset(listener: OnFpsChangedListener) {
+    handler.removeCallbacksAndMessages(fpsManagerToken)
+    calculateFps(listener)
+    previousRefreshNs = -1
+  }
+
+  private fun performPacing(): Boolean {
+    val drawnFrameIndex = (choreographerTicks * userDefinedRatio).toInt()
+    if (LOG_STATISTICS) {
+      logI(
+        TAG,
+        "Performing pacing, current index=$drawnFrameIndex," +
+          " previous drawn=$previousDrawnFrameIndex, proceed with rendering=${drawnFrameIndex > previousDrawnFrameIndex}"
+      )
+    }
+    if (drawnFrameIndex > previousDrawnFrameIndex) {
+      previousDrawnFrameIndex = drawnFrameIndex
+      return true
+    }
+    choreographerSkips++
+    return false
+  }
+
+  private fun calculateFps(listener: OnFpsChangedListener) {
+    if (choreographerTicks == 0) {
+      return
+    }
+    val droppedFps = choreographerSkips.toDouble() / choreographerTicks
+    val fps = (1.0 - droppedFps) * screenRefreshRate
+    val averageRenderTimeNs = frameRenderTimeAccumulatedNs.toDouble() / choreographerTicks
+    listener.onFpsChanged(fps)
+    if (LOG_STATISTICS) {
+      logW(
+        TAG,
+        "VSYNC based FPS is $fps," +
+          " average core rendering time is ${averageRenderTimeNs / 10.0.pow(6.0)} ms," +
+          " missed $choreographerSkips out of $choreographerTicks VSYNC pulses"
+      )
+    }
+    previousDrawnFrameIndex = 0
+    frameRenderTimeAccumulatedNs = 0L
+    choreographerTicks = 0
+    choreographerSkips = 0
+  }
+
+  private companion object {
+    private const val TAG = "Mbgl-FpsManager"
+    private const val USER_DEFINED_REFRESH_RATE_NOT_SET = -1
+    private const val USER_DEFINED_RATIO_NOT_SET = 0.0
+    private const val SCREEN_METRICS_NOT_DEFINED = -1
+    private const val LOG_STATISTICS = true
+    private const val IDLE_TIMEOUT_MS = 50L
+
+    /**
+     * We use same handler and looper as our render thread and we need to make sure that
+     * we clear messages related to FPS manager only.
+     */
+    private val fpsManagerToken = Any()
+    private val ONE_SECOND_NS = 10.0.pow(9.0).toLong()
+    private val ONE_MILLISECOND_NS = 10.0.pow(6.0).toLong()
+  }
+}

--- a/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
@@ -151,16 +151,15 @@ internal class FpsManager(
     }
     val droppedFps = choreographerSkips.toDouble() / choreographerTicks
     val fps = (1.0 - droppedFps) * screenRefreshRate
-    val averageRenderTimeNs = frameRenderTimeAccumulatedNs.toDouble() / choreographerTicks
+    val averageRenderTimeNs = frameRenderTimeAccumulatedNs.toDouble() / (choreographerTicks - choreographerSkips)
     listener.onFpsChanged(fps)
-    if (LOG_STATISTICS) {
-      logW(
-        TAG,
-        "VSYNC based FPS is $fps," +
-          " average core rendering time is ${averageRenderTimeNs / 10.0.pow(6.0)} ms," +
-          " missed $choreographerSkips out of $choreographerTicks VSYNC pulses"
-      )
-    }
+    logI(
+      TAG,
+      "VSYNC based FPS is $fps," +
+        " average core rendering time is ${averageRenderTimeNs / 10.0.pow(6.0)} ms" +
+        " (or ${String.format("%.2f", screenRefreshPeriodNs / averageRenderTimeNs * screenRefreshRate)} FPS)," +
+        " missed $choreographerSkips out of $choreographerTicks VSYNC pulses"
+    )
     previousDrawnFrameIndex = 0
     frameRenderTimeAccumulatedNs = 0L
     choreographerTicks = 0
@@ -172,7 +171,7 @@ internal class FpsManager(
     private const val USER_DEFINED_REFRESH_RATE_NOT_SET = -1
     private const val USER_DEFINED_RATIO_NOT_SET = 0.0
     private const val SCREEN_METRICS_NOT_DEFINED = -1
-    private const val LOG_STATISTICS = false
+    private const val LOG_STATISTICS = true
     private const val IDLE_TIMEOUT_MS = 50L
 
     /**

--- a/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/FpsManager.kt
@@ -172,7 +172,7 @@ internal class FpsManager(
     private const val USER_DEFINED_REFRESH_RATE_NOT_SET = -1
     private const val USER_DEFINED_RATIO_NOT_SET = 0.0
     private const val SCREEN_METRICS_NOT_DEFINED = -1
-    private const val LOG_STATISTICS = true
+    private const val LOG_STATISTICS = false
     private const val IDLE_TIMEOUT_MS = 50L
 
     /**

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -79,21 +79,19 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
 
   // could not be volatile as setter method is synchronized
   internal var fpsChangedListener by Delegates.observable<OnFpsChangedListener?>(null) { _, old, new ->
-    new?.let {
-      if (old != it) {
-        /**
-         * Consider setting [OnFpsChangedListener] as non-render event to make sure that
-         * it does not get dropped if user has set it right after MapView creation before render thread
-         * is actually fully prepared for rendering.
-         */
-        postNonRenderEvent(
-          RenderEvent(
-            { fpsManager.fpsChangedListener = it },
-            false,
-            EventType.DEFAULT
-          )
+    if (old != new) {
+      /**
+       * Consider setting [OnFpsChangedListener] as non-render event to make sure that
+       * it does not get dropped if user has set it right after MapView creation before render thread
+       * is actually fully prepared for rendering.
+       */
+      postNonRenderEvent(
+        RenderEvent(
+          { fpsManager.fpsChangedListener = new },
+          false,
+          EventType.DEFAULT
         )
-      }
+      )
     }
   }
 
@@ -451,7 +449,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     prepareRenderFrame(creatingSurface = true)
   }
 
-  @MainThread
+  @UiThread
   fun setScreenRefreshRate(refreshRate: Int) {
     renderHandlerThread.post {
       fpsManager.setScreenRefreshRate(refreshRate)

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -1,13 +1,9 @@
 package com.mapbox.maps.renderer
 
 import android.opengl.GLES20
-import android.os.SystemClock
 import android.view.Choreographer
 import android.view.Surface
-import androidx.annotation.AnyThread
-import androidx.annotation.UiThread
-import androidx.annotation.VisibleForTesting
-import androidx.annotation.WorkerThread
+import androidx.annotation.*
 import com.mapbox.maps.logE
 import com.mapbox.maps.logI
 import com.mapbox.maps.logW
@@ -22,7 +18,7 @@ import javax.microedition.khronos.egl.EGL10
 import javax.microedition.khronos.egl.EGL11
 import javax.microedition.khronos.egl.EGLSurface
 import kotlin.concurrent.withLock
-import kotlin.math.pow
+import kotlin.properties.Delegates
 
 /**
  * The render thread is responsible for the communication between any thread and the render thread it creates.
@@ -57,11 +53,6 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
 
   @Volatile
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-  internal var renderTimeNs = 0L
-  private var expectedVsyncWakeTimeNs = 0L
-
-  @Volatile
-  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var awaitingNextVsync = false
   private var sizeChanged = false
   @Volatile
@@ -86,8 +77,27 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
   private var eglPrepared = false
   private var renderNotSupported = false
 
-  internal var fpsChangedListener: OnFpsChangedListener? = null
-  private var timeElapsed = 0L
+  // could not be volatile as setter method is synchronized
+  internal var fpsChangedListener by Delegates.observable<OnFpsChangedListener?>(null) { _, old, new ->
+    new?.let {
+      if (old != it) {
+        /**
+         * Consider setting [OnFpsChangedListener] as non-render event to make sure that
+         * it does not get dropped if user has set it right after MapView creation before render thread
+         * is actually fully prepared for rendering.
+         */
+        postNonRenderEvent(
+          RenderEvent(
+            { fpsManager.fpsChangedListener = it },
+            false,
+            EventType.DEFAULT
+          )
+        )
+      }
+    }
+  }
+
+  private val fpsManager: FpsManager
 
   // TODO needed for workaround until issue is fixed in gl-native
   internal var renderDestroyCallChain = false
@@ -112,7 +122,9 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     this.eglCore = EGLCore(translucentSurface, antialiasingSampleCount)
     this.eglSurface = eglCore.eglNoSurface
     this.widgetTextureRenderer = TextureRenderer()
-    renderHandlerThread = RenderHandlerThread().apply { start() }
+    renderHandlerThread = RenderHandlerThread()
+    val handler = renderHandlerThread.start()
+    fpsManager = FpsManager(handler)
   }
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -121,6 +133,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     mapboxWidgetRenderer: MapboxWidgetRenderer,
     handlerThread: RenderHandlerThread,
     eglCore: EGLCore,
+    fpsManager: FpsManager,
     widgetTextureRenderer: TextureRenderer,
   ) {
     this.translucentSurface = false
@@ -128,6 +141,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     this.widgetRenderer = mapboxWidgetRenderer
     this.renderHandlerThread = handlerThread
     this.eglCore = eglCore
+    this.fpsManager = fpsManager
     this.widgetTextureRenderer = widgetTextureRenderer
     this.eglSurface = eglCore.eglNoSurface
   }
@@ -242,17 +256,13 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     }
   }
 
-  private fun draw() {
-    val renderTimeNsCopy = renderTimeNs
-    val currentTimeNs = SystemClock.elapsedRealtimeNanos()
-    val expectedEndRenderTimeNs = currentTimeNs + renderTimeNsCopy
-    if (expectedVsyncWakeTimeNs > currentTimeNs) {
+  private fun draw(frameTimeNanos: Long) {
+    if (!fpsManager.preRender(frameTimeNanos)) {
       // when we have FPS limited and desire to skip core render - we must schedule new draw call
       // otherwise map may remain in not fully loaded state
       postPrepareRenderFrame()
       return
     }
-
     if (widgetRenderer.hasWidgets()) {
       if (widgetRenderer.needTextureUpdate) {
         widgetRenderer.updateTexture()
@@ -272,20 +282,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     // it makes sense to execute them after drawing a map but before swapping buffers
     // **note** this queue also holds snapshot tasks
     drainQueue(renderEventQueue)
-    // calculate FPS here, before actual swap as swap could happen either this or next frame
-    val actualEndRenderTimeNanos = SystemClock.elapsedRealtimeNanos()
-    if (renderTimeNsCopy != 0L && actualEndRenderTimeNanos < expectedEndRenderTimeNs) {
-      // we need to stop swap buffers for less than time requested in order to have some time to render upcoming frame
-      // before next vsync so it will be drawn, otherwise we will drop it
-      expectedVsyncWakeTimeNs = expectedEndRenderTimeNs - ONE_MILLISECOND_NS
-    }
-    fpsChangedListener?.let {
-      val fps = 1E9 / (actualEndRenderTimeNanos - timeElapsed)
-      if (timeElapsed != 0L) {
-        it.onFpsChanged(fps)
-      }
-      timeElapsed = actualEndRenderTimeNanos
-    }
+    fpsManager.postRender()
     if (needViewAnnotationSync && viewAnnotationMode == ViewAnnotationUpdateMode.MAP_SYNCHRONIZED) {
       // when we're syncing view annotations with the map -
       // we swap buffers the next frame to achieve better synchronization with view annotations update
@@ -420,6 +417,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
             } else {
               releaseEglSurface()
             }
+            fpsManager.onSurfaceDestroyed()
             destroyCondition.signal()
           }
         }
@@ -453,6 +451,13 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     prepareRenderFrame(creatingSurface = true)
   }
 
+  @MainThread
+  fun setScreenRefreshRate(refreshRate: Int) {
+    renderHandlerThread.post {
+      fpsManager.setScreenRefreshRate(refreshRate)
+    }
+  }
+
   @UiThread
   fun onSurfaceCreated(surface: Surface, width: Int, height: Int) {
     lock.withLock {
@@ -464,15 +469,17 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
   }
 
   @AnyThread
-  fun setMaximumFps(fps: Int) {
-    renderTimeNs = ONE_SECOND_NS / fps
+  fun setUserRefreshRate(fps: Int) {
+    renderHandlerThread.post {
+      fpsManager.setUserRefreshRate(fps)
+    }
   }
 
   @WorkerThread
   override fun doFrame(frameTimeNanos: Long) {
     // it makes sense to draw not only when EGL config is prepared but when native renderer is created
     if (renderThreadPrepared && !paused) {
-      draw()
+      draw(frameTimeNanos)
     }
     awaitingNextVsync = false
     // It's critical to drain queue after setting `awaitingNextVsync` to false as some tasks may recursively schedule other tasks when executed.
@@ -547,6 +554,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
               releaseAll()
             }
             renderHandlerThread.clearDefaultMessages()
+            fpsManager.destroy()
             eglCore.clearRendererStateListeners()
             destroyCondition.signal()
           }
@@ -566,12 +574,8 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     }
   }
 
-  companion object {
+  internal companion object {
     private const val TAG = "Mbgl-RenderThread"
-
-    private val ONE_SECOND_NS = 10.0.pow(9.0).toLong()
-    private val ONE_MILLISECOND_NS = 10.0.pow(6.0).toLong()
-
     /**
      * If we hit some issue caused by invalid state (most likely caused by GPU driver) we start
      * rescheduling configuration with that delay in order not to overflood handler thread message queue.

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -182,7 +182,11 @@ internal abstract class MapboxRenderer : MapClient {
 
   @AnyThread
   fun setMaximumFps(fps: Int) {
-    renderThread.setMaximumFps(fps)
+    if (fps <= 0 || fps >= MapView.MAX_POSSIBLE_FPS) {
+      logE(TAG, "Maximum FPS could not be <= 0 or >= ${MapView.MAX_POSSIBLE_FPS}")
+      return
+    }
+    renderThread.setUserRefreshRate(fps)
   }
 
   @AnyThread

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -20,7 +20,6 @@ internal abstract class MapboxRenderer : MapClient {
   internal lateinit var renderThread: MapboxRenderThread
   internal abstract val widgetRenderer: MapboxWidgetRenderer
 
-  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var map: MapInterface? = null
 
   private var width: Int = 0

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -181,8 +181,8 @@ internal abstract class MapboxRenderer : MapClient {
 
   @AnyThread
   fun setMaximumFps(fps: Int) {
-    if (fps <= 0 || fps >= MapView.MAX_POSSIBLE_FPS) {
-      logE(TAG, "Maximum FPS could not be <= 0 or >= ${MapView.MAX_POSSIBLE_FPS}, ignoring $fps value.")
+    if (fps <= 0) {
+      logE(TAG, "Maximum FPS could not be <= 0, ignoring $fps value.")
       return
     }
     renderThread.setUserRefreshRate(fps)

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -182,7 +182,7 @@ internal abstract class MapboxRenderer : MapClient {
   @AnyThread
   fun setMaximumFps(fps: Int) {
     if (fps <= 0 || fps >= MapView.MAX_POSSIBLE_FPS) {
-      logE(TAG, "Maximum FPS could not be <= 0 or >= ${MapView.MAX_POSSIBLE_FPS}")
+      logE(TAG, "Maximum FPS could not be <= 0 or >= ${MapView.MAX_POSSIBLE_FPS}, ignoring $fps value.")
       return
     }
     renderThread.setUserRefreshRate(fps)

--- a/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
@@ -11,7 +11,6 @@ internal class RenderHandlerThread {
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal lateinit var handlerThread: HandlerThread
-  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var handler: Handler? = null
 
   internal val started

--- a/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
@@ -29,10 +29,12 @@ internal class RenderHandlerThread {
     } ?: logW(TAG, "Thread $HANDLE_THREAD_NAME was not started, ignoring event")
   }
 
-  fun start() {
-    handlerThread = HandlerThread(HANDLE_THREAD_NAME, THREAD_PRIORITY_DISPLAY).apply {
-      start()
-      handler = Handler(this.looper)
+  fun start(): Handler {
+    handlerThread = HandlerThread(HANDLE_THREAD_NAME, THREAD_PRIORITY_DISPLAY)
+    handlerThread.start()
+    Handler(handlerThread.looper).also {
+      handler = it
+      return it
     }
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
@@ -32,9 +32,8 @@ internal class RenderHandlerThread {
   fun start(): Handler {
     handlerThread = HandlerThread(HANDLE_THREAD_NAME, THREAD_PRIORITY_DISPLAY)
     handlerThread.start()
-    Handler(handlerThread.looper).also {
+    return Handler(handlerThread.looper).also {
       handler = it
-      return it
     }
   }
 

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -382,27 +382,31 @@ class MapControllerTest {
 
   @Test
   fun setValidScreenRefreshRate() {
-    mockkStatic("com.mapbox.maps.MapboxLogger")
-    every { logE(any(), any()) } just Runs
-    val mockRenderThread = mockk<MapboxRenderThread>(relaxed = true)
-    every { mockRenderer.renderThread } returns mockRenderThread
-    val validScreenRefreshRate = 90
-    testMapController.setScreenRefreshRate(validScreenRefreshRate)
-    verify(exactly = 1) {
-      mockRenderThread.setScreenRefreshRate(validScreenRefreshRate)
-    }
-    unmockkStatic("com.mapbox.maps.MapboxLogger")
+    screenRefreshRateTest(1, 60)
   }
 
   @Test
-  fun setInvalidScreenRefreshRate() {
+  fun setZeroScreenRefreshRate() {
+    screenRefreshRateTest(0, 0)
+  }
+
+  @Test
+  fun setNegativeScreenRefreshRate() {
+    screenRefreshRateTest(0, -1)
+  }
+
+  @Test
+  fun setMoreThanMaxScreenRefreshRate() {
+    screenRefreshRateTest(0, MapView.MAX_POSSIBLE_FPS.toInt() + 1)
+  }
+
+  private fun screenRefreshRateTest(expectedCallCount: Int, actualRefreshRate: Int) {
     mockkStatic("com.mapbox.maps.MapboxLogger")
     every { logE(any(), any()) } just Runs
     val mockRenderThread = mockk<MapboxRenderThread>(relaxed = true)
     every { mockRenderer.renderThread } returns mockRenderThread
-    testMapController.setScreenRefreshRate(-1)
-    testMapController.setScreenRefreshRate(MapView.MAX_POSSIBLE_FPS.toInt() + 1)
-    verify(exactly = 0) {
+    testMapController.setScreenRefreshRate(actualRefreshRate)
+    verify(exactly = expectedCallCount) {
       mockRenderThread.setScreenRefreshRate(any())
     }
     unmockkStatic("com.mapbox.maps.MapboxLogger")

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -9,6 +9,7 @@ import com.mapbox.maps.plugin.Plugin
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.delegates.listeners.OnCameraChangeListener
 import com.mapbox.maps.plugin.delegates.listeners.OnStyleDataLoadedListener
+import com.mapbox.maps.renderer.MapboxRenderThread
 import com.mapbox.maps.renderer.MapboxRenderer
 import com.mapbox.maps.renderer.OnFpsChangedListener
 import io.mockk.*
@@ -301,9 +302,12 @@ class MapControllerTest {
 
   @Test
   fun setMaximumFpsInvalid() {
+    every { mockRenderer.setMaximumFps(any()) } just Runs
+
     testMapController.setMaximumFps(-1)
 
-    verify(exactly = 0) { mockRenderer.setMaximumFps(any()) }
+    // range check is performed within MapboxRenderer
+    verify { mockRenderer.setMaximumFps(any()) }
   }
 
   @Test
@@ -321,7 +325,6 @@ class MapControllerTest {
     every { mockMapInitOptions.plugins } answers { emptyList() }
 
     testMapController.initializePlugins(mockMapInitOptions)
-
     verify(exactly = 0) {
       mockPluginRegistry.createPlugin(any(), mockMapInitOptions, any())
       mockMapboxMap.setCameraAnimationPlugin(any())
@@ -375,5 +378,33 @@ class MapControllerTest {
       mockPluginRegistry.createPlugin(mockMapView, mockMapInitOptions, createdPlugin)
       mockMapboxMap.setCameraAnimationPlugin(createdPlugin.instance as CameraAnimationsPlugin)
     }
+  }
+
+  @Test
+  fun setValidScreenRefreshRate() {
+    mockkStatic("com.mapbox.maps.MapboxLogger")
+    every { logE(any(), any()) } just Runs
+    val mockRenderThread = mockk<MapboxRenderThread>(relaxed = true)
+    every { mockRenderer.renderThread } returns mockRenderThread
+    val validScreenRefreshRate = 90
+    testMapController.setScreenRefreshRate(validScreenRefreshRate)
+    verify(exactly = 1) {
+      mockRenderThread.setScreenRefreshRate(validScreenRefreshRate)
+    }
+    unmockkStatic("com.mapbox.maps.MapboxLogger")
+  }
+
+  @Test
+  fun setInvalidScreenRefreshRate() {
+    mockkStatic("com.mapbox.maps.MapboxLogger")
+    every { logE(any(), any()) } just Runs
+    val mockRenderThread = mockk<MapboxRenderThread>(relaxed = true)
+    every { mockRenderer.renderThread } returns mockRenderThread
+    testMapController.setScreenRefreshRate(-1)
+    testMapController.setScreenRefreshRate(MapView.MAX_POSSIBLE_FPS.toInt() + 1)
+    verify(exactly = 0) {
+      mockRenderThread.setScreenRefreshRate(any())
+    }
+    unmockkStatic("com.mapbox.maps.MapboxLogger")
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -396,8 +396,8 @@ class MapControllerTest {
   }
 
   @Test
-  fun setMoreThanMaxScreenRefreshRate() {
-    screenRefreshRateTest(0, MapView.MAX_POSSIBLE_FPS.toInt() + 1)
+  fun setMaxScreenRefreshRate() {
+    screenRefreshRateTest(1, Int.MAX_VALUE)
   }
 
   private fun screenRefreshRateTest(expectedCallCount: Int, actualRefreshRate: Int) {

--- a/sdk/src/test/java/com/mapbox/maps/renderer/FpsManagerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/FpsManagerTest.kt
@@ -78,6 +78,40 @@ class FpsManagerTest {
   }
 
   @Test
+  fun userRefreshRate1Test() {
+    fpsManager.setUserRefreshRate(1)
+    pauseHandler()
+    val vsyncCount = 120
+    val frameRenderedPattern = mutableListOf<Boolean>()
+    val expectedRenderedPattern = BooleanArray(vsyncCount)
+    for (i in 0 until 120) {
+      expectedRenderedPattern[i] = i == 59 || i == 119
+    }
+    idleHandler(vsyncCount = vsyncCount) {
+      frameRenderedPattern.add(fpsManager.preRender(it))
+    }
+    Assert.assertArrayEquals(
+      expectedRenderedPattern.toTypedArray(),
+      frameRenderedPattern.toTypedArray()
+    )
+  }
+
+  @Test
+  fun userRefreshRateMaxIntTest() {
+    fpsManager.setUserRefreshRate(Int.MAX_VALUE)
+    pauseHandler()
+    val vsyncCount = 1000
+    val frameRenderedPattern = mutableListOf<Boolean>()
+    idleHandler(vsyncCount = vsyncCount) {
+      frameRenderedPattern.add(fpsManager.preRender(it))
+    }
+    Assert.assertArrayEquals(
+      Array(vsyncCount) { true },
+      frameRenderedPattern.toTypedArray()
+    )
+  }
+
+  @Test
   fun userFpsListenerTest() {
     val fpsValueArray = mutableListOf<Double>()
     val fpsChangedListener = OnFpsChangedListener {

--- a/sdk/src/test/java/com/mapbox/maps/renderer/FpsManagerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/FpsManagerTest.kt
@@ -64,15 +64,29 @@ class FpsManagerTest {
   fun userRefreshRate7Test() {
     fpsManager.setUserRefreshRate(7)
     pauseHandler()
+    val vsyncCount = 18
     val frameRenderedPattern = mutableListOf<Boolean>()
-    idleHandler(vsyncCount = 18) {
+    idleHandler(vsyncCount = vsyncCount) {
       frameRenderedPattern.add(fpsManager.preRender(it))
     }
     Assert.assertArrayEquals(
-      arrayOf(
-        false, false, false, false, false, false, false, false, true,
-        false, false, false, false, false, false, false, false, true,
-      ),
+      Array(vsyncCount) { it == 8 || it == 17 },
+      frameRenderedPattern.toTypedArray()
+    )
+  }
+
+  @Test
+  fun userRefreshRate3for2secondsTest() {
+    fpsManager.setUserRefreshRate(3)
+    pauseHandler()
+    val vsyncCount = 120
+    val frameRenderedPattern = mutableListOf<Boolean>()
+    idleHandler(vsyncCount = vsyncCount) {
+      frameRenderedPattern.add(fpsManager.preRender(it))
+    }
+    Assert.assertArrayEquals(
+      // 6 frames should be rendered in total during 2 seconds with 3 FPS
+      Array(vsyncCount) { it == 19 || it == 39 || it == 59 || it == 79 || it == 99 || it == 119 },
       frameRenderedPattern.toTypedArray()
     )
   }
@@ -83,15 +97,11 @@ class FpsManagerTest {
     pauseHandler()
     val vsyncCount = 120
     val frameRenderedPattern = mutableListOf<Boolean>()
-    val expectedRenderedPattern = BooleanArray(vsyncCount)
-    for (i in 0 until 120) {
-      expectedRenderedPattern[i] = i == 59 || i == 119
-    }
     idleHandler(vsyncCount = vsyncCount) {
       frameRenderedPattern.add(fpsManager.preRender(it))
     }
     Assert.assertArrayEquals(
-      expectedRenderedPattern.toTypedArray(),
+      Array(vsyncCount) { it == 59 || it == 119 },
       frameRenderedPattern.toTypedArray()
     )
   }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/FpsManagerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/FpsManagerTest.kt
@@ -1,0 +1,182 @@
+package com.mapbox.maps.renderer
+
+import android.os.Looper
+import android.view.Choreographer
+import com.mapbox.maps.logI
+import com.mapbox.maps.logW
+import com.mapbox.maps.renderer.FpsManager.Companion.IDLE_TIMEOUT_MS
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowChoreographer
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+class FpsManagerTest {
+
+  private lateinit var fpsManager: FpsManager
+
+  @Before
+  fun setUp() {
+    fpsManager = FpsManager()
+    mockkStatic("com.mapbox.maps.MapboxLogger")
+    every { logI(any(), any()) } just Runs
+    every { logW(any(), any()) } just Runs
+    // simulate all the tests on 60 Hz screen, meaning we have 16.6 ms time to render a frame
+    ShadowChoreographer.setPostFrameCallbackDelay(CHOREOGRAPHER_POST_FRAME_CALLBACK_DELAY_MS)
+    fpsManager.setScreenRefreshRate(SCREEN_FPS)
+  }
+
+  @Test
+  fun userRefreshRateNotSetTest() {
+    pauseHandler()
+    val frameTotalNumber = 10
+    var frameRenderedCount = 0
+    for (i in 0 until frameTotalNumber) {
+      Choreographer.getInstance().postFrameCallback {
+        assert(fpsManager.preRender(it))
+        frameRenderedCount++
+      }
+    }
+    idleHandler(vsyncCount = frameTotalNumber)
+    assert(frameRenderedCount == frameTotalNumber)
+  }
+
+  @Test
+  fun userRefreshRate24Test() {
+    fpsManager.setUserRefreshRate(24)
+    pauseHandler()
+    val frameTotalNumber = 10
+    val frameRenderedPattern = mutableListOf<Boolean>()
+    for (i in 0 until frameTotalNumber) {
+      Choreographer.getInstance().postFrameCallback {
+        frameRenderedPattern.add(fpsManager.preRender(it))
+      }
+    }
+    idleHandler(vsyncCount = frameTotalNumber)
+    Assert.assertArrayEquals(
+      arrayOf(
+        false, false, true, false, true,
+        false, false, true, false, true
+      ),
+      frameRenderedPattern.toTypedArray()
+    )
+  }
+
+  @Test
+  fun userRefreshRate7Test() {
+    fpsManager.setUserRefreshRate(7)
+    pauseHandler()
+    val frameTotalNumber = 18
+    val frameRenderedPattern = mutableListOf<Boolean>()
+    for (i in 0 until frameTotalNumber) {
+      Choreographer.getInstance().postFrameCallback {
+        frameRenderedPattern.add(fpsManager.preRender(it))
+      }
+    }
+    idleHandler(vsyncCount = frameTotalNumber)
+    Assert.assertArrayEquals(
+      arrayOf(
+        false, false, false, false, false, false, false, false, true,
+        false, false, false, false, false, false, false, false, true,
+      ),
+      frameRenderedPattern.toTypedArray()
+    )
+  }
+
+  @Test
+  fun userFpsListenerTest() {
+    val fpsValueArray = mutableListOf<Double>()
+    val fpsChangedListener = OnFpsChangedListener {
+      fpsValueArray.add(it)
+    }
+    fpsManager.fpsChangedListener = fpsChangedListener
+    pauseHandler()
+    // render a bit more frames than screen frequency
+    val frameTotalNumber = SCREEN_FPS + 10
+    for (i in 0 until frameTotalNumber) {
+      Choreographer.getInstance().postFrameCallback {
+        assert(fpsManager.preRender(it))
+        fpsManager.postRender()
+      }
+    }
+    idleHandler(vsyncCount = frameTotalNumber)
+    assert(fpsValueArray.size == 1)
+    Assert.assertEquals(SCREEN_FPS.toDouble(), fpsValueArray[0], EPS)
+  }
+
+  @Test
+  fun mapBecomeIdleDuringRenderingNoFpsListenerTest() {
+    mapIdleTest()
+  }
+
+  @Test
+  fun mapBecomeIdleDuringRenderingWithFpsListenerTest() {
+    var fpsValue = 0.0
+    val fpsChangedListener = OnFpsChangedListener {
+      fpsValue = it
+    }
+    fpsManager.fpsChangedListener = fpsChangedListener
+    mapIdleTest()
+    Assert.assertEquals(40.0, fpsValue, EPS)
+  }
+
+  private fun mapIdleTest() {
+    // pattern is [0, 1, 1, 1, 1]
+    fpsManager.setUserRefreshRate(48)
+    pauseHandler()
+    // first we render 3 frames
+    val frameTotalNumberBefore = 3
+    val frameRenderedBeforePattern = mutableListOf<Boolean>()
+    for (i in 0 until frameTotalNumberBefore) {
+      Choreographer.getInstance().postFrameCallback {
+        frameRenderedBeforePattern.add(fpsManager.preRender(it))
+        fpsManager.postRender()
+      }
+    }
+    idleHandler(vsyncCount = frameTotalNumberBefore)
+    // then we simulate map being IDLE for several vsync ticks - counters should be reset, fps should be reported
+    val frameTotalNumberWhenIdle = (IDLE_TIMEOUT_MS / CHOREOGRAPHER_POST_FRAME_CALLBACK_DELAY_MS).toInt() + 1
+    idleHandler(vsyncCount = frameTotalNumberWhenIdle)
+    // and render 5 more frames
+    val frameTotalNumberAfter = 5
+    val frameRenderedAfterPattern = mutableListOf<Boolean>()
+    for (i in 0 until frameTotalNumberAfter) {
+      Choreographer.getInstance().postFrameCallback {
+        frameRenderedAfterPattern.add(fpsManager.preRender(it))
+        fpsManager.postRender()
+      }
+    }
+    idleHandler(vsyncCount = frameTotalNumberAfter)
+    Assert.assertArrayEquals(
+      arrayOf(
+        false, true, true,
+        false, true, true, true, true
+      ),
+      frameRenderedBeforePattern.plus(frameRenderedAfterPattern).toTypedArray()
+    )
+  }
+
+  private fun pauseHandler() = Shadows.shadowOf(Looper.getMainLooper()).pause()
+
+  private fun idleHandler(vsyncCount: Int) = Shadows.shadowOf(Looper.getMainLooper())
+    .idleFor(CHOREOGRAPHER_POST_FRAME_CALLBACK_DELAY_MS.toLong() * vsyncCount, TimeUnit.MILLISECONDS)
+
+  @After
+  fun cleanUp() {
+    unmockkStatic("com.mapbox.maps.MapboxLogger")
+  }
+
+  private companion object {
+    private const val EPS = 0.0001
+    private const val SCREEN_FPS = 60
+    private const val CHOREOGRAPHER_POST_FRAME_CALLBACK_DELAY_MS = 16
+  }
+}

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -98,9 +98,16 @@ internal abstract class MapboxRendererTest {
   }
 
   @Test
-  fun setMaximumFpsTest() {
+  fun setValidMaximumFpsTest() {
     mapboxRenderer.setMaximumFps(10)
-    verify { renderThread.setMaximumFps(10) }
+    verify { renderThread.setUserRefreshRate(10) }
+  }
+
+  @Test
+  fun setInvalidMaximumFpsTest() {
+    mapboxRenderer.setMaximumFps(-1)
+    mapboxRenderer.setMaximumFps(MapView.MAX_POSSIBLE_FPS.toInt() + 1)
+    verify(exactly = 0) { renderThread.setUserRefreshRate(any()) }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -104,9 +104,9 @@ internal abstract class MapboxRendererTest {
   }
 
   @Test
-  fun setMoreThanMaximumFpsTest() {
-    mapboxRenderer.setMaximumFps(MapView.MAX_POSSIBLE_FPS.toInt() + 1)
-    verify(exactly = 0) { renderThread.setUserRefreshRate(any()) }
+  fun setMaximumFpsTest() {
+    mapboxRenderer.setMaximumFps(Int.MAX_VALUE)
+    verify(exactly = 1) { renderThread.setUserRefreshRate(Int.MAX_VALUE) }
   }
 
   @Test

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRendererTest.kt
@@ -100,13 +100,24 @@ internal abstract class MapboxRendererTest {
   @Test
   fun setValidMaximumFpsTest() {
     mapboxRenderer.setMaximumFps(10)
-    verify { renderThread.setUserRefreshRate(10) }
+    verify(exactly = 1) { renderThread.setUserRefreshRate(10) }
   }
 
   @Test
-  fun setInvalidMaximumFpsTest() {
-    mapboxRenderer.setMaximumFps(-1)
+  fun setMoreThanMaximumFpsTest() {
     mapboxRenderer.setMaximumFps(MapView.MAX_POSSIBLE_FPS.toInt() + 1)
+    verify(exactly = 0) { renderThread.setUserRefreshRate(any()) }
+  }
+
+  @Test
+  fun setNegativeFpsTest() {
+    mapboxRenderer.setMaximumFps(-1)
+    verify(exactly = 0) { renderThread.setUserRefreshRate(any()) }
+  }
+
+  @Test
+  fun setZeroFpsTest() {
+    mapboxRenderer.setMaximumFps(0)
     verify(exactly = 0) { renderThread.setUserRefreshRate(any()) }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

This PR fixes 2 problems that are pretty close to each other.

 - when adding FPS listener via `MapView.setOnFpsChangedListener` previously callback was triggered immediately after render call was executed. That was actually not correct as docs stated that callback should return average amount of rendered frames during last second. Now this is fixed and FPS values are much more readable and reliable. Assuming we use rendering on demand (and not continuous) corner situations are also covered:
   - when not interacting with the map for some time and starting to interact after some delay - we will not report huge amount of missed VSYNC events, instead we will report last FPS update after 50 ms update of map being IDLE and reset counters.
   - when going to background we will also report last FPS update and reset counters so that when resuming the map number of VSYNC missed events will not be huge
 - when setting maximum custom FPS via `MapView.setMaximumFps` correct FPS value will be now applied. Previously without frame pacing algorithm when setting let's say 59 FPS on 60 Hz screen actual FPS was 30 (closest divider). Now we do have basic frame pacing algorithm in place that spreads moments of time when we actually wish to render the frame evenly across one second timeframe.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
