### PR TITLE
Bump gl-native to 10.8-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ Mapbox welcomes participation and contributions from everyone.
 # main
 
 # 10.8.0-rc.1
-## Features ✨ and improvements 🏁
-
 ## Bug fixes 🐞
 * Try recreate EGL surface when it throws exception. ([1589](https://github.com/mapbox/mapbox-maps-android/pull/1589))
 * Fix `MapboxMap` extension plugin functions throwing exceptions. ([1591](https://github.com/mapbox/mapbox-maps-android/pull/1591))
 * Fix concurrent modification exception when using widgets. ([1597](https://github.com/mapbox/mapbox-maps-android/pull/1597))
+* Relax LOD requirements for maps with insets and zero terrain exaggeration, leading to more content shown in easily readable map areas. ([1623](https://github.com/mapbox/mapbox-maps-android/pull/1623))
+* Make CameraManager.setCamera method exception free. In cases when incorrect CameraOptions are provided, error would be logged. ([1623](https://github.com/mapbox/mapbox-maps-android/pull/1623))
+* Fix black holes in the globe view when edge insets are used. ([1623](https://github.com/mapbox/mapbox-maps-android/pull/1623))
+
+## Dependencies
+Bump gl-native to v10.8.0-rc.1 and common to v23.0.0-rc.2. ([1623](https://github.com/mapbox/mapbox-maps-android/pull/1623))
 
 # 10.8.0-beta.1 August 11, 2022
 ## Features ✨ and improvements 🏁

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -108,8 +108,8 @@ object Versions {
   const val mapboxGestures = "0.7.0"
   const val mapboxJavaServices = "5.4.1"
   const val mapboxBase = "0.8.0"
-  const val mapboxGlNative = "10.8.0-beta.2"
-  const val mapboxCommon = "23.0.0-beta.1"
+  const val mapboxGlNative = "10.8.0-rc.1"
+  const val mapboxCommon = "23.0.0-rc.2"
   const val mapboxAndroidCore = "5.0.2"
   const val mapboxAndroidTelemetry = "8.1.5"
   const val androidxCore = "1.7.0" // last version compatible with kotlin 1.5.31

--- a/extension-localization/README.md
+++ b/extension-localization/README.md
@@ -31,7 +31,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.extension:maps-localization:10.8.0-beta.1'
+    implementation 'com.mapbox.extension:maps-localization:10.8.0-rc.1'
 }
 ```
 

--- a/extension-style/README.md
+++ b/extension-style/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.extension:maps-style:10.8.0-beta.1'
+  implementation 'com.mapbox.extension:maps-style:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-animation/README.md
+++ b/plugin-animation/README.md
@@ -34,7 +34,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-animation:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-animation:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -30,7 +30,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-annotation:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-annotation:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-attribution/README.md
+++ b/plugin-attribution/README.md
@@ -33,7 +33,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-attribution:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-attribution:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-compass/README.md
+++ b/plugin-compass/README.md
@@ -32,9 +32,9 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-compass:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-compass:10.8.0-rc.1'
   // Mapbox Maps Compass Plugin depends on the Mapbox Maps Animation Plugin
-  implementation 'com.mapbox.plugin:maps-animation:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-animation:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-gestures/README.md
+++ b/plugin-gestures/README.md
@@ -30,9 +30,9 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.plugin:maps-gestures:10.8.0-beta.1'
+    implementation 'com.mapbox.plugin:maps-gestures:10.8.0-rc.1'
     // Mapbox Maps Gestures Plugin depends on the Mapbox Maps Animation Plugin
-    implementation 'com.mapbox.plugin:maps-animation:10.8.0-beta.1'
+    implementation 'com.mapbox.plugin:maps-animation:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-lifecycle/README.md
+++ b/plugin-lifecycle/README.md
@@ -30,7 +30,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-lifecycle:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-lifecycle:10.8.0-rc.1'
   // Make sure the version of appcompat is 1.3.0+
   implementation 'androidx.appcompat:appcompat:1.3.0'
 }

--- a/plugin-locationcomponent/README.md
+++ b/plugin-locationcomponent/README.md
@@ -32,7 +32,7 @@ allprojects {
 }
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-locationcomponent:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-locationcomponent:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-logo/README.md
+++ b/plugin-logo/README.md
@@ -30,7 +30,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-logo:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-logo:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-overlay/README.md
+++ b/plugin-overlay/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-overlay:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-overlay:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-scalebar/README.md
+++ b/plugin-scalebar/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-scalebar:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-scalebar:10.8.0-rc.1'
 }
 ```
 

--- a/plugin-viewport/README.md
+++ b/plugin-viewport/README.md
@@ -50,7 +50,7 @@ allprojects {
 }
 // In the app build.gradle file
 dependencies {
-  implementation 'com.mapbox.plugin:maps-viewport:10.8.0-beta.1'
+  implementation 'com.mapbox.plugin:maps-viewport:10.8.0-rc.1'
 }
 ```
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

## Bug fixes 🐞
* Relax LOD requirements for maps with insets and zero terrain exaggeration, leading to more content shown in easily readable map areas
* Make CameraManager.setCamera method exception free. In cases when incorrect CameraOptions are provided, error would be logged.
* Fix black holes in the globe view when edge insets are used 

## Dependencies
* Upgrade mapbox-common version to v23.0.0-rc.2

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
