### PR TITLE
Fix style getters for terrain, light and atmosphere resetting properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Deliver style to the plugin registry on map start if a new one was loaded after map stop. ([1558](https://github.com/mapbox/mapbox-maps-android/pull/1558))
 * Fix a bug in cameraForGeometry returning incorrect camera options when pitch > 0. ([1568](https://github.com/mapbox/mapbox-maps-android/pull/1568))
 * Fix Android memory leak when destroying platform view annotation manager. ([1568](https://github.com/mapbox/mapbox-maps-android/pull/1568))
+* Fix style getters for terrain, light and atmosphere resetting properties. ([1573](https://github.com/mapbox/mapbox-maps-android/pull/1573))
 
 ## Dependencies
 Bump gl-native to v10.8.0-beta.1, common to v23.0.0-beta.1. ([1568](https://github.com/mapbox/mapbox-maps-android/pull/1568))

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/atmosphere/generated/Atmosphere.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/atmosphere/generated/Atmosphere.kt
@@ -24,7 +24,7 @@ import com.mapbox.maps.extension.style.utils.unwrap
  */
 @UiThread
 class Atmosphere : AtmosphereDslReceiver, StyleContract.StyleAtmosphereExtension {
-  private var delegate: StyleInterface? = null
+  internal var delegate: StyleInterface? = null
   private val properties = HashMap<String, PropertyValue<*>>()
 
   /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/atmosphere/generated/AtmosphereExt.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/atmosphere/generated/AtmosphereExt.kt
@@ -12,7 +12,7 @@ import com.mapbox.maps.extension.style.StyleInterface
  * @return Atmosphere
  */
 fun StyleInterface.getAtmosphere(): Atmosphere {
-  return Atmosphere().also { it.bindTo(this) }
+  return Atmosphere().also { it.delegate = this }
 }
 
 /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/light/generated/Light.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/light/generated/Light.kt
@@ -29,7 +29,7 @@ import kotlin.collections.HashMap
  */
 @UiThread
 class Light : LightDslReceiver, StyleContract.StyleLightExtension {
-  private var delegate: StyleInterface? = null
+  internal var delegate: StyleInterface? = null
   private val properties = HashMap<String, PropertyValue<*>>()
 
   /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/light/generated/LightExt.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/light/generated/LightExt.kt
@@ -12,7 +12,7 @@ import com.mapbox.maps.extension.style.StyleInterface
  * @return Light
  */
 fun StyleInterface.getLight(): Light {
-  return Light().also { it.bindTo(this) }
+  return Light().also { it.delegate = this }
 }
 
 /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/terrain/generated/Terrain.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/terrain/generated/Terrain.kt
@@ -20,7 +20,7 @@ import com.mapbox.maps.extension.style.utils.unwrap
  */
 @UiThread
 class Terrain(private val sourceId: String) : TerrainDslReceiver, StyleContract.StyleTerrainExtension {
-  private var delegate: StyleInterface? = null
+  internal var delegate: StyleInterface? = null
   private val properties = HashMap<String, PropertyValue<*>>()
 
   /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/terrain/generated/TerrainExt.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/terrain/generated/TerrainExt.kt
@@ -13,7 +13,7 @@ import com.mapbox.maps.extension.style.StyleInterface
  * @return Terrain
  */
 fun StyleInterface.getTerrain(sourceId: String): Terrain {
-  return Terrain(sourceId).also { it.bindTo(this) }
+  return Terrain(sourceId).also { it.delegate = this }
 }
 
 /**

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/atmosphere/generated/AtmosphereTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/atmosphere/generated/AtmosphereTest.kt
@@ -923,7 +923,7 @@ class AtmosphereTest {
   @Test
   fun getAtmosphereTest() {
     assertNotNull(style.getAtmosphere())
-    verify { style.setStyleAtmosphere(any()) }
+    verify(exactly = 0) { style.setStyleAtmosphere(any()) }
   }
 }
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/light/generated/LightTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/light/generated/LightTest.kt
@@ -716,7 +716,7 @@ class LightTest {
   @Test
   fun getLightTest() {
     assertNotNull(style.getLight())
-    verify { style.setStyleLight(any()) }
+    verify(exactly = 0) { style.setStyleLight(any()) }
   }
 }
 

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/terrain/generated/TerrainTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/terrain/generated/TerrainTest.kt
@@ -171,7 +171,7 @@ class TerrainTest {
   @Test
   fun getTerrainTest() {
     assertNotNull(style.getTerrain(sourceId))
-    verify { style.setStyleTerrain(any()) }
+    verify(exactly = 0) { style.setStyleTerrain(any()) }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Style extension getters for terrain, light and atmosphere were actually calling core setter method under the hood which is unexpected for the user and could cause visual glitches e.g.:
```kotlin
mapboxMap.loadStyle(
  styleExtension = style(Style.SATELLITE_STREETS) {
    +terrain(SOURCE) {
      exaggeration(8.0)
    }
  }
) { style ->
  // correct exagerration is used
  println("Exagerration : ${style.getStyleTerrainProperty("exaggeration")}") 
  val terrain = style.getTerrain(SOURCE)
  // will get null exaggeration property after this call and gl-native uses default value (1.0)
  println("After get terrain : ${terrain.exaggeration}")
}
```

This will be fixed now - correct value will be returned and when calling `style.getTerrain(SOURCE)` - no terrain will be re-added.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
