### PR TITLE
Fix edge cases for renderer that could result in map not rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Support altitude interpolation in location component, and pass through GPS altitude information from the DefaultLocationProvider. ([1478](https://github.com/mapbox/mapbox-maps-android/pull/1478))
 * Fix excessive logs appearing sometimes after `onStop` lifecycle event. ([1527](https://github.com/mapbox/mapbox-maps-android/pull/1527))
 * Fix `com.mapbox.maps.MapboxMapException` crash on style load. ([1532](https://github.com/mapbox/mapbox-maps-android/pull/1532))
+* Fix edge cases for renderer that could result in map not rendered. ([1538](https://github.com/mapbox/mapbox-maps-android/pull/1538))
 
 # 10.7.0-rc.1 July 14, 2022
 ## Features ✨ and improvements 🏁

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -311,8 +311,10 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       EGL10.EGL_SUCCESS -> { }
       EGL11.EGL_CONTEXT_LOST -> {
         logW(TAG, "Context lost. Waiting for re-acquire")
-        // release all resources but not release Android surface if it's still valid -
-        // same surface may then be re-used to re-attach EGL.
+        // release all resources but not release Android surface
+        // as it still potentially may be valid - then it could be re-used to recreate EGL;
+        // if it's not valid - system should shortly send us brand new surface and
+        // we will recreate EGL and native renderer anyway
         releaseAll(releaseAndroidSurface = false)
       }
       else -> {
@@ -343,7 +345,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       eglCore.release()
     }
     eglPrepared = false
-    if (releaseAndroidSurface || surface?.isValid == false) {
+    if (releaseAndroidSurface) {
       surface?.release()
     }
   }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -311,7 +311,9 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       EGL10.EGL_SUCCESS -> { }
       EGL11.EGL_CONTEXT_LOST -> {
         logW(TAG, "Context lost. Waiting for re-acquire")
-        releaseEgl()
+        // Android surface is still valid so we don't release it
+        // otherwise no more rendering will happen
+        releaseAll(releaseAndroidSurface = false)
       }
       else -> {
         logW(TAG, "eglSwapBuffer error: $swapStatus. Waiting for new surface")
@@ -337,7 +339,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     widgetRenderer.release()
   }
 
-  private fun releaseAll() {
+  private fun releaseAll(releaseAndroidSurface: Boolean = true) {
     renderDestroyCallChain = true
     mapboxRenderer.destroyRenderer()
     renderDestroyCallChain = false
@@ -345,7 +347,9 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     nonRenderEventQueue.clear()
     renderCreated = false
     releaseEgl()
-    surface?.release()
+    if (releaseAndroidSurface) {
+      surface?.release()
+    }
   }
 
   private fun prepareRenderFrame(creatingSurface: Boolean = false) {

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -315,7 +315,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
         // as it still potentially may be valid - then it could be re-used to recreate EGL;
         // if it's not valid - system should shortly send us brand new surface and
         // we will recreate EGL and native renderer anyway
-        releaseAll(releaseAndroidSurface = false)
+        releaseAll(tryRecreate = true)
       }
       else -> {
         logW(TAG, "eglSwapBuffer error: $swapStatus. Waiting for new surface")
@@ -333,7 +333,7 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
     widgetRenderer.release()
   }
 
-  private fun releaseAll(releaseAndroidSurface: Boolean = true) {
+  private fun releaseAll(tryRecreate: Boolean = false) {
     renderDestroyCallChain = true
     mapboxRenderer.destroyRenderer()
     renderDestroyCallChain = false
@@ -345,7 +345,9 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       eglCore.release()
     }
     eglPrepared = false
-    if (releaseAndroidSurface) {
+    if (tryRecreate) {
+      setUpRenderThread(creatingSurface = true)
+    } else {
       surface?.release()
     }
   }

--- a/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/renderer/MapboxRenderThreadTest.kt
@@ -808,17 +808,19 @@ class MapboxRenderThreadTest {
     every { eglCore.swapBuffers(any()) } returns EGL11.EGL_SUCCESS
     mapboxRenderThread.queueRenderEvent(MapboxRenderer.repaintRenderEvent)
     idleHandler()
-    // one swap buffer for surface creation, one for EGL_CONTEXT_LOST, one for EGL_SUCCESS
-    verify(exactly = 3) {
-      eglCore.swapBuffers(any())
-    }
-    // EGL and native renderer are recreated
     verifyOrder {
+      // swap buffers for surface creation
+      eglCore.swapBuffers(any())
+      // swap buffers for EGL_CONTEXT_LOST
+      eglCore.swapBuffers(any())
+      // EGL and native renderer are recreated
       mapboxRenderer.destroyRenderer()
       eglCore.releaseSurface(any())
       eglCore.release()
       eglCore.prepareEgl()
       mapboxRenderer.createRenderer()
+      // swap buffers for EGL_SUCCESS
+      eglCore.swapBuffers(any())
     }
     // however Android surface is not released
     verifyNo {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Fix several edge-case situations:
 - when new Android surface arrived and previous one is not valid anymore - we additionally recreate native renderer. Previously just EGL core was recreated while native renderer could still reference to outdated GPU resources.
 - when `EGL_CONTEXT_LOST` is triggered during buffer swap (which should not even happen due to other checks) - we re-create EGL as well as native renderer so that it does not reference to outdated GPU resources.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
