### PR TITLE
downgrade androidx core to 1.7.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -70,7 +70,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox Maps Android uses portions of the Android Support Library compat.
 
-URL: [https://developer.android.com/jetpack/androidx/releases/core#1.8.0](https://developer.android.com/jetpack/androidx/releases/core#1.8.0)
+URL: [https://developer.android.com/jetpack/androidx/releases/core#1.7.0](https://developer.android.com/jetpack/androidx/releases/core#1.7.0)
 
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -94,7 +94,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox Maps Android uses portions of the Core Kotlin Extensions.
 
-URL: [https://developer.android.com/jetpack/androidx/releases/core#1.8.0](https://developer.android.com/jetpack/androidx/releases/core#1.8.0)
+URL: [https://developer.android.com/jetpack/androidx/releases/core#1.7.0](https://developer.android.com/jetpack/androidx/releases/core#1.7.0)
 
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -112,7 +112,7 @@ object Versions {
   const val mapboxCommon = "22.1.0"
   const val mapboxAndroidCore = "5.0.2"
   const val mapboxAndroidTelemetry = "8.1.5"
-  const val androidxCore = "1.7.0"
+  const val androidxCore = "1.7.0" // last version compatible with kotlin 1.5.31
   const val androidxFragmentTesting = "1.5.0"
   const val androidxAnnotation = "1.1.0"
   const val androidxAppcompat = "1.3.0"

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -112,7 +112,7 @@ object Versions {
   const val mapboxCommon = "22.1.0"
   const val mapboxAndroidCore = "5.0.2"
   const val mapboxAndroidTelemetry = "8.1.5"
-  const val androidxCore = "1.8.0"
+  const val androidxCore = "1.7.0"
   const val androidxFragmentTesting = "1.5.0"
   const val androidxAnnotation = "1.1.0"
   const val androidxAppcompat = "1.3.0"

--- a/extension-style/api/metalava.txt
+++ b/extension-style/api/metalava.txt
@@ -4165,8 +4165,6 @@ package com.mapbox.maps.extension.style.light.generated {
     method public com.mapbox.maps.extension.style.light.generated.Light anchor(com.mapbox.maps.extension.style.layers.properties.generated.Anchor anchor);
     method public com.mapbox.maps.extension.style.light.generated.Light anchor(com.mapbox.maps.extension.style.expressions.generated.Expression anchor);
     method public void bindTo(com.mapbox.maps.extension.style.StyleInterface delegate);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light castShadows(boolean castShadows);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light castShadows(com.mapbox.maps.extension.style.expressions.generated.Expression castShadows);
     method public com.mapbox.maps.extension.style.light.generated.Light color(@ColorInt int color);
     method public com.mapbox.maps.extension.style.light.generated.Light color(String color);
     method public com.mapbox.maps.extension.style.light.generated.Light color(com.mapbox.maps.extension.style.expressions.generated.Expression color);
@@ -4174,8 +4172,6 @@ package com.mapbox.maps.extension.style.light.generated {
     method public com.mapbox.maps.extension.style.light.generated.Light colorTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.properties.generated.Anchor? getAnchor();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getAnchorAsExpression();
-    method public Boolean? getCastShadows();
-    method public com.mapbox.maps.extension.style.expressions.generated.Expression? getCastShadowsAsExpression();
     method public String? getColor();
     method @ColorInt public Integer? getColorAsColorInt();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getColorAsExpression();
@@ -4186,9 +4182,6 @@ package com.mapbox.maps.extension.style.light.generated {
     method public com.mapbox.maps.extension.style.light.LightPosition? getPosition();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getPositionAsExpression();
     method public com.mapbox.maps.extension.style.types.StyleTransition? getPositionTransition();
-    method public Double? getShadowIntensity();
-    method public com.mapbox.maps.extension.style.expressions.generated.Expression? getShadowIntensityAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getShadowIntensityTransition();
     method public com.mapbox.maps.extension.style.light.generated.Light intensity(double intensity);
     method public com.mapbox.maps.extension.style.light.generated.Light intensity(com.mapbox.maps.extension.style.expressions.generated.Expression intensity);
     method public com.mapbox.maps.extension.style.light.generated.Light intensityTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
@@ -4198,14 +4191,8 @@ package com.mapbox.maps.extension.style.light.generated {
     method public com.mapbox.maps.extension.style.light.generated.Light position(com.mapbox.maps.extension.style.expressions.generated.Expression position);
     method public com.mapbox.maps.extension.style.light.generated.Light positionTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
     method public com.mapbox.maps.extension.style.light.generated.Light positionTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light shadowIntensity(double shadowIntensity);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light shadowIntensity(com.mapbox.maps.extension.style.expressions.generated.Expression shadowIntensity);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light shadowIntensityTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light shadowIntensityTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     property public final com.mapbox.maps.extension.style.layers.properties.generated.Anchor? anchor;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? anchorAsExpression;
-    property public final Boolean? castShadows;
-    property public final com.mapbox.maps.extension.style.expressions.generated.Expression? castShadowsAsExpression;
     property public final String? color;
     property @ColorInt public final Integer? colorAsColorInt;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? colorAsExpression;
@@ -4216,9 +4203,6 @@ package com.mapbox.maps.extension.style.light.generated {
     property public final com.mapbox.maps.extension.style.light.LightPosition? position;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? positionAsExpression;
     property public final com.mapbox.maps.extension.style.types.StyleTransition? positionTransition;
-    property public final Double? shadowIntensity;
-    property public final com.mapbox.maps.extension.style.expressions.generated.Expression? shadowIntensityAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? shadowIntensityTransition;
     field public static final com.mapbox.maps.extension.style.light.generated.Light.Companion Companion;
   }
 
@@ -4228,8 +4212,6 @@ package com.mapbox.maps.extension.style.light.generated {
   @com.mapbox.maps.extension.style.types.LightDsl public interface LightDslReceiver {
     method public com.mapbox.maps.extension.style.light.generated.Light anchor(com.mapbox.maps.extension.style.layers.properties.generated.Anchor anchor = com.mapbox.maps.extension.style.layers.properties.generated.Anchor.VIEWPORT);
     method public com.mapbox.maps.extension.style.light.generated.Light anchor(com.mapbox.maps.extension.style.expressions.generated.Expression anchor);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light castShadows(boolean castShadows = false);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light castShadows(com.mapbox.maps.extension.style.expressions.generated.Expression castShadows);
     method public com.mapbox.maps.extension.style.light.generated.Light color(@ColorInt int color);
     method public com.mapbox.maps.extension.style.light.generated.Light color(String color = "#ffffff");
     method public com.mapbox.maps.extension.style.light.generated.Light color(com.mapbox.maps.extension.style.expressions.generated.Expression color);
@@ -4244,10 +4226,6 @@ package com.mapbox.maps.extension.style.light.generated {
     method public com.mapbox.maps.extension.style.light.generated.Light position(com.mapbox.maps.extension.style.expressions.generated.Expression position);
     method public com.mapbox.maps.extension.style.light.generated.Light positionTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
     method public com.mapbox.maps.extension.style.light.generated.Light positionTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light shadowIntensity(double shadowIntensity = 0.2);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light shadowIntensity(com.mapbox.maps.extension.style.expressions.generated.Expression shadowIntensity);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light shadowIntensityTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.extension.style.light.generated.Light shadowIntensityTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
   }
 
   public final class LightKt {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

Downgrade androix core to pass metalava checks for current kotlin version (`1.5.31`).
With current core version (`1.8.0`) we not compatible with current Kotlin version, because it's required 1.6.+.

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
