### PR TITLE
Try recreate EGL surface when it throws exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Mapbox welcomes participation and contributions from everyone.
 # main
 
+# 10.8.0-rc.1
+## Features ✨ and improvements 🏁
+
+## Bug fixes 🐞
+* Try recreate EGL surface when it throws exception. ([1589](https://github.com/mapbox/mapbox-maps-android/pull/1589))
+
 # 10.8.0-beta.1 August 11, 2022
 ## Features ✨ and improvements 🏁
 * Introduce a callback to be invoked when the device compass sensors need to be re-calibrated. ([1513](https://github.com/mapbox/mapbox-maps-android/pull/1513))

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderThread.kt
@@ -222,6 +222,11 @@ internal class MapboxRenderThread : Choreographer.FrameCallback {
       eglSurface = eglCore.createWindowSurface(surface)
       if (eglSurface == eglCore.eglNoSurface) {
         // try recreate it in next iteration.
+        logW(
+          TAG,
+          "Could not create EGL surface although Android surface was valid," +
+            " retrying in $RETRY_DELAY_MS ms..."
+        )
         postPrepareRenderFrame(delayMillis = RETRY_DELAY_MS)
         return false
       }

--- a/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/egl/EGLCore.kt
@@ -119,19 +119,25 @@ internal class EGLCore(
    * Creates an EGL surface associated with a Surface.
    */
   fun createWindowSurface(surface: Surface): EGLSurface {
-    // Create a window surface, and attach it to the Surface we received.
-    val surfaceAttribs = intArrayOf(EGL10.EGL_NONE)
-    val eglSurface = egl.eglCreateWindowSurface(
-      eglDisplay,
-      eglConfig,
-      surface,
-      surfaceAttribs
-    )
-    val eglWindowCreatedError = checkEglErrorAndNotify("eglCreateWindowSurface")
-    if (eglWindowCreatedError != null || eglSurface == null) {
+    try {
+      // Create a window surface, and attach it to the Surface we received.
+      val surfaceAttribs = intArrayOf(EGL10.EGL_NONE)
+      // may throw java.lang.IllegalArgumentException even when surface is valid
+      val eglSurface = egl.eglCreateWindowSurface(
+        eglDisplay,
+        eglConfig,
+        surface,
+        surfaceAttribs
+      )
+      val eglWindowCreatedError = checkEglErrorAndNotify("eglCreateWindowSurface")
+      if (eglWindowCreatedError != null || eglSurface == null) {
+        return eglNoSurface
+      }
+      return eglSurface
+    } catch (e: Exception) {
+      logE(TAG, "eglCreateWindowSurface has thrown an exception:\n${e.localizedMessage}")
       return eglNoSurface
     }
-    return eglSurface
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
There is a possibility that calling native `EGLSurface  eglCreateWindowSurface(EGLDisplay display, EGLConfig config, Object native_window, int[] attrib_list);` could produce the `java.lang.IllegalArgumentException` even although we are checking that Android `Surface` is valid right beforehand.

Now we will try to create it later, similar solution is implemented in an Android `GLSurfaceView` is to actually retry creating it later:

<img width="1729" alt="image" src="https://user-images.githubusercontent.com/15800566/184325776-6acd3aee-2681-4264-aaa7-f346f0dd25c6.png">


full AOSP delta is [here](https://github.com/aosp-mirror/platform_frameworks_base/commit/7d73df83f9a28950f404e957eb2e4ea1e8525c55#diff-c7a96cfebb7b482f891bd4862d5976e99240ecadc9698b3cd7e21a45b065b4b5R1453).

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
