### PR TITLE
[Experimental] Allow animations to be started from a background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Features ✨ and improvements 🏁
 * Introduce a callback to be invoked when the device compass sensors need to be re-calibrated. ([1513](https://github.com/mapbox/mapbox-maps-android/pull/1513))
 * Add support for `LocationComponentSettingsInterface.pulsingMaxRadius` to follow location's accuracy radius. ([1561](https://github.com/mapbox/mapbox-maps-android/pull/1561))
+* Add experimental api to start animations from a background thread. Start animations with the `CameraAnimationsPlugin.post` function. Background thread animations is enabled with a Manifest metadata entry of `com.mapbox.maps.BackgroundAnimatorThread` and corresponding true value. This is needed for Xiaomi devices to process animations when using Android Auto. ([1605](https://github.com/mapbox/mapbox-maps-android/pull/1605)).
  
 ## Bug fixes 🐞
 * Support altitude interpolation in location component, and pass through GPS altitude information from the DefaultLocationProvider. ([1478](https://github.com/mapbox/mapbox-maps-android/pull/1478))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Mapbox welcomes participation and contributions from everyone.
 # main
+* Add experimental api to start animations from a background thread. Start animations with the `CameraAnimationsPlugin.post` function. Background thread animations is enabled with a Manifest metadata entry of `com.mapbox.maps.BackgroundAnimatorThread` and corresponding true value. This is needed for Xiaomi devices to process animations when using Android Auto. ([1605](https://github.com/mapbox/mapbox-maps-android/pull/1605)).
 
 # 10.8.0-rc.1
 ## Features ✨ and improvements 🏁
@@ -15,8 +16,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Features ✨ and improvements 🏁
 * Introduce a callback to be invoked when the device compass sensors need to be re-calibrated. ([1513](https://github.com/mapbox/mapbox-maps-android/pull/1513))
 * Add support for `LocationComponentSettingsInterface.pulsingMaxRadius` to follow location's accuracy radius. ([1561](https://github.com/mapbox/mapbox-maps-android/pull/1561))
-* Add experimental api to start animations from a background thread. Start animations with the `CameraAnimationsPlugin.post` function. Background thread animations is enabled with a Manifest metadata entry of `com.mapbox.maps.BackgroundAnimatorThread` and corresponding true value. This is needed for Xiaomi devices to process animations when using Android Auto. ([1605](https://github.com/mapbox/mapbox-maps-android/pull/1605)).
- 
+
 ## Bug fixes 🐞
 * Support altitude interpolation in location component, and pass through GPS altitude information from the DefaultLocationProvider. ([1478](https://github.com/mapbox/mapbox-maps-android/pull/1478))
 * Fix edge cases for renderer that could result in map not rendered. ([1538](https://github.com/mapbox/mapbox-maps-android/pull/1538))

--- a/android-auto-app/src/main/AndroidManifest.xml
+++ b/android-auto-app/src/main/AndroidManifest.xml
@@ -38,6 +38,14 @@
             android:value="1"
             tools:ignore="MetadataTagInsideApplicationTag" />
 
+        <meta-data
+            android:name="com.mapbox.maps.ThreadChecker"
+            android:value="false" />
+
+        <meta-data
+            android:name="com.mapbox.maps.BackgroundAnimatorThread"
+            android:value="true" />
+
         <service
             android:name=".service.MapboxCarAppService"
             android:exported="true"

--- a/plugin-animation/api/metalava.txt
+++ b/plugin-animation/api/metalava.txt
@@ -138,3 +138,15 @@ package com.mapbox.maps.plugin.animation.animator {
 
 }
 
+package com.mapbox.maps.plugin.animation.threads {
+
+  @com.mapbox.maps.MapboxExperimental public final class MapboxAnimatorThread {
+    ctor public MapboxAnimatorThread();
+    method public void onAttached();
+    method public void onDetached();
+    method public boolean post(Runnable runnable);
+    method public boolean postMain(Runnable runnable);
+  }
+
+}
+

--- a/plugin-animation/api/metalava.txt
+++ b/plugin-animation/api/metalava.txt
@@ -24,11 +24,13 @@ package com.mapbox.maps.plugin.animation {
     method public com.mapbox.maps.ScreenCoordinate? getAnchor();
     method public com.mapbox.maps.plugin.animation.CameraAnimatorsFactory getCameraAnimationsFactory();
     method public boolean getDebugMode();
+    method public void initialize();
     method public com.mapbox.maps.plugin.animation.Cancelable moveBy(com.mapbox.maps.ScreenCoordinate screenCoordinate, com.mapbox.maps.plugin.animation.MapAnimationOptions? animationOptions);
     method public void onDelegateProvider(com.mapbox.maps.plugin.delegates.MapDelegateProvider delegateProvider);
     method public com.mapbox.maps.plugin.animation.Cancelable pitchBy(double pitch, com.mapbox.maps.plugin.animation.MapAnimationOptions? animationOptions);
     method public void playAnimatorsSequentially(android.animation.ValueAnimator... animators);
     method public void playAnimatorsTogether(android.animation.ValueAnimator... animators);
+    method @com.mapbox.maps.MapboxExperimental public boolean post(Runnable runnable);
     method public void registerAnimators(android.animation.ValueAnimator... cameraAnimators);
     method public void removeCameraAnchorChangeListener(com.mapbox.maps.plugin.animation.CameraAnimatorNullableChangeListener<com.mapbox.maps.ScreenCoordinate> listener);
     method public void removeCameraAnimationsLifecycleListener(com.mapbox.maps.plugin.animation.CameraAnimationsLifecycleListener listener);

--- a/plugin-animation/api/plugin-animation.api
+++ b/plugin-animation/api/plugin-animation.api
@@ -29,6 +29,7 @@ public final class com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl :
 	public fun pitchBy (DLcom/mapbox/maps/plugin/animation/MapAnimationOptions;)Lcom/mapbox/maps/plugin/animation/Cancelable;
 	public fun playAnimatorsSequentially ([Landroid/animation/ValueAnimator;)V
 	public fun playAnimatorsTogether ([Landroid/animation/ValueAnimator;)V
+	public fun post (Ljava/lang/Runnable;)Z
 	public fun registerAnimators ([Landroid/animation/ValueAnimator;)V
 	public fun removeCameraAnchorChangeListener (Lcom/mapbox/maps/plugin/animation/CameraAnimatorNullableChangeListener;)V
 	public fun removeCameraAnimationsLifecycleListener (Lcom/mapbox/maps/plugin/animation/CameraAnimationsLifecycleListener;)V

--- a/plugin-animation/api/plugin-animation.api
+++ b/plugin-animation/api/plugin-animation.api
@@ -122,3 +122,11 @@ public final class com/mapbox/maps/plugin/animation/animator/Evaluators {
 	public final fun getSCREEN_COORDINATE ()Landroid/animation/TypeEvaluator;
 }
 
+public final class com/mapbox/maps/plugin/animation/threads/MapboxAnimatorThread {
+	public fun <init> ()V
+	public final fun onAttached ()V
+	public final fun onDetached ()V
+	public final fun post (Ljava/lang/Runnable;)Z
+	public final fun postMain (Ljava/lang/Runnable;)Z
+}
+

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -11,6 +11,7 @@ import androidx.annotation.VisibleForTesting.PRIVATE
 import com.mapbox.geojson.Point
 import com.mapbox.maps.*
 import com.mapbox.maps.plugin.animation.animator.*
+import com.mapbox.maps.plugin.animation.threads.MapboxAnimatorThread
 import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.util.MathUtils
 import java.util.concurrent.CopyOnWriteArraySet

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -282,7 +282,9 @@ class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
           lifecycleListeners.forEach {
             it.onAnimatorStarting(type, this, owner)
           }
-          mapTransformDelegate.setUserAnimationInProgress(true)
+          animatorThread.postMain {
+            mapTransformDelegate.setUserAnimationInProgress(true)
+          }
           // check if such animation is not running already
           // if it is - then cancel it
           // Safely iterate over new set because of the possible changes of "this.animators" in Animator callbacks
@@ -337,7 +339,9 @@ class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
             unregisterAnimators(this, cancelAnimators = false)
           }
           if (runningAnimatorsQueue.isEmpty()) {
-            mapTransformDelegate.setUserAnimationInProgress(false)
+            animatorThread.postMain {
+              mapTransformDelegate.setUserAnimationInProgress(true)
+            }
           }
           lifecycleListeners.forEach {
             when (finishStatus) {

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/AndroidManifestMetaData.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/AndroidManifestMetaData.kt
@@ -1,0 +1,34 @@
+package com.mapbox.maps.plugin.animation.threads
+
+import android.content.pm.PackageManager
+import android.os.Bundle
+import com.mapbox.common.MapboxSDKCommon
+
+/**
+ * The [PackageManager] has issues being mocked. This class makes it so usages of the package
+ * meta data can be tested without mocking the application info metadata.
+ *
+ * https://github.com/mockk/mockk/issues/182
+ */
+internal class AndroidManifestMetaData {
+
+  private fun metaData(): Bundle {
+    val context = MapboxSDKCommon.getContext()
+    val packageManager: PackageManager = context.packageManager
+    return packageManager.getApplicationInfo(
+      context.packageName, PackageManager.GET_META_DATA
+    ).metaData
+  }
+
+  /**
+   * Perform manifest metadata lookup for boolean value of
+   * com.mapbox.maps.BackgroundAnimatorThread. Returns false by default.
+   */
+  fun backgroundAnimatorThreadEnabled(): Boolean {
+    return metaData().getBoolean(BACKGROUND_ANIMATOR_THREAD_KEY, false)
+  }
+
+  private companion object {
+    private const val BACKGROUND_ANIMATOR_THREAD_KEY = "com.mapbox.maps.BackgroundAnimatorThread"
+  }
+}

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/AnimatorThread.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/AnimatorThread.kt
@@ -1,0 +1,22 @@
+package com.mapbox.maps.plugin.animation.threads
+
+import android.os.Handler
+import android.os.Looper
+import androidx.annotation.VisibleForTesting
+
+internal interface AnimatorThread {
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  val handler: Handler?
+
+  fun onAttached(): AnimatorThread
+  fun onDetached()
+
+  fun post(runnable: Runnable): Boolean {
+    return if (Looper.myLooper() == handler?.looper) {
+      runnable.run()
+      true
+    } else {
+      handler?.post(runnable) ?: false
+    }
+  }
+}

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/BackgroundAnimatorThread.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/BackgroundAnimatorThread.kt
@@ -1,0 +1,28 @@
+package com.mapbox.maps.plugin.animation.threads
+
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Process
+import java.util.*
+
+internal class BackgroundAnimatorThread : AnimatorThread {
+  private val threadName = "animation_thread_${UUID.randomUUID()}"
+  private var handlerThread: HandlerThread = HandlerThread(
+    threadName,
+    Process.THREAD_PRIORITY_FOREGROUND
+  )
+
+  override var handler: Handler? = null
+    private set
+
+  override fun onAttached() = apply {
+    handlerThread.start()
+    handler = Handler(handlerThread.looper)
+  }
+
+  override fun onDetached() {
+    handler?.removeCallbacksAndMessages(null)
+    handlerThread.quitSafely()
+    handler = null
+  }
+}

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/MainAnimatorThread.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/MainAnimatorThread.kt
@@ -1,0 +1,18 @@
+package com.mapbox.maps.plugin.animation.threads
+
+import android.os.Handler
+import android.os.Looper
+
+internal class MainAnimatorThread : AnimatorThread {
+  override var handler: Handler? = null
+    private set
+
+  override fun onAttached() = apply {
+    handler = Handler(Looper.getMainLooper())
+  }
+
+  override fun onDetached() {
+    handler?.removeCallbacksAndMessages(null)
+    handler = null
+  }
+}

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/MapboxAnimatorThread.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/threads/MapboxAnimatorThread.kt
@@ -1,17 +1,10 @@
-package com.mapbox.maps.plugin.animation
+package com.mapbox.maps.plugin.animation.threads
 
 import android.animation.Animator
-import android.content.pm.PackageManager
-import android.os.Bundle
-import android.os.Handler
-import android.os.HandlerThread
 import android.os.Looper
-import android.os.Process
 import androidx.annotation.VisibleForTesting
-import com.mapbox.common.MapboxSDKCommon
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.logW
-import java.util.*
 
 /**
  * Allows you to run animations on a background thread.
@@ -96,89 +89,5 @@ class MapboxAnimatorThread {
 
   private companion object {
     private const val TAG = "MapboxAnimatorThread"
-  }
-}
-
-/**
- * The [PackageManager] has issues being mocked. This class makes it so usages of the package
- * meta data can be tested without mocking the application info metadata.
- *
- * https://github.com/mockk/mockk/issues/182
- */
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-internal class AndroidManifestMetaData {
-
-  private fun metaData(): Bundle {
-    val context = MapboxSDKCommon.getContext()
-    val packageManager: PackageManager = context.packageManager
-    return packageManager.getApplicationInfo(
-      context.packageName,
-      PackageManager.GET_META_DATA
-    ).metaData
-  }
-
-  /**
-   * Perform manifest metadata lookup for boolean value of
-   * com.mapbox.maps.BackgroundAnimatorThread. Returns false by default.
-   */
-  fun backgroundAnimatorThreadEnabled(): Boolean {
-    return metaData().getBoolean(BACKGROUND_ANIMATOR_THREAD_KEY, false)
-  }
-
-  private companion object {
-    private const val BACKGROUND_ANIMATOR_THREAD_KEY = "com.mapbox.maps.BackgroundAnimatorThread"
-  }
-}
-
-private interface AnimatorThread {
-  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-  val handler: Handler?
-
-  fun onAttached(): AnimatorThread
-  fun onDetached()
-
-  fun post(runnable: Runnable): Boolean {
-    return if (Looper.myLooper() == handler?.looper) {
-      runnable.run()
-      true
-    } else {
-      handler?.post(runnable) ?: false
-    }
-  }
-}
-
-private class BackgroundAnimatorThread : AnimatorThread {
-  private val threadName = "animation_thread_${UUID.randomUUID()}"
-  private var handlerThread: HandlerThread = HandlerThread(
-    threadName,
-    Process.THREAD_PRIORITY_DISPLAY
-  )
-
-  override var handler: Handler? = null
-    private set
-
-  override fun onAttached() = apply {
-    handlerThread.start()
-    handler = Handler(handlerThread.looper)
-  }
-
-  override fun onDetached() {
-    handler?.removeCallbacksAndMessages(null)
-    handlerThread.quitSafely()
-    handler = null
-  }
-}
-
-private class MainAnimatorThread : AnimatorThread {
-  override var handler: Handler? = null
-    private set
-
-  override fun onAttached() = apply {
-    handler = Handler(Looper.getMainLooper())
-  }
-
-  override fun onDetached() {
-    handler?.removeCallbacksAndMessages(null)
-    handler = null
   }
 }

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -85,6 +85,7 @@ class CameraAnimationsPluginImplTest {
     every { delegateProvider.mapTransformDelegate } returns mapTransformDelegate
     cameraAnimationsPluginImpl = CameraAnimationsPluginImpl().apply {
       onDelegateProvider(delegateProvider)
+      initialize()
     }
   }
 

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/threads/MapboxAnimatorThreadTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/threads/MapboxAnimatorThreadTest.kt
@@ -1,4 +1,4 @@
-package com.mapbox.maps.plugin.animation
+package com.mapbox.maps.plugin.animation.threads
 
 import android.os.Build
 import android.os.Looper

--- a/plugin-locationcomponent/build.gradle.kts
+++ b/plugin-locationcomponent/build.gradle.kts
@@ -25,6 +25,7 @@ android {
 dependencies {
   api(Dependencies.mapboxAndroidCore)
   implementation(project(":sdk-base"))
+  implementation(project(":plugin-animation"))
   implementation(Dependencies.mapboxBase)
   implementation(Dependencies.kotlin)
   implementation(Dependencies.androidxAppCompat)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
@@ -4,7 +4,7 @@ import android.animation.ValueAnimator
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import com.mapbox.geojson.Point
-import com.mapbox.maps.plugin.animation.MapboxAnimatorThread
+import com.mapbox.maps.plugin.animation.threads.MapboxAnimatorThread
 import com.mapbox.maps.plugin.locationcomponent.*
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings2

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManagerTest.kt
@@ -4,7 +4,7 @@ import android.animation.ValueAnimator
 import android.graphics.Color
 import android.os.Looper
 import com.mapbox.geojson.Point
-import com.mapbox.maps.plugin.animation.MapboxAnimatorThread
+import com.mapbox.maps.plugin.animation.threads.MapboxAnimatorThread
 import com.mapbox.maps.plugin.locationcomponent.LocationLayerRenderer
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings2

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManagerTest.kt
@@ -4,6 +4,7 @@ import android.animation.ValueAnimator
 import android.graphics.Color
 import android.os.Looper
 import com.mapbox.geojson.Point
+import com.mapbox.maps.plugin.animation.MapboxAnimatorThread
 import com.mapbox.maps.plugin.locationcomponent.LocationLayerRenderer
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettings2
@@ -34,6 +35,12 @@ class PuckAnimatorManagerTest {
     PuckAccuracyRadiusAnimator(mockk(relaxUnitFun = true))
   private val pulsingAnimator: PuckPulsingAnimator = mockk(relaxed = true)
   private val pixelRatio: Float = 1.0f
+  private val animatorThread: MapboxAnimatorThread = mockk(relaxed = true) {
+    every { post(any()) } answers {
+      firstArg<Runnable>().run()
+      true
+    }
+  }
 
   @Before
   fun setUp() {
@@ -45,7 +52,8 @@ class PuckAnimatorManagerTest {
       positionAnimator,
       pulsingAnimator,
       accuracyRadiusAnimator,
-      pixelRatio
+      pixelRatio,
+      animatorThread
     )
   }
 

--- a/sdk-base/api/metalava.txt
+++ b/sdk-base/api/metalava.txt
@@ -861,14 +861,6 @@ package com.mapbox.maps.plugin.animation {
     field public static final String LOCATION = "Maps-Location";
   }
 
-  @com.mapbox.maps.MapboxExperimental public final class MapboxAnimatorThread {
-    ctor public MapboxAnimatorThread();
-    method public void onAttached();
-    method public void onDetached();
-    method public boolean post(Runnable runnable);
-    method public boolean postMain(Runnable runnable);
-  }
-
 }
 
 package com.mapbox.maps.plugin.annotation {

--- a/sdk-base/api/metalava.txt
+++ b/sdk-base/api/metalava.txt
@@ -866,6 +866,7 @@ package com.mapbox.maps.plugin.animation {
     method public void onAttached();
     method public void onDetached();
     method public boolean post(Runnable runnable);
+    method public boolean postMain(Runnable runnable);
   }
 
 }

--- a/sdk-base/api/metalava.txt
+++ b/sdk-base/api/metalava.txt
@@ -763,6 +763,7 @@ package com.mapbox.maps.plugin.animation {
     method public com.mapbox.maps.plugin.animation.Cancelable pitchBy(double pitch, com.mapbox.maps.plugin.animation.MapAnimationOptions? animationOptions = null);
     method public void playAnimatorsSequentially(android.animation.ValueAnimator... animators);
     method public void playAnimatorsTogether(android.animation.ValueAnimator... animators);
+    method @com.mapbox.maps.MapboxExperimental public boolean post(Runnable runnable);
     method public void registerAnimators(android.animation.ValueAnimator... cameraAnimators);
     method public void removeCameraAnchorChangeListener(com.mapbox.maps.plugin.animation.CameraAnimatorNullableChangeListener<com.mapbox.maps.ScreenCoordinate> listener);
     method public void removeCameraAnimationsLifecycleListener(com.mapbox.maps.plugin.animation.CameraAnimationsLifecycleListener listener);
@@ -858,6 +859,13 @@ package com.mapbox.maps.plugin.animation {
     field public static final com.mapbox.maps.plugin.animation.MapAnimationOwnerRegistry INSTANCE;
     field public static final String INTERNAL = "Maps-CameraInternal";
     field public static final String LOCATION = "Maps-Location";
+  }
+
+  @com.mapbox.maps.MapboxExperimental public final class MapboxAnimatorThread {
+    ctor public MapboxAnimatorThread();
+    method public void onAttached();
+    method public void onDetached();
+    method public boolean post(Runnable runnable);
   }
 
 }

--- a/sdk-base/api/sdk-base.api
+++ b/sdk-base/api/sdk-base.api
@@ -772,6 +772,7 @@ public abstract interface class com/mapbox/maps/plugin/animation/CameraAnimation
 	public abstract fun pitchBy (DLcom/mapbox/maps/plugin/animation/MapAnimationOptions;)Lcom/mapbox/maps/plugin/animation/Cancelable;
 	public abstract fun playAnimatorsSequentially ([Landroid/animation/ValueAnimator;)V
 	public abstract fun playAnimatorsTogether ([Landroid/animation/ValueAnimator;)V
+	public abstract fun post (Ljava/lang/Runnable;)Z
 	public abstract fun registerAnimators ([Landroid/animation/ValueAnimator;)V
 	public abstract fun removeCameraAnchorChangeListener (Lcom/mapbox/maps/plugin/animation/CameraAnimatorNullableChangeListener;)V
 	public abstract fun removeCameraAnimationsLifecycleListener (Lcom/mapbox/maps/plugin/animation/CameraAnimationsLifecycleListener;)V
@@ -885,6 +886,13 @@ public final class com/mapbox/maps/plugin/animation/MapAnimationOwnerRegistry {
 	public static final field INSTANCE Lcom/mapbox/maps/plugin/animation/MapAnimationOwnerRegistry;
 	public static final field INTERNAL Ljava/lang/String;
 	public static final field LOCATION Ljava/lang/String;
+}
+
+public final class com/mapbox/maps/plugin/animation/MapboxAnimatorThread {
+	public fun <init> ()V
+	public final fun onAttached ()V
+	public final fun onDetached ()V
+	public final fun post (Ljava/lang/Runnable;)Z
 }
 
 public abstract class com/mapbox/maps/plugin/annotation/Annotation {

--- a/sdk-base/api/sdk-base.api
+++ b/sdk-base/api/sdk-base.api
@@ -893,6 +893,7 @@ public final class com/mapbox/maps/plugin/animation/MapboxAnimatorThread {
 	public final fun onAttached ()V
 	public final fun onDetached ()V
 	public final fun post (Ljava/lang/Runnable;)Z
+	public final fun postMain (Ljava/lang/Runnable;)Z
 }
 
 public abstract class com/mapbox/maps/plugin/annotation/Annotation {

--- a/sdk-base/api/sdk-base.api
+++ b/sdk-base/api/sdk-base.api
@@ -888,14 +888,6 @@ public final class com/mapbox/maps/plugin/animation/MapAnimationOwnerRegistry {
 	public static final field LOCATION Ljava/lang/String;
 }
 
-public final class com/mapbox/maps/plugin/animation/MapboxAnimatorThread {
-	public fun <init> ()V
-	public final fun onAttached ()V
-	public final fun onDetached ()V
-	public final fun post (Ljava/lang/Runnable;)Z
-	public final fun postMain (Ljava/lang/Runnable;)Z
-}
-
 public abstract class com/mapbox/maps/plugin/annotation/Annotation {
 	public static final field Companion Lcom/mapbox/maps/plugin/annotation/Annotation$Companion;
 	public static final field ID_DATA Ljava/lang/String;

--- a/sdk-base/build.gradle.kts
+++ b/sdk-base/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   testImplementation(Dependencies.mockk)
   testImplementation(Dependencies.androidxTestCore)
   testImplementation(Dependencies.equalsVerifier)
+  testImplementation(Dependencies.robolectric)
   detektPlugins(Dependencies.detektFormatting)
 }
 

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPlugin.kt
@@ -4,6 +4,7 @@ import android.animation.ValueAnimator
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.plugin.MapPlugin
 
@@ -325,4 +326,18 @@ interface CameraAnimationsPlugin : MapPlugin {
    * @param animators Variable number of [ValueAnimator]'s
    */
   fun playAnimatorsSequentially(vararg animators: ValueAnimator)
+
+  /**
+   * Animations may need to run on a background thread. Use this to call [Animator.start] to
+   * ensure the animations are called on the animation thread.
+   *
+   * The thread for animations can be specified in the AndroidManifest.xml.
+   * ``` xml
+   *  <meta-data
+   *    android:name="com.mapbox.maps.BackgroundAnimatorThread"
+   *    android:value="true" />
+   * ```
+   */
+  @MapboxExperimental
+  fun post(runnable: Runnable): Boolean
 }

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/MapboxAnimatorThread.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/MapboxAnimatorThread.kt
@@ -1,0 +1,133 @@
+package com.mapbox.maps.plugin.animation
+
+import android.animation.Animator
+import android.content.pm.PackageManager
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.os.Process
+import com.mapbox.common.MapboxSDKCommon
+import com.mapbox.maps.MapboxExperimental
+import com.mapbox.maps.logD
+import java.util.*
+
+/**
+ * Allows you to run animations on a background thread.
+ *
+ *  ```xml
+ *  <meta-data
+ *    android:name="com.mapbox.maps.BackgroundAnimatorThread"
+ *    android:value="true" />
+ * ```
+ */
+@MapboxExperimental
+class MapboxAnimatorThread {
+  private val animatorThread: AnimatorThread by lazy {
+    if (backgroundAnimatorThreadEnabled()) {
+      BackgroundAnimatorThread()
+    } else {
+      MainAnimatorThread()
+    }
+  }
+
+  fun onAttached() {
+    animatorThread.onAttached()
+  }
+
+  /**
+   * Allows you to post any job onto the animator thread. This can be used to trigger animations
+   * that may not be using the [Animator].
+   */
+  fun post(runnable: Runnable): Boolean {
+    return animatorThread.post(runnable)
+  }
+
+  fun onDetached() {
+    animatorThread.onDetached()
+  }
+
+  private companion object {
+    private const val METADATA_KEY = "com.mapbox.maps.BackgroundAnimatorThread"
+
+    /**
+     * Perform manifest metadata lookup for boolean value of
+     * com.mapbox.maps.BackgroundAnimatorThread. Returns false by default.
+     */
+    private fun backgroundAnimatorThreadEnabled(): Boolean {
+      val context = MapboxSDKCommon.getContext()
+      val packageManager: PackageManager = context.packageManager
+      val appInfo = packageManager.getApplicationInfo(
+        context.packageName,
+        PackageManager.GET_META_DATA
+      )
+
+      val metaData = appInfo.metaData
+      return metaData.getBoolean(METADATA_KEY, false)
+    }
+  }
+}
+
+private interface AnimatorThread {
+  fun onAttached()
+  fun post(runnable: Runnable): Boolean
+  fun onDetached()
+}
+
+private class BackgroundAnimatorThread : AnimatorThread {
+  private val event: Any = Object()
+  private val threadName by lazy {
+    "animation_thread_${UUID.randomUUID()}"
+  }
+
+  private var startTime = 0L
+  private var isRunning = false
+  private var handlerThread: HandlerThread? = null
+  private var handler: Handler? = null
+
+  override fun onAttached() {
+    logD(TAG, "onAttached thread $threadName")
+    isRunning = true
+    startTime = System.nanoTime()
+    handlerThread = HandlerThread(threadName, Process.THREAD_PRIORITY_DISPLAY).apply {
+      start()
+      handler = Handler(this.looper)
+    }
+  }
+
+  override fun post(runnable: Runnable): Boolean {
+    return handler?.post(runnable) ?: false
+  }
+
+  override fun onDetached() {
+    handler?.removeCallbacksAndMessages(event)
+    handlerThread?.quitSafely()
+    handler = null
+    isRunning = false
+    logD(TAG, "onDetached thread $threadName")
+  }
+
+  private companion object {
+    private const val TAG = "BackgroundAnimatorThread"
+  }
+}
+
+private class MainAnimatorThread : AnimatorThread {
+  private var mainThreadHandler: Handler? = null
+
+  override fun onAttached() {
+    mainThreadHandler = Handler(Looper.getMainLooper())
+  }
+
+  override fun post(runnable: Runnable): Boolean {
+    return if (mainThreadHandler != null && Looper.myLooper() == Looper.getMainLooper()) {
+      runnable.run()
+      true
+    } else {
+      mainThreadHandler?.post(runnable) ?: false
+    }
+  }
+
+  override fun onDetached() {
+    mainThreadHandler = null
+  }
+}

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/MapboxAnimatorThread.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/animation/MapboxAnimatorThread.kt
@@ -2,13 +2,15 @@ package com.mapbox.maps.plugin.animation
 
 import android.animation.Animator
 import android.content.pm.PackageManager
+import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
 import android.os.Process
+import androidx.annotation.VisibleForTesting
 import com.mapbox.common.MapboxSDKCommon
 import com.mapbox.maps.MapboxExperimental
-import com.mapbox.maps.logD
+import com.mapbox.maps.logW
 import java.util.*
 
 /**
@@ -22,112 +24,161 @@ import java.util.*
  */
 @MapboxExperimental
 class MapboxAnimatorThread {
-  private val animatorThread: AnimatorThread by lazy {
-    if (backgroundAnimatorThreadEnabled()) {
-      BackgroundAnimatorThread()
-    } else {
-      MainAnimatorThread()
-    }
+  constructor() : this(AndroidManifestMetaData())
+
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  internal constructor(manifestMetaData: AndroidManifestMetaData) {
+    this.manifestMetaData = manifestMetaData
   }
 
+  private val manifestMetaData: AndroidManifestMetaData
+  private val mainAnimatorThread: MainAnimatorThread = MainAnimatorThread()
+  private var backgroundAnimatorThread: BackgroundAnimatorThread? = null
+
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  internal val backgroundLooper: Looper?
+    get() = backgroundAnimatorThread?.handler?.looper
+
+  /**
+   * The beginning of the animator thread lifecycle. This will create resources for running
+   * animator threads.
+   */
   fun onAttached() {
-    animatorThread.onAttached()
+    mainAnimatorThread.onAttached()
+    if (manifestMetaData.backgroundAnimatorThreadEnabled()) {
+      backgroundAnimatorThread = BackgroundAnimatorThread().onAttached()
+    }
   }
 
   /**
    * Allows you to post any job onto the animator thread. This can be used to trigger animations
    * that may not be using the [Animator].
+   *
+   * Run immediate if my looper is the designated looper, otherwise post the work to a handler
+   * queue. This is to reduce thread context switches while running animations.
    */
   fun post(runnable: Runnable): Boolean {
-    return animatorThread.post(runnable)
+    return (backgroundAnimatorThread ?: mainAnimatorThread).post(runnable).also { posted ->
+      if (!posted) {
+        logW(
+          TAG,
+          "post did not happen, ensure the app is in foreground. background  animator " +
+            "thread: ${backgroundAnimatorThread != null}"
+        )
+      }
+    }
   }
 
+  /**
+   * Mapbox gl-native libraries require the main thread. Use this function whenever an animation
+   * task should be posted on the main thread, even when background threads are enabled.
+   *
+   * Run immediate if my looper is the designated looper, otherwise post the work to a handler
+   * queue. This is to reduce thread context switches while running animations.
+   */
+  fun postMain(runnable: Runnable): Boolean {
+    return mainAnimatorThread.post(runnable).also { posted ->
+      if (!posted) {
+        logW(TAG, "postMain did not happen, ensure the app is in foreground")
+      }
+    }
+  }
+
+  /**
+   * The beginning of the animator thread lifecycle. This will create resources for running
+   * animator threads.
+   */
   fun onDetached() {
-    animatorThread.onDetached()
+    mainAnimatorThread.onDetached()
+    backgroundAnimatorThread?.onDetached()
+    backgroundAnimatorThread = null
   }
 
   private companion object {
-    private const val METADATA_KEY = "com.mapbox.maps.BackgroundAnimatorThread"
+    private const val TAG = "MapboxAnimatorThread"
+  }
+}
 
-    /**
-     * Perform manifest metadata lookup for boolean value of
-     * com.mapbox.maps.BackgroundAnimatorThread. Returns false by default.
-     */
-    private fun backgroundAnimatorThreadEnabled(): Boolean {
-      val context = MapboxSDKCommon.getContext()
-      val packageManager: PackageManager = context.packageManager
-      val appInfo = packageManager.getApplicationInfo(
-        context.packageName,
-        PackageManager.GET_META_DATA
-      )
+/**
+ * The [PackageManager] has issues being mocked. This class makes it so usages of the package
+ * meta data can be tested without mocking the application info metadata.
+ *
+ * https://github.com/mockk/mockk/issues/182
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+internal class AndroidManifestMetaData {
 
-      val metaData = appInfo.metaData
-      return metaData.getBoolean(METADATA_KEY, false)
-    }
+  private fun metaData(): Bundle {
+    val context = MapboxSDKCommon.getContext()
+    val packageManager: PackageManager = context.packageManager
+    return packageManager.getApplicationInfo(
+      context.packageName,
+      PackageManager.GET_META_DATA
+    ).metaData
+  }
+
+  /**
+   * Perform manifest metadata lookup for boolean value of
+   * com.mapbox.maps.BackgroundAnimatorThread. Returns false by default.
+   */
+  fun backgroundAnimatorThreadEnabled(): Boolean {
+    return metaData().getBoolean(BACKGROUND_ANIMATOR_THREAD_KEY, false)
+  }
+
+  private companion object {
+    private const val BACKGROUND_ANIMATOR_THREAD_KEY = "com.mapbox.maps.BackgroundAnimatorThread"
   }
 }
 
 private interface AnimatorThread {
-  fun onAttached()
-  fun post(runnable: Runnable): Boolean
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  val handler: Handler?
+
+  fun onAttached(): AnimatorThread
   fun onDetached()
+
+  fun post(runnable: Runnable): Boolean {
+    return if (Looper.myLooper() == handler?.looper) {
+      runnable.run()
+      true
+    } else {
+      handler?.post(runnable) ?: false
+    }
+  }
 }
 
 private class BackgroundAnimatorThread : AnimatorThread {
-  private val event: Any = Object()
-  private val threadName by lazy {
-    "animation_thread_${UUID.randomUUID()}"
-  }
+  private val threadName = "animation_thread_${UUID.randomUUID()}"
+  private var handlerThread: HandlerThread = HandlerThread(
+    threadName,
+    Process.THREAD_PRIORITY_DISPLAY
+  )
 
-  private var startTime = 0L
-  private var isRunning = false
-  private var handlerThread: HandlerThread? = null
-  private var handler: Handler? = null
+  override var handler: Handler? = null
+    private set
 
-  override fun onAttached() {
-    logD(TAG, "onAttached thread $threadName")
-    isRunning = true
-    startTime = System.nanoTime()
-    handlerThread = HandlerThread(threadName, Process.THREAD_PRIORITY_DISPLAY).apply {
-      start()
-      handler = Handler(this.looper)
-    }
-  }
-
-  override fun post(runnable: Runnable): Boolean {
-    return handler?.post(runnable) ?: false
+  override fun onAttached() = apply {
+    handlerThread.start()
+    handler = Handler(handlerThread.looper)
   }
 
   override fun onDetached() {
-    handler?.removeCallbacksAndMessages(event)
-    handlerThread?.quitSafely()
+    handler?.removeCallbacksAndMessages(null)
+    handlerThread.quitSafely()
     handler = null
-    isRunning = false
-    logD(TAG, "onDetached thread $threadName")
-  }
-
-  private companion object {
-    private const val TAG = "BackgroundAnimatorThread"
   }
 }
 
 private class MainAnimatorThread : AnimatorThread {
-  private var mainThreadHandler: Handler? = null
+  override var handler: Handler? = null
+    private set
 
-  override fun onAttached() {
-    mainThreadHandler = Handler(Looper.getMainLooper())
-  }
-
-  override fun post(runnable: Runnable): Boolean {
-    return if (mainThreadHandler != null && Looper.myLooper() == Looper.getMainLooper()) {
-      runnable.run()
-      true
-    } else {
-      mainThreadHandler?.post(runnable) ?: false
-    }
+  override fun onAttached() = apply {
+    handler = Handler(Looper.getMainLooper())
   }
 
   override fun onDetached() {
-    mainThreadHandler = null
+    handler?.removeCallbacksAndMessages(null)
+    handler = null
   }
 }

--- a/sdk-base/src/test/java/com/mapbox/maps/plugin/animation/MapboxAnimatorThreadTest.kt
+++ b/sdk-base/src/test/java/com/mapbox/maps/plugin/animation/MapboxAnimatorThreadTest.kt
@@ -1,0 +1,171 @@
+package com.mapbox.maps.plugin.animation
+
+import android.os.Build
+import android.os.Looper
+import android.os.Looper.getMainLooper
+import com.mapbox.common.MapboxSDKCommon
+import com.mapbox.maps.MapboxExperimental
+import com.mapbox.maps.logW
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@OptIn(MapboxExperimental::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+@LooperMode(LooperMode.Mode.PAUSED)
+class MapboxAnimatorThreadTest {
+
+  // All tests will keep track of the looper that was used for the runnable.
+  private val looperSlot = mutableListOf<Looper?>()
+  private val runnable = mockk<Runnable> {
+    every { run() } answers {
+      looperSlot.add(Looper.myLooper())
+    }
+  }
+
+  private val manifestMetaData: AndroidManifestMetaData = mockk()
+  private val mapboxAnimatorThread = MapboxAnimatorThread(manifestMetaData)
+
+  @Before
+  fun setup() {
+    mockkObject(MapboxSDKCommon)
+    mockkStatic("com.mapbox.maps.MapboxLogger")
+    every { logW(any(), any()) } just Runs
+  }
+
+  @After
+  fun teardown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `should run post on main looper by default`() {
+    every { manifestMetaData.backgroundAnimatorThreadEnabled() } returns false
+    val mapboxAnimatorThread = MapboxAnimatorThread(manifestMetaData)
+
+    mapboxAnimatorThread.onAttached()
+    val posted = mapboxAnimatorThread.post(runnable)
+
+    assertTrue(posted)
+    assertEquals(1, looperSlot.size)
+    assertEquals(getMainLooper(), looperSlot[0])
+  }
+
+  @Test
+  fun `should run post on background looper when metadata is enabled`() {
+    every { manifestMetaData.backgroundAnimatorThreadEnabled() } returns true
+
+    mapboxAnimatorThread.onAttached()
+    val posted = mapboxAnimatorThread.post(runnable)
+    shadowOf(mapboxAnimatorThread.backgroundLooper).idle()
+
+    assertTrue(posted)
+    assertEquals(1, looperSlot.size)
+    assertEquals(mapboxAnimatorThread.backgroundLooper, looperSlot[0])
+  }
+
+  @Test
+  fun `should not post when animator thread is not attached`() {
+    every { manifestMetaData.backgroundAnimatorThreadEnabled() } returns true
+
+    val posted = mapboxAnimatorThread.post(runnable)
+    val postedMain = mapboxAnimatorThread.postMain(runnable)
+
+    assertFalse(posted)
+    assertFalse(postedMain)
+    shadowOf(getMainLooper()).idle()
+    assertTrue(looperSlot.isEmpty())
+  }
+
+  @Test
+  fun `should run immediately when called from the main looper`() {
+    every { manifestMetaData.backgroundAnimatorThreadEnabled() } returns false
+
+    mapboxAnimatorThread.onAttached()
+    val posted = mapboxAnimatorThread.postMain(runnable)
+    assertTrue(posted)
+
+    assertEquals(1, looperSlot.size)
+    assertEquals(getMainLooper(), looperSlot[0])
+  }
+
+  @Test
+  fun `should run immediately when called from the background looper`() {
+    every { manifestMetaData.backgroundAnimatorThreadEnabled() } returns true
+
+    mapboxAnimatorThread.onAttached()
+    mapboxAnimatorThread.post {
+      // Run to next task will trigger this one but not the next. So this will ensure that the
+      // background thread is called in place from the same background thread.
+      mapboxAnimatorThread.post(runnable)
+      assertEquals(1, looperSlot.size)
+      assertEquals(mapboxAnimatorThread.backgroundLooper!!, looperSlot[0])
+    }
+    shadowOf(mapboxAnimatorThread.backgroundLooper!!).runToNextTask()
+  }
+
+  @Test
+  fun `should not post runnable when detached`() {
+    every { manifestMetaData.backgroundAnimatorThreadEnabled() } returns true
+
+    mapboxAnimatorThread.onAttached()
+    mapboxAnimatorThread.post(runnable)
+    mapboxAnimatorThread.onDetached()
+    mapboxAnimatorThread.post(runnable)
+
+    assertEquals(1, looperSlot.size)
+    assertNull(mapboxAnimatorThread.backgroundLooper)
+  }
+
+  @Test
+  fun `attaching and detaching will create a new background looper`() {
+    every { manifestMetaData.backgroundAnimatorThreadEnabled() } returns true
+
+    mapboxAnimatorThread.onAttached()
+    mapboxAnimatorThread.post(runnable)
+    shadowOf(mapboxAnimatorThread.backgroundLooper!!).idle()
+    mapboxAnimatorThread.onDetached()
+    mapboxAnimatorThread.onAttached()
+    mapboxAnimatorThread.post(runnable)
+    shadowOf(mapboxAnimatorThread.backgroundLooper!!).idle()
+    mapboxAnimatorThread.onDetached()
+
+    assertEquals(2, looperSlot.size)
+    assertNotEquals(looperSlot[0], looperSlot[1])
+  }
+
+  @Test
+  fun `attaching and detaching will use the same main looper`() {
+    every { manifestMetaData.backgroundAnimatorThreadEnabled() } returns false
+
+    mapboxAnimatorThread.onAttached()
+    mapboxAnimatorThread.post(runnable)
+    shadowOf(getMainLooper()).idle()
+    mapboxAnimatorThread.onDetached()
+    mapboxAnimatorThread.onAttached()
+    mapboxAnimatorThread.post(runnable)
+    shadowOf(getMainLooper()).idle()
+    mapboxAnimatorThread.onDetached()
+
+    assertEquals(2, looperSlot.size)
+    assertEquals(looperSlot[0], looperSlot[1])
+  }
+}

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -405,7 +405,17 @@ class MapboxMap :
    */
   override fun setCamera(cameraOptions: CameraOptions) {
     checkNativeMap("setCamera")
-    nativeMap.setCamera(cameraOptions)
+    try {
+      nativeMap.setCamera(cameraOptions)
+    } catch (thr: Throwable) {
+      logW(
+        TAG,
+        """
+          setCamera failed: ${thr.message}
+          This will happen when using com.mapbox.maps.BackgroundAnimatorThread 
+        """.trimIndent()
+      )
+    }
   }
 
   /**


### PR DESCRIPTION
This pull request is for communication and investigation purposes. I'm also running into enough issues that, I want to write them down somewhere.

## Issues 

https://github.com/mapbox/mapbox-maps-android/issues/1413
https://github.com/mapbox/mapbox-maps-android/issues/1556

In order to make Android Auto animations work with Xiaomi devices, all animations need to be run on a background thread. This is because the Xiaomi devices ignore the [Choreographer](https://developer.android.com/reference/android/view/Choreographer) calls when the app is in background. The CameraAnimator uses ValueAnimator, and ValueAnimator uses Choreographer.

## More issues

Mapbox has many calls that assume the UI thread, so in order to trigger the animations from a background thread there would be a bit work to ensure each call receives appropriate threads.

Here is an example where an evaluator is running on a background thread and Mapbox Maps assumes ui thread
```
2022-08-16 13:56:33.589 14515-14912/com.mapbox.maps.testapp.auto I/Mapbox: [maps-android\kyle_debug]: getFlyTo.CameraCenterAnimator.evaluator animation_thread_c8b20b45-befb-499f-8a4e-f798c442284b
2022-08-16 13:56:33.590 14515-14912/com.mapbox.maps.testapp.auto E/AndroidRuntime: FATAL EXCEPTION: animation_thread_c8b20b45-befb-499f-8a4e-f798c442284b
    Process: com.mapbox.maps.testapp.auto, PID: 14515
    com.mapbox.maps.exception.WorkerThreadException: The exception that is thrown when an application attempts to 
    perform a map operation on a worker thread.
        at com.mapbox.maps.ThreadChecker.throwIfNotMainThread(ThreadChecker.kt:88)
        at com.mapbox.maps.MapboxMap.checkNativeMap(MapboxMap.kt:1792)
        at com.mapbox.maps.MapboxMap.checkNativeMap$default(MapboxMap.kt:1790)
        at com.mapbox.maps.MapboxMap.unproject(MapboxMap.kt:950)
        at com.mapbox.maps.plugin.animation.CameraAnimatorsFactory.getFlyTo$lambda-9(CameraAnimatorsFactory.kt:377)
        at com.mapbox.maps.plugin.animation.CameraAnimatorsFactory.$r8$lambda$i0eVRz5Pdg1wufkPMzLCax34Kqw(Unknown Source:0)
        at com.mapbox.maps.plugin.animation.CameraAnimatorsFactory$$ExternalSyntheticLambda1.evaluate(Unknown Source:41)
```

## A little good news

### Before - animations break when app is backgrounded

https://user-images.githubusercontent.com/3021882/184988646-b065a503-2d67-4dcd-bf1e-f45e6e73beed.mov

### After - see it works

https://user-images.githubusercontent.com/3021882/185195971-2f86debd-c20a-4d07-817c-2bb53a464659.mov


