### PR TITLE
Update telemetry to 8.1.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ Mapbox welcomes participation and contributions from everyone.
 ## Bug fixes 🐞
 * Remove android.permission.WAKE_LOCK permission from the SDK. ([1484](https://github.com/mapbox/mapbox-maps-android/pull/1484))
 * Avoid NaN when converting screen coordinates to geographical coordinates executed as part of gesture. [#1491](https://github.com/mapbox/mapbox-maps-android/pull/1491)
+* Remove android.permission.WAKE_LOCK permission from the SDK. ([1484](https://github.com/mapbox/mapbox-maps-android/pull/1494))
 
 ## Dependencies
-* Bump telemetry to [v8.1.4](https://github.com/mapbox/mapbox-events-android/releases/tag/telem-8.1.4-core-5.0.2). ([#1484](https://github.com/mapbox/mapbox-maps-android/pull/1484))
+* Bump telemetry to [v8.1.5](https://github.com/mapbox/mapbox-events-android/releases/tag/telem-8.1.5-core-5.0.2). ([#1494](https://github.com/mapbox/mapbox-maps-android/pull/1494))
 
 #main
 ## Bug fixes 🐞

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,8 @@
 Mapbox welcomes participation and contributions from everyone.
 # main
 ## Bug fixes 🐞
-* Remove android.permission.WAKE_LOCK permission from the SDK. ([1484](https://github.com/mapbox/mapbox-maps-android/pull/1484))
 * Avoid NaN when converting screen coordinates to geographical coordinates executed as part of gesture. [#1491](https://github.com/mapbox/mapbox-maps-android/pull/1491)
-* Remove android.permission.WAKE_LOCK permission from the SDK. ([1484](https://github.com/mapbox/mapbox-maps-android/pull/1494))
+* Remove android.permission.WAKE_LOCK permission from the SDK. ([1494](https://github.com/mapbox/mapbox-maps-android/pull/1494))
 
 ## Dependencies
 * Bump telemetry to [v8.1.5](https://github.com/mapbox/mapbox-events-android/releases/tag/telem-8.1.5-core-5.0.2). ([#1494](https://github.com/mapbox/mapbox-maps-android/pull/1494))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Dependencies
 * Bump telemetry to [v8.1.5](https://github.com/mapbox/mapbox-events-android/releases/tag/telem-8.1.5-core-5.0.2). ([#1494](https://github.com/mapbox/mapbox-maps-android/pull/1494))
+Also bumps [WorkManager 2.7.1](https://developer.android.com/jetpack/androidx/releases/work#2.7.1) that enforces compileSdk 31 or newer. 
 
 #main
 ## Bug fixes 🐞

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -111,7 +111,7 @@ object Versions {
   const val mapboxGlNative = "10.7.0-beta.1"
   const val mapboxCommon = "22.1.0-beta.1"
   const val mapboxAndroidCore = "5.0.2"
-  const val mapboxAndroidTelemetry = "8.1.4"
+  const val mapboxAndroidTelemetry = "8.1.5"
   const val androidxCore = "1.3.1"
   const val androidxAnnotation = "1.1.0"
   const val androidxAppcompat = "1.3.0"

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -1,7 +1,7 @@
 object AndroidVersions {
   const val minSdkVersion = 21
   const val targetSdkVersion = 30
-  const val compileSdkVersion = 30
+  const val compileSdkVersion = 31
   object AndroidAuto {
     const val minSdkVersion = 23
     const val targetSdkVersion = 30


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Includes telemetry lib with fix for the crash when targetSdk = 31+ is used due to WorkManager 2.6 issues (https://github.com/mapbox/mapbox-events-android/pull/571#issuecomment-1179010463).

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
