### PR TITLE
Fix possible crash if null touch event is delivered.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Try recreate EGL surface when it throws exception. ([1589](https://github.com/mapbox/mapbox-maps-android/pull/1589))
 * Fix `MapboxMap` extension plugin functions throwing exceptions. ([1591](https://github.com/mapbox/mapbox-maps-android/pull/1591))
 * Fix concurrent modification exception when using widgets. ([1597](https://github.com/mapbox/mapbox-maps-android/pull/1597))
+* Fix rare crash in onFling gesture detector. ([1608](https://github.com/mapbox/mapbox-maps-android/pull/1608))
 
 # 10.8.0-beta.1 August 11, 2022
 ## Features ✨ and improvements 🏁

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -416,7 +416,7 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
    * but with nullable MotionEvents since it adds NonNull annotations while its parent
    * [android.view.GestureDetector.OnGestureListener] does not have those annotations in the released
    * Android versions. Added just recently at https://android.googlesource.com/platform/frameworks/base/+/68c65e58b4f4daf79c9ffab518a826a506799db2/core/java/android/view/GestureDetector.java).
-    */
+   */
   private open class SimpleStandardOnGestureListener : StandardOnGestureListener {
     override fun onSingleTapConfirmed(motionEvent: MotionEvent?): Boolean {
       return false
@@ -523,10 +523,10 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
       velocityX: Float,
       velocityY: Float
     ): Boolean {
-      if (e1 == null || e2 == null) {
+      if (e2 == null) {
         return false
       }
-      return handleFlingEvent(e1, e2, velocityX, velocityY)
+      return handleFlingEvent(e2, velocityX, velocityY)
     }
   }
 
@@ -1334,7 +1334,6 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
   }
 
   internal fun handleFlingEvent(
-    e1: MotionEvent,
     e2: MotionEvent,
     velocityX: Float,
     velocityY: Float

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
@@ -12,7 +12,6 @@ import android.view.MotionEvent
 import android.view.MotionEvent.*
 import androidx.test.core.view.PointerCoordsBuilder
 import androidx.test.core.view.PointerPropertiesBuilder
-import com.google.common.base.CharMatcher.any
 import com.mapbox.android.gestures.*
 import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Point
@@ -59,11 +58,12 @@ class GesturesPluginTest {
   private var scaleGestureDetector: StandardScaleGestureDetector = mockk(relaxUnitFun = true)
   private var moveGestureDetector: MoveGestureDetector = mockk(relaxUnitFun = true)
 
-  private val motionEvent1 = mockk<MotionEvent>()
-  private val motionEvent2 = mockk<MotionEvent>()
+  private val motionEvent = mockk<MotionEvent>()
 
   private val typedArray: TypedArray = mockk(relaxed = true)
   private val pack = "com.mapbox.maps"
+
+  private val gestureListener = slot<StandardGestureDetector.StandardOnGestureListener>()
 
   private lateinit var presenter: GesturesPluginImpl
 
@@ -106,15 +106,18 @@ class GesturesPluginTest {
       StylePropertyValueKind.CONSTANT
     )
 
-    every { motionEvent1.x } returns 0.0f
-    every { motionEvent1.y } returns 0.0f
-    every { motionEvent2.x } returns 0.0f
-    every { motionEvent2.y } returns 0.0f
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
 
     presenter = GesturesPluginImpl(context, attrs, style)
 
     presenter.bind(context, gesturesManager, attrs, 1f)
     presenter.onDelegateProvider(mapDelegateProvider)
+
+    every {
+      gesturesManager.setStandardGestureListener(capture(gestureListener))
+    } just Runs
+
     presenter.initialize()
 
     every { gesturesManager.rotateGestureDetector } returns rotateGestureDetector
@@ -331,16 +334,16 @@ class GesturesPluginTest {
   fun verifyFlingListener() {
     val listener: OnFlingListener = mockk(relaxed = true)
     presenter.addOnFlingListener(listener)
-    presenter.handleFlingEvent(motionEvent1, motionEvent2, 0.0f, 0.0f)
+    presenter.handleFlingEvent(motionEvent, 0.0f, 0.0f)
     verify(exactly = 1) { listener.onFling() }
     presenter.removeOnFlingListener(listener)
-    presenter.handleFlingEvent(motionEvent1, motionEvent2, 0.0f, 0.0f)
+    presenter.handleFlingEvent(motionEvent, 0.0f, 0.0f)
     verify(exactly = 1) { listener.onFling() }
   }
 
   @Test
   fun verifyFlingIgnoreSmallDisplacement() {
-    val result = presenter.handleFlingEvent(motionEvent1, motionEvent2, 0.1f, 0.1f)
+    val result = presenter.handleFlingEvent(motionEvent, 0.1f, 0.1f)
     assertFalse(result)
   }
 
@@ -349,7 +352,7 @@ class GesturesPluginTest {
     val listener: OnFlingListener = mockk(relaxed = true)
     presenter.addOnFlingListener(listener)
     presenter.scrollEnabled = false
-    val result = presenter.handleFlingEvent(motionEvent1, motionEvent2, 0.1f, 0.1f)
+    val result = presenter.handleFlingEvent(motionEvent, 0.1f, 0.1f)
     assertFalse(result)
     verify(exactly = 0) { listener.onFling() }
   }
@@ -1121,6 +1124,19 @@ class GesturesPluginTest {
     assertEquals(cameraOptionsSlot.captured.zoom!!, startZoom + expectedZoomDelta * 3, EPS)
   }
 
+  @Test
+  fun verifyDoesNotCrashIfNullMotionEventPassed() {
+    gestureListener.captured.onSingleTapConfirmed(null)
+    gestureListener.captured.onDoubleTap(null)
+    gestureListener.captured.onDoubleTapEvent(null)
+    gestureListener.captured.onDown(null)
+    gestureListener.captured.onShowPress(null)
+    gestureListener.captured.onSingleTapUp(null)
+    gestureListener.captured.onLongPress(null)
+    gestureListener.captured.onScroll(null, null, 0f, 0f)
+    gestureListener.captured.onFling(null, null, 0f, 0f)
+  }
+
   private companion object {
     const val ROTATION_ANGLE_THRESHOLD = 3.0f
     const val MAX_SHOVE_ANGLE = 45.0f
@@ -1258,12 +1274,9 @@ class IsPointAboveHorizonTest(
 
   @Test
   fun testFlingEvent() {
-    val motionEvent1 = mockk<MotionEvent>()
-    val motionEvent2 = mockk<MotionEvent>()
-    every { motionEvent1.x } returns testScreenCoordinate.x.toFloat()
-    every { motionEvent1.y } returns testScreenCoordinate.y.toFloat()
-    every { motionEvent2.x } returns testScreenCoordinate.x.toFloat()
-    every { motionEvent2.y } returns testScreenCoordinate.y.toFloat()
+    val motionEvent = mockk<MotionEvent>()
+    every { motionEvent.x } returns testScreenCoordinate.x.toFloat()
+    every { motionEvent.y } returns testScreenCoordinate.y.toFloat()
     every { mapCameraManagerDelegate.cameraState } returns CameraState(
       Point.fromLngLat(0.0, 0.0),
       EdgeInsets(0.0, 0.0, 0.0, 0.0),
@@ -1280,7 +1293,7 @@ class IsPointAboveHorizonTest(
 
     val listener: OnFlingListener = mockk(relaxed = true)
     presenter.addOnFlingListener(listener)
-    presenter.handleFlingEvent(motionEvent1, motionEvent2, 1000.0f, 1000.0f)
+    presenter.handleFlingEvent(motionEvent, 1000.0f, 1000.0f)
     verify(exactly = if (expectedResult) 0 else 1) { listener.onFling() }
     verify(exactly = if (expectedResult) 0 else 1) {
       cameraAnimationsPlugin.easeTo(
@@ -1424,8 +1437,7 @@ class FlingGestureTest(
   private val typedArray: TypedArray = mockk(relaxed = true)
   private val pack = "com.mapbox.maps"
 
-  private val motionEvent1 = mockk<MotionEvent>()
-  private val motionEvent2 = mockk<MotionEvent>()
+  private val motionEvent = mockk<MotionEvent>()
   private val mapAnimationOptionsSlot = slot<MapAnimationOptions>()
 
   @MapboxExperimental
@@ -1487,18 +1499,15 @@ class FlingGestureTest(
       )
     } returns CameraOptions.Builder().build()
     presenter.updateSettings { scrollMode = targetScrollMode }
-    every { motionEvent1.x } returns 0.0f
-    every { motionEvent1.y } returns 0.0f
-    every { motionEvent2.x } returns 0.0f
-    every { motionEvent2.y } returns 0.0f
+    every { motionEvent.x } returns 0.0f
+    every { motionEvent.y } returns 0.0f
   }
 
   @Test
   fun testFling() {
     val result =
       presenter.handleFlingEvent(
-        motionEvent1,
-        motionEvent2,
+        motionEvent,
         targetVelocity.first,
         targetVelocity.second
       )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Fixes crash due to the null MotionEvent passed to Kotlin non-nullable var. 
Reported by some users at https://github.com/mapbox/mapbox-maps-android/issues/1019.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
