### PR TITLE
[Android Auto] Fix android automotive surface recreation issue

### DIFF
--- a/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/car/MapScreen.kt
+++ b/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/car/MapScreen.kt
@@ -47,6 +47,21 @@ class MapScreen(
             }
             .build()
         )
+        .addAction(
+          Action.Builder()
+            .setIcon(
+              CarIcon.Builder(
+                IconCompat.createWithResource(
+                  carContext,
+                  android.R.drawable.ic_menu_search
+                )
+              ).build()
+            )
+            .setOnClickListener {
+              screenManager.push(SearchScreen(carContext))
+            }
+            .build()
+        )
         .build()
     )
     // Set the map action strip with the pan and zoom buttons.

--- a/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/car/SearchScreen.kt
+++ b/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/car/SearchScreen.kt
@@ -1,0 +1,33 @@
+package com.mapbox.maps.testapp.auto.car
+
+import androidx.car.app.CarContext
+import androidx.car.app.Screen
+import androidx.car.app.SurfaceContainer
+import androidx.car.app.model.Action
+import androidx.car.app.model.SearchTemplate
+import androidx.car.app.model.Template
+import com.mapbox.maps.extension.androidauto.MapboxCarMap
+import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
+
+/**
+ * This screen is to demonstrate a behavior where the map surface is destroyed and re-created.
+ *
+ * Android Auto can transition between [Template]s that do not include a [SurfaceContainer] for
+ * rendering the map. The [SearchTemplate] is one example template to reproduce this behavior.
+ * The [MapboxCarMap] does not need to be re-created, but when the surface is destroyed the
+ * [MapboxCarMap] will detach all registered [MapboxCarMapObserver]s. The observers will be
+ * attached after a new surface is created.
+ */
+class SearchScreen(carContext: CarContext) : Screen(carContext) {
+
+  override fun onGetTemplate(): Template {
+    val searchCallback = object : SearchTemplate.SearchCallback {
+      override fun onSearchTextChanged(searchText: String) {}
+
+      override fun onSearchSubmitted(searchText: String) {}
+    }
+    return SearchTemplate.Builder(searchCallback)
+      .setHeaderAction(Action.BACK)
+      .build()
+  }
+}

--- a/extension-androidauto/CHANGELOG.md
+++ b/extension-androidauto/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 # main
 ## Features ✨ and improvements 🏁
 ## Bug fixes 🐞
+* Destroy previous surface when new surface becomes available. This adds better support for `androidx.car.app:app-automotive`. ([#1509](https://github.com/mapbox/mapbox-maps-android/pull/1509))
 
 # 0.1.0 April 7, 2022
 

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/CarMapSurfaceOwner.kt
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/CarMapSurfaceOwner.kt
@@ -56,7 +56,14 @@ internal class CarMapSurfaceOwner(
     logI(TAG, "surfaceAvailable")
     val oldCarMapSurface = this.mapboxCarMapSurface
     this.mapboxCarMapSurface = mapboxCarMapSurface
-    oldCarMapSurface?.let { carMapObservers.forEach { it.onDetached(oldCarMapSurface) } }
+    oldCarMapSurface?.let {
+      carMapObservers.forEach { it.onDetached(oldCarMapSurface) }
+      // The surface can become available without a call to surfaceDestroyed
+      // https://issuetracker.google.com/issues/235121269
+      oldCarMapSurface.mapSurface.onStop()
+      oldCarMapSurface.mapSurface.surfaceDestroyed()
+      oldCarMapSurface.mapSurface.onDestroy()
+    }
     carMapObservers.forEach { it.onAttached(mapboxCarMapSurface) }
 
     notifyVisibleAreaChanged()

--- a/extension-androidauto/src/test/java/com/mapbox/maps/extension/androidauto/CarMapSurfaceOwnerTest.kt
+++ b/extension-androidauto/src/test/java/com/mapbox/maps/extension/androidauto/CarMapSurfaceOwnerTest.kt
@@ -224,13 +224,12 @@ class CarMapSurfaceOwnerTest {
       observer.onAttached(firstSurface)
       observer.onVisibleAreaChanged(any(), any())
       observer.onDetached(firstSurface)
+      firstMapSurface.onStop()
+      firstMapSurface.surfaceDestroyed()
+      firstMapSurface.onDestroy()
       observer.onAttached(secondSurface)
       observer.onVisibleAreaChanged(any(), any())
     }
-    // Map style changes should not destroy the map.
-    verify(exactly = 0) { firstMapSurface.onStop() }
-    verify(exactly = 0) { firstMapSurface.surfaceDestroyed() }
-    verify(exactly = 0) { firstMapSurface.onDestroy() }
   }
 
   @Test

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -24,7 +24,7 @@ if grep -q "$pr_number" <<< "$skip_changelog_prs"; then
   exit 0
 fi
 
-changelog_diff=$(git diff origin/main..HEAD CHANGELOG.md)
+changelog_diff=$(git diff origin/main..HEAD CHANGELOG.md extension-androidauto/CHANGELOG.md)
 
 if [[ -z "$changelog_diff" ]]; then
     echo "No changes in CHANGELOG.md found"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

When building Android Auto for Android Automotive, the automotive surface library has a different behavior for creating surfaces when transitioning screens. 

Tested and reproduced on `androidx.car.app:app-automotive:1.1.0` and `androidx.car.app:app-automotive:1.2.0-rc`.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->

Fixes a blocking issue for anyone trying to build an Android Auto app for Android Automotive

cc: @yunikkk @pengdev 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: Resolves https://github.com/mapbox/mapbox-maps-android/issues/1503
Related: https://github.com/mapbox/mapbox-maps-android/issues/1397

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
