### PR TITLE
Fix ANR while using textureView - MAPSAND-364

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix edge cases for renderer that could result in map not rendered. ([1538](https://github.com/mapbox/mapbox-maps-android/pull/1538))
 * Fix onAnnotationDragStarted event is still fired when annotation is not draggable. ([1552](https://github.com/mapbox/mapbox-maps-android/pull/1552))
 * Fix camera flying away when pitching. ([1560](https://github.com/mapbox/mapbox-maps-android/pull/1560))
+* Fix ANR while open and close MapView quickly with textureView set to true. ([1563](https://github.com/mapbox/mapbox-maps-android/pull/1563))
 
 # 10.7.0 July 29, 2022
 [Changes](https://github.com/mapbox/mapbox-maps-android/compare/android-v10.6.0...android-v10.7.0) since [Mapbox Maps SDK for Android 10.6.0](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.6.0)

--- a/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/RenderHandlerThread.kt
@@ -15,7 +15,7 @@ internal class RenderHandlerThread {
   internal var handler: Handler? = null
 
   internal val started
-    get() = handlerThread.isAlive
+    get() = handler != null
 
   fun post(task: () -> Unit) {
     postDelayed(task, 0, EventType.DEFAULT)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
While open and close Mapview quickly, `RenderHandlerThread#started` might return true while `handler` has been set to null. This will cause a deadlock in [MapboxRenderThread](https://github.com/mapbox/mapbox-maps-android/blob/main/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt#L411) and thus cause the ANR.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
