### PR TITLE
Fix concurrent modification exception when using widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Bug fixes 🐞
 * Try recreate EGL surface when it throws exception. ([1589](https://github.com/mapbox/mapbox-maps-android/pull/1589))
 * Fix `MapboxMap` extension plugin functions throwing exceptions. ([1591](https://github.com/mapbox/mapbox-maps-android/pull/1591))
+* Fix concurrent modification exception when using widgets. ([1597](https://github.com/mapbox/mapbox-maps-android/pull/1597))
 
 # 10.8.0-beta.1 August 11, 2022
 ## Features ✨ and improvements 🏁

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxWidgetRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxWidgetRenderer.kt
@@ -4,6 +4,7 @@ import android.opengl.GLES20
 import com.mapbox.maps.logE
 import com.mapbox.maps.renderer.egl.EGLCore
 import com.mapbox.maps.renderer.widget.Widget
+import java.util.concurrent.CopyOnWriteArrayList
 import javax.microedition.khronos.egl.EGLContext
 import javax.microedition.khronos.egl.EGLSurface
 
@@ -18,7 +19,7 @@ internal class MapboxWidgetRenderer(
   private val textures = intArrayOf(0)
   private val framebuffers = intArrayOf(0)
 
-  private val widgets = mutableListOf<Widget>()
+  private val widgets = CopyOnWriteArrayList<Widget>()
 
   private var width = 0
   private var height = 0

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxWidgetRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxWidgetRenderer.kt
@@ -4,7 +4,7 @@ import android.opengl.GLES20
 import com.mapbox.maps.logE
 import com.mapbox.maps.renderer.egl.EGLCore
 import com.mapbox.maps.renderer.widget.Widget
-import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CopyOnWriteArraySet
 import javax.microedition.khronos.egl.EGLContext
 import javax.microedition.khronos.egl.EGLSurface
 
@@ -19,7 +19,7 @@ internal class MapboxWidgetRenderer(
   private val textures = intArrayOf(0)
   private val framebuffers = intArrayOf(0)
 
-  private val widgets = CopyOnWriteArrayList<Widget>()
+  private val widgets = CopyOnWriteArraySet<Widget>()
 
   private var width = 0
   private var height = 0


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

<!-- https://mapbox.atlassian.net/browse/MAPSMBL-148 -->

### Summary of changes

Fix concurrent modification exception when using OpenGL ES widgets (e.g. for Android Auto case).

Fixes https://github.com/mapbox/mapbox-maps-android/issues/1596

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
