### PR TITLE
Bump version readme

### DIFF
--- a/extension-localization/README.md
+++ b/extension-localization/README.md
@@ -31,7 +31,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.extension:maps-localization:10.7.0-beta.1'
+    implementation 'com.mapbox.extension:maps-localization:10.7.0-rc.1'
 }
 ```
 

--- a/extension-style/README.md
+++ b/extension-style/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.extension:maps-style:10.7.0-beta.1'
+  implementation 'com.mapbox.extension:maps-style:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-animation/README.md
+++ b/plugin-animation/README.md
@@ -34,7 +34,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-animation:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-animation:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -30,7 +30,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-annotation:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-annotation:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-attribution/README.md
+++ b/plugin-attribution/README.md
@@ -33,7 +33,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-attribution:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-attribution:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-compass/README.md
+++ b/plugin-compass/README.md
@@ -32,9 +32,9 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-compass:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-compass:10.7.0-rc.1'
   // Mapbox Maps Compass Plugin depends on the Mapbox Maps Animation Plugin
-  implementation 'com.mapbox.plugin:maps-animation:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-animation:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-gestures/README.md
+++ b/plugin-gestures/README.md
@@ -30,9 +30,9 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.plugin:maps-gestures:10.7.0-beta.1'
+    implementation 'com.mapbox.plugin:maps-gestures:10.7.0-rc.1'
     // Mapbox Maps Gestures Plugin depends on the Mapbox Maps Animation Plugin
-    implementation 'com.mapbox.plugin:maps-animation:10.7.0-beta.1'
+    implementation 'com.mapbox.plugin:maps-animation:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-lifecycle/README.md
+++ b/plugin-lifecycle/README.md
@@ -30,7 +30,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-lifecycle:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-lifecycle:10.7.0-rc.1'
   // Make sure the version of appcompat is 1.3.0+
   implementation 'androidx.appcompat:appcompat:1.3.0'
 }

--- a/plugin-locationcomponent/README.md
+++ b/plugin-locationcomponent/README.md
@@ -32,7 +32,7 @@ allprojects {
 }
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-locationcomponent:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-locationcomponent:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-logo/README.md
+++ b/plugin-logo/README.md
@@ -30,7 +30,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-logo:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-logo:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-overlay/README.md
+++ b/plugin-overlay/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-overlay:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-overlay:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-scalebar/README.md
+++ b/plugin-scalebar/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-scalebar:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-scalebar:10.7.0-rc.1'
 }
 ```
 

--- a/plugin-viewport/README.md
+++ b/plugin-viewport/README.md
@@ -50,7 +50,7 @@ allprojects {
 }
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-viewport:10.7.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-viewport:10.7.0-rc.1'
 }
 ```
 


### PR DESCRIPTION
Forgot to bump version in plugin readme's. 

Generally it seems pretty useless to have those sections and to bump the dependencies every release, suspect no one is copy-pasting this code.
Also since those READMEs say `This README is intended for developers who are interested in [contributing]` - there's no reason to include maven dependency on the module at all, contrubutors will grab the code instead, I think. @tobrun do you remember why was it introduced?