### PR TITLE
[ci ] Fix ci to run on correct internal branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ commands:
           name: Start internal CI release flow
           command: |
             if [[ $CIRCLE_TAG =~ << pipeline.parameters.git_release_tag >> ]]; then
-              TARGET_BRANCH=$(echo $CIRCLE_TAG | awk -F\- '{print $2}' | cut -f1-2 -d".")
+              TARGET_BRANCH=$(echo $CIRCLE_TAG | awk -F\- '{print $1}' | cut -f1-2 -d".")
               python3 scripts/start-internal-release-pipeline.py --token ${MOBILE_METRICS_TOKEN} --origin-slug mapbox/mapbox-maps-android --target-slug mapbox/mapbox-maps-android-internal --release_tag $CIRCLE_TAG --branch $TARGET_BRANCH
             fi
   track-metrics:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
Fixing ci to get the correct internal branch after changing tag name from `android-v*` to `v*`
Our internal ci currently runs on specific target branches rather than main. 

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
