### PR TITLE
Fix MapSurface#surfaceChanged to update dimensions for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix style getters for terrain, light and atmosphere resetting properties. ([1573](https://github.com/mapbox/mapbox-maps-android/pull/1573))
 * Fix possible ANR when destroying renderer. ([1567](https://github.com/mapbox/mapbox-maps-android/pull/1567))
 * Fix elevation of pole geometry when exaggerated terrain is used. ([1574](https://github.com/mapbox/mapbox-maps-android/pull/1574))
+* Fix `MapSurface#surfaceChanged` to update dimensions for plugins. ([1575](https://github.com/mapbox/mapbox-maps-android/pull/1575))
 
 ## Dependencies
 Bump gl-native to v10.8.0-beta.2 and common to v23.0.0-beta.1. ([1574](https://github.com/mapbox/mapbox-maps-android/pull/1574), [1568](https://github.com/mapbox/mapbox-maps-android/pull/1568))

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -65,6 +65,7 @@ class MapSurface @JvmOverloads constructor(
    */
   fun surfaceChanged(width: Int, height: Int) {
     renderer.surfaceChanged(surface, width, height)
+    onSizeChanged(width, height)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
When implementing MapSurface (e.g. for Android Auto) it is regular practice to overload just `surfaceCreated`, `surfaceChanged` and `surfaceDestroyed` methods. However in that case we're missing `MapControllable.onSizeChanged` call that actually notifies all the plugins.

That will lead as an example to incorrect map shove gesture as center focal point will always be (0, 0). Now `surfaceChanged` call will also call `MapControllable.onSizeChanged` under the hood.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
