### PR TITLE
[ci] fix snapshot version name MAPSAND-377

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,11 +278,9 @@ commands:
                 name: Publish the SDK snapshot based on the keyword in commit message
                 command: |
                   COMMIT_SHA=$(git rev-parse --short HEAD)
-                  LAST_RELEASE=$(git describe --tags --abbrev=0)
+                  LAST_RELEASE=$(git describe --tags --abbrev=0 --match 'android-v[0-9]*.[0-9]*.[0-9]*' --match 'v[0-9]*.[0-9]*.[0-9]*')
                   if [[ $LAST_RELEASE == android-v* ]]; then
                     LAST_RELEASE=${LAST_RELEASE:9}
-                  elif [[ $LAST_RELEASE == extension-androidauto-v* ]]; then
-                    LAST_RELEASE=${LAST_RELEASE:23}
                   else
                     LAST_RELEASE=${LAST_RELEASE:1}
                   fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,8 +279,15 @@ commands:
                 command: |
                   COMMIT_SHA=$(git rev-parse --short HEAD)
                   LAST_RELEASE=$(git describe --tags --abbrev=0)
+                  if [[ $LAST_RELEASE == android-v* ]]; then
+                    LAST_RELEASE=${LAST_RELEASE:9}
+                  elif [[ $LAST_RELEASE == extension-androidauto-v* ]]; then
+                    LAST_RELEASE=${LAST_RELEASE:23}
+                  else
+                    LAST_RELEASE=${LAST_RELEASE:1}
+                  fi
                   if [[ -n ${CIRCLE_BRANCH+x} ]] && [[ $CIRCLE_BRANCH != "main" ]] && [[ "$(git log -1)" = *"publish_android_snapshot"* ]]; then
-                    sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${LAST_RELEASE:1}-${CIRCLE_BRANCH}-${COMMIT_SHA}-SNAPSHOT/" gradle.properties
+                    sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${LAST_RELEASE}-${CIRCLE_BRANCH}-${COMMIT_SHA}-SNAPSHOT/" gradle.properties
                     make sdkRegistryUpload
                   fi
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
Fix snapshot name by adding conditions for the last release to accommodate different version tags and create correct version name for snapshot build.

snapshot name will be; 
<img width="1121" alt="Screenshot 2022-08-11 at 2 18 54 PM" src="https://user-images.githubusercontent.com/11589497/184122079-3c20e5f5-ca48-4f9c-b2dc-7a70053d346c.png">



### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
