### PR TITLE
Use on draw listener in view annotation manager for more granular control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 # main
+## Bug fixes 🐞
+* Fix broken view annotation positioning when marking them `View.INVISIBLE` and then making `View.VISIBLE`. ([1616](https://github.com/mapbox/mapbox-maps-android/pull/1616))
+
+# 10.8.0-rc.1
 ## Features ✨ and improvements 🏁
 
 ## Bug fixes 🐞

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone.
 # main
-## Bug fixes 🐞
-* Fix broken view annotation positioning when marking them `View.INVISIBLE` and then making `View.VISIBLE`. ([1616](https://github.com/mapbox/mapbox-maps-android/pull/1616))
-
-# 10.8.0-rc.1
 ## Features ✨ and improvements 🏁
 
 ## Bug fixes 🐞
 * Fix scale bar truncated at high zoom levels near the poles. ([1620](https://github.com/mapbox/mapbox-maps-android/pull/1620))
+* Fix broken view annotation positioning when marking them `View.INVISIBLE` and then making `View.VISIBLE`. ([1616](https://github.com/mapbox/mapbox-maps-android/pull/1616))
 
 # 10.8.0-rc.1
 ## Bug fixes 🐞

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/infowindow/MarkerManager.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/infowindow/MarkerManager.kt
@@ -111,7 +111,7 @@ class MarkerManager(
         offsetX(0)
       }
     )
-    view.visibility = View.GONE
+    view.visibility = View.INVISIBLE
   }
 
   // if info window view is shown near screen edge - we adjust offsetX so that it fully appears on the screen

--- a/sdk/src/androidTest/java/com/mapbox/maps/ViewAnnotationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/ViewAnnotationTest.kt
@@ -893,6 +893,7 @@ class ViewAnnotationTest(
             anchor(ViewAnnotationAnchor.TOP_LEFT)
           }
         )
+        firstView.visibility = View.VISIBLE
       },
       makeChecks = {
         val initialTranslation = firstView.translationX.toDouble()
@@ -902,18 +903,29 @@ class ViewAnnotationTest(
           ADMISSIBLE_ERROR_PX
         )
         firstView.visibility = resultVisibility
+        val shiftX = 50.0
+        // trigger map movement while view annotation is not visible to trigger several core updates
+        mapboxMap.moveBy(
+          ScreenCoordinate(
+            shiftX,
+            0.0
+          ),
+          mapAnimationOptions {
+            duration(100L)
+          }
+        )
         mainHandler.postDelayed(
           {
             // make visible and move the map to make sure position is updated after view is visible
             firstView.visibility = View.VISIBLE
-            val shiftX = 100.0
+            val additionalShiftX = 50.0
             mapboxMap.moveBy(
               ScreenCoordinate(
-                shiftX,
+                additionalShiftX,
                 0.0
               ),
               mapAnimationOptions {
-                duration(1_000L)
+                duration(100L)
               }
             )
             mainHandler.postDelayed(
@@ -927,16 +939,16 @@ class ViewAnnotationTest(
                   actualVisibilityUpdateList.toTypedArray()
                 )
                 assertEquals(
-                  initialTranslation + shiftX,
+                  initialTranslation + shiftX + additionalShiftX,
                   firstView.translationX.toDouble(),
                   ADMISSIBLE_ERROR_PX
                 )
                 it.countDown()
               },
-              VIEW_PLACEMENT_DELAY_MS
+              VIEW_PLACEMENT_DELAY_MS / 3
             )
           },
-          VIEW_PLACEMENT_DELAY_MS
+          VIEW_PLACEMENT_DELAY_MS / 3
         )
       }
     )

--- a/sdk/src/androidTest/java/com/mapbox/maps/ViewAnnotationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/ViewAnnotationTest.kt
@@ -16,6 +16,8 @@ import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
+import com.mapbox.maps.plugin.animation.MapAnimationOptions.Companion.mapAnimationOptions
+import com.mapbox.maps.plugin.animation.moveBy
 import com.mapbox.maps.test.R
 import com.mapbox.maps.viewannotation.OnViewAnnotationUpdatedListener
 import com.mapbox.maps.viewannotation.ViewAnnotationManager
@@ -825,10 +827,8 @@ class ViewAnnotationTest(
     )
   }
 
-  // checking automatic view visibility handling
-
   @Test
-  fun automaticViewVisibilityHandling() {
+  fun automaticViewVisibilityHandlingViewsOverlap() {
     viewAnnotationTestHelper(
       additionalLatchCount = 1,
       performAction = {
@@ -865,6 +865,76 @@ class ViewAnnotationTest(
               actualVisibilityUpdateList.toTypedArray()
             )
             it.countDown()
+          },
+          VIEW_PLACEMENT_DELAY_MS
+        )
+      }
+    )
+  }
+
+  @Test
+  fun automaticViewVisibilityHandlingInvisibleCase() {
+    automaticViewVisibilityTest(View.INVISIBLE)
+  }
+
+  @Test
+  fun automaticViewVisibilityHandlingGoneCase() {
+    automaticViewVisibilityTest(View.GONE)
+  }
+
+  private fun automaticViewVisibilityTest(resultVisibility: Int) {
+    viewAnnotationTestHelper(
+      additionalLatchCount = 1,
+      performAction = {
+        firstView = viewAnnotationManager.addViewAnnotation(
+          resId = layoutResId,
+          options = viewAnnotationOptions {
+            geometry(CAMERA_CENTER)
+            anchor(ViewAnnotationAnchor.TOP_LEFT)
+          }
+        )
+      },
+      makeChecks = {
+        val initialTranslation = firstView.translationX.toDouble()
+        assertEquals(
+          mapboxMap.pixelForCoordinate(CAMERA_CENTER).x,
+          initialTranslation,
+          ADMISSIBLE_ERROR_PX
+        )
+        firstView.visibility = resultVisibility
+        mainHandler.postDelayed(
+          {
+            // make visible and move the map to make sure position is updated after view is visible
+            firstView.visibility = View.VISIBLE
+            val shiftX = 100.0
+            mapboxMap.moveBy(
+              ScreenCoordinate(
+                shiftX,
+                0.0
+              ),
+              mapAnimationOptions {
+                duration(1_000L)
+              }
+            )
+            mainHandler.postDelayed(
+              {
+                assertArrayEquals(
+                  arrayOf(
+                    Pair(firstView, true),
+                    Pair(firstView, false),
+                    Pair(firstView, true)
+                  ),
+                  actualVisibilityUpdateList.toTypedArray()
+                )
+                assertEquals(
+                  initialTranslation + shiftX,
+                  firstView.translationX.toDouble(),
+                  ADMISSIBLE_ERROR_PX
+                )
+                it.countDown()
+              },
+              VIEW_PLACEMENT_DELAY_MS
+            )
           },
           VIEW_PLACEMENT_DELAY_MS
         )

--- a/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
@@ -214,7 +214,8 @@ internal class ViewAnnotationManagerImpl(
       measuredWidth = if (options.width != null) USER_FIXED_DIMENSION else inflatedViewLayout.width,
       measuredHeight = if (options.height != null) USER_FIXED_DIMENSION else inflatedViewLayout.height,
     )
-    val onDrawListener = ViewTreeObserver.OnDrawListener {
+    // triggered not so often and needed to control view's width and height when WRAP_CONTENT is used
+    val onGlobalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
       if (viewAnnotation.measuredWidth != USER_FIXED_DIMENSION &&
         inflatedView.measuredWidth > 0 &&
         inflatedView.measuredWidth != viewAnnotation.measuredWidth
@@ -243,6 +244,10 @@ internal class ViewAnnotationManagerImpl(
           )
         )
       }
+    }
+    // triggered on every frame and needed to check if visibility changed
+    // as OnGlobalLayoutListener does not cover cases for View.INVISIBLE properly
+    val onDrawListener = ViewTreeObserver.OnDrawListener {
       if (viewAnnotation.handleVisibilityAutomatically) {
         val isAndroidViewVisible = (inflatedView.visibility == View.VISIBLE)
         if ((isAndroidViewVisible && viewAnnotation.isVisible) ||
@@ -277,10 +282,12 @@ internal class ViewAnnotationManagerImpl(
     viewAnnotation.attachStateListener = object : View.OnAttachStateChangeListener {
       override fun onViewAttachedToWindow(v: View) {
         inflatedView.viewTreeObserver.addOnDrawListener(onDrawListener)
+        inflatedView.viewTreeObserver.addOnGlobalLayoutListener(onGlobalLayoutListener)
       }
 
       override fun onViewDetachedFromWindow(v: View) {
         inflatedView.viewTreeObserver.removeOnDrawListener(onDrawListener)
+        inflatedView.viewTreeObserver.removeOnGlobalLayoutListener(onGlobalLayoutListener)
       }
     }
     inflatedView.addOnAttachStateChangeListener(viewAnnotation.attachStateListener)

--- a/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
@@ -214,7 +214,7 @@ internal class ViewAnnotationManagerImpl(
       measuredWidth = if (options.width != null) USER_FIXED_DIMENSION else inflatedViewLayout.width,
       measuredHeight = if (options.height != null) USER_FIXED_DIMENSION else inflatedViewLayout.height,
     )
-    val globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+    val onDrawListener = ViewTreeObserver.OnDrawListener {
       if (viewAnnotation.measuredWidth != USER_FIXED_DIMENSION &&
         inflatedView.measuredWidth > 0 &&
         inflatedView.measuredWidth != viewAnnotation.measuredWidth
@@ -248,7 +248,7 @@ internal class ViewAnnotationManagerImpl(
         if ((isAndroidViewVisible && viewAnnotation.isVisible) ||
           (!isAndroidViewVisible && viewAnnotation.visibility == ViewAnnotationVisibility.INVISIBLE)
         ) {
-          return@OnGlobalLayoutListener
+          return@OnDrawListener
         }
         // hide view below map surface and pull it back when new position from core will arrive
         if (isAndroidViewVisible) {
@@ -276,11 +276,11 @@ internal class ViewAnnotationManagerImpl(
     }
     viewAnnotation.attachStateListener = object : View.OnAttachStateChangeListener {
       override fun onViewAttachedToWindow(v: View) {
-        inflatedView.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
+        inflatedView.viewTreeObserver.addOnDrawListener(onDrawListener)
       }
 
       override fun onViewDetachedFromWindow(v: View) {
-        inflatedView.viewTreeObserver.removeOnGlobalLayoutListener(globalLayoutListener)
+        inflatedView.viewTreeObserver.removeOnDrawListener(onDrawListener)
       }
     }
     inflatedView.addOnAttachStateChangeListener(viewAnnotation.attachStateListener)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

In view annotation manager we were relying on `ViewTreeObserver.OnGlobalLayoutListener` listener to control 2 state changes for the view annotation:
 - dimension change caused by `WRAP_CONTENT`
 - visibility changes based on user calling `View.setVisibility` in order to update core with new visible status

However it turned out that changing view visibility from `VISIBLE` to `INVISIBLE` does not actually trigger `OnGlobalLayoutListener` as the view still remains in the view tree. That actually was breaking view annotation logic when user was simply setting view annotation visibility to `INVISIBLE`, dragging the map and making it `VISIBLE` again.

The solution found here is to actually check view visibility inside `ViewTreeObserver.OnDrawListener` that is called on each frame for the view. In order to save a bit of CPU cycles only visibility check was migrated to `OnDrawListener` while checking for `WRAP_CONTENT` dimensions did remain in `OnGlobalLayoutListener`.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
