### PR TITLE
Avoid NaN when converting screen coordinates to geographical coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 # main
 ## Bug fixes 🐞
 * Remove android.permission.WAKE_LOCK permission from the SDK. ([1484](https://github.com/mapbox/mapbox-maps-android/pull/1484))
+* Avoid NaN when converting screen coordinates to geographical coordinates executed as part of gesture. [#1491](https://github.com/mapbox/mapbox-maps-android/pull/1491)
 
 ## Dependencies
 * Bump telemetry to [v8.1.4](https://github.com/mapbox/mapbox-events-android/releases/tag/telem-8.1.4-core-5.0.2). ([#1484](https://github.com/mapbox/mapbox-maps-android/pull/1484))

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -1043,7 +1043,8 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
     }
     // Get pitch value (scale and clamp)
     var pitch = mapCameraManagerDelegate.cameraState.pitch
-    val optimizedPitch = pitch - (SHOVE_PIXEL_CHANGE_FACTOR * (deltaPixelsSinceLast + deferredShove))
+    val optimizedPitch =
+      pitch - (SHOVE_PIXEL_CHANGE_FACTOR * (deltaPixelsSinceLast + deferredShove))
     deferredShove = 0.0
     pitch = clamp(optimizedPitch, MINIMUM_PITCH, MAXIMUM_PITCH)
     easeToImmediately(
@@ -1393,7 +1394,22 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
     // Prevent drag start in area around horizon to avoid sharp map movements
     val topMapMargin = 0.04 * mapTransformDelegate.getSize().height
     val reprojectErrorMargin = min(10.0, topMapMargin / 2)
-    val point = ScreenCoordinate(pixel.x, pixel.y - topMapMargin)
+
+    // sanitize input x to be non NaN
+    var pointX = pixel.x
+    if (pointX.isNaN()) {
+      logE(TAG, "isPointAboveHorizon: screen coordinate x is NaN.")
+      pointX = 0.0
+    }
+
+    // sanitize input y to be non NaN
+    var pointY = pixel.y
+    if (pointY.isNaN()) {
+      logE(TAG, "isPointAboveHorizon: screen coordinate y is NaN.")
+      pointY = 0.0
+    }
+
+    val point = ScreenCoordinate(pointX, pointY - topMapMargin)
     val coordinate = mapCameraManagerDelegate.coordinateForPixel(point)
     val roundtripPoint = mapCameraManagerDelegate.pixelForCoordinate(coordinate)
     return (roundtripPoint.y >= point.y + reprojectErrorMargin)


### PR DESCRIPTION
### Summary of changes
This patch a crash reported by a user. The crash is very much edge case and while the usage of ScreenCoordinate(0,0) might be a band-aid solution, it's better than crashing the end-user application. 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.
