### PR TITLE
Fix weird crash in StyleObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Bug fixes 🐞
 * Support altitude interpolation in location component, and pass through GPS altitude information from the DefaultLocationProvider. ([1478](https://github.com/mapbox/mapbox-maps-android/pull/1478))
 * Fix excessive logs appearing sometimes after `onStop` lifecycle event. ([1527](https://github.com/mapbox/mapbox-maps-android/pull/1527))
+* Fix `com.mapbox.maps.MapboxMapException` crash on style load. ([1532](https://github.com/mapbox/mapbox-maps-android/pull/1532))
 
 # 10.7.0-rc.1 July 14, 2022
 ## Features ✨ and improvements 🏁

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -251,44 +251,6 @@ class StyleObserverTest {
   }
 
   @Test
-  fun onStyleDataSourcesThrowsIfNoStyleData() {
-    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
-    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
-    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
-
-    styleObserver.setLoadStyleListener(
-      null,
-      styleCallback,
-      styleSpritesCallback,
-      styleSourcesCallback,
-      null
-    )
-
-    assertThrows(MapboxMapException::class.java) {
-      styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SOURCES))
-    }
-  }
-
-  @Test
-  fun onStyleDataSpritesThrowsIfNoStyleData() {
-    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
-    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
-    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
-
-    styleObserver.setLoadStyleListener(
-      null,
-      styleCallback,
-      styleSpritesCallback,
-      styleSourcesCallback,
-      null
-    )
-
-    assertThrows(MapboxMapException::class.java) {
-      styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SPRITE))
-    }
-  }
-
-  @Test
   fun onStyleLoadedThrowsIfNoStyleData() {
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)


### PR DESCRIPTION
Do not throw exception and just log instead in case StyleDataType.SOURCES is fired before StyleDataType.STYLE.

Fixes MAPSMBL-127

<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
