### PR TITLE
Add COMMIT_SHA to the snapshot name.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ commands:
                   COMMIT_SHA=$(git rev-parse --short HEAD)
                   LAST_RELEASE=$(git describe --tags --abbrev=0)
                   if [[ -n ${CIRCLE_BRANCH+x} ]] && [[ $CIRCLE_BRANCH != "main" ]] && [[ "$(git log -1)" = *"publish_android_snapshot"* ]]; then
-                    sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${LAST_RELEASE:1}-${CIRCLE_BRANCH}-SNAPSHOT/" gradle.properties
+                    sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${LAST_RELEASE:1}-${CIRCLE_BRANCH}-${COMMIT_SHA}-SNAPSHOT/" gradle.properties
                     make sdkRegistryUpload
                   fi
 


### PR DESCRIPTION
COMMIT_SHA was not added to the uploaded snapshot, thus reuploading snapshots from the same branch could fail for different reasons - either cached locally, or somewhere at the proxy server etc.