### PR TITLE
[v10.9] revert setCamera exception fix #652

### DIFF
--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -133,7 +133,8 @@ class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     }
   }
 
-  private var lastCameraOptions: CameraOptions? = null
+  @VisibleForTesting(otherwise = PRIVATE)
+  internal var lastCameraOptions: CameraOptions? = null
   private var cameraOptionsBuilder = CameraOptions.Builder()
 
   private lateinit var mapDelegateProvider: MapDelegateProvider
@@ -180,15 +181,23 @@ class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     handler.removeCallbacks(commitChangesRunnable)
   }
 
-  private fun performMapJump(cameraOptions: CameraOptions) {
+  @VisibleForTesting(otherwise = PRIVATE)
+  internal fun performMapJump(cameraOptions: CameraOptions) {
     if (lastCameraOptions == cameraOptions) {
       return
     }
     // move native map to new position
-    mapCameraManagerDelegate.setCamera(cameraOptions)
-    // notify listeners with actual values
-    notifyListeners(mapCameraManagerDelegate.cameraState)
-    lastCameraOptions = cameraOptions
+    try {
+      mapCameraManagerDelegate.setCamera(cameraOptions)
+      // notify listeners with actual values
+      notifyListeners(mapCameraManagerDelegate.cameraState)
+      lastCameraOptions = cameraOptions
+    } catch (e: Exception) {
+      logE(
+        TAG,
+        "Exception while setting camera options : ${e.message} CameraOptions = $cameraOptions"
+      )
+    }
   }
 
   private fun updateAnimatorValues(cameraAnimator: CameraAnimator<*>): Boolean {

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImpl.kt
@@ -133,8 +133,7 @@ class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     }
   }
 
-  @VisibleForTesting(otherwise = PRIVATE)
-  internal var lastCameraOptions: CameraOptions? = null
+  private var lastCameraOptions: CameraOptions? = null
   private var cameraOptionsBuilder = CameraOptions.Builder()
 
   private lateinit var mapDelegateProvider: MapDelegateProvider
@@ -181,28 +180,15 @@ class CameraAnimationsPluginImpl : CameraAnimationsPlugin {
     handler.removeCallbacks(commitChangesRunnable)
   }
 
-  @VisibleForTesting(otherwise = PRIVATE)
-  internal fun performMapJump(cameraOptions: CameraOptions) {
+  private fun performMapJump(cameraOptions: CameraOptions) {
     if (lastCameraOptions == cameraOptions) {
       return
     }
     // move native map to new position
-    try {
-      mapCameraManagerDelegate.setCamera(cameraOptions)
-      // notify listeners with actual values
-      notifyListeners(mapCameraManagerDelegate.cameraState)
-      lastCameraOptions = cameraOptions
-    } catch (e: Exception) {
-      logE(
-        TAG,
-        "Exception while setting camera options : ${e.message} CameraOptions = $cameraOptions"
-      )
-    } catch (error: Error) {
-      logE(
-        TAG,
-        "Error while setting camera options : ${error.message} CameraOptions = $cameraOptions"
-      )
-    }
+    mapCameraManagerDelegate.setCamera(cameraOptions)
+    // notify listeners with actual values
+    notifyListeners(mapCameraManagerDelegate.cameraState)
+    lastCameraOptions = cameraOptions
   }
 
   private fun updateAnimatorValues(cameraAnimator: CameraAnimator<*>): Boolean {

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -30,8 +30,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowLog
-import java.lang.Error
-import java.lang.Exception
 import java.time.Duration
 
 @RunWith(RobolectricTestRunner::class)
@@ -1009,35 +1007,6 @@ class CameraAnimationsPluginImplTest {
     cameraAnimationsPluginImpl.easeTo(cameraState.toCameraOptions(), mapAnimationOptions { duration(DURATION) })
     shadowOf(getMainLooper()).idle()
     verify(exactly = 0) { logD(TAG, any()) }
-  }
-
-  @Test
-  fun catchErrorOnSetCameraTest() {
-    executeSetCameraTest(Error("Invalid camera options"))
-  }
-
-  @Test
-  fun catchExceptionOnSetCameraTest() {
-    executeSetCameraTest(Exception("Invalid camera options"))
-  }
-
-  private fun executeSetCameraTest(error: Throwable) {
-    val lastCameraOptions = cameraState.toCameraOptions()
-    val targetCameraOptions = CameraOptions.Builder().center(
-      Point.fromLngLat(50.0, 50.0)
-    ).pitch(50.0)
-      .bearing(50.0)
-      .zoom(5.0).build()
-    cameraAnimationsPluginImpl.lastCameraOptions = lastCameraOptions
-    every { mapCameraManagerDelegate.setCamera(any<CameraOptions>()) } throws error
-
-    cameraAnimationsPluginImpl.performMapJump(targetCameraOptions)
-    // assert camera options did not change
-    assertNotEquals(targetCameraOptions, cameraAnimationsPluginImpl.lastCameraOptions)
-
-    // assert camera states
-    assertNotNull(cameraAnimationsPluginImpl.lastCameraOptions)
-    assertEquals(lastCameraOptions, cameraAnimationsPluginImpl.lastCameraOptions)
   }
 
   class LifecycleListener : CameraAnimationsLifecycleListener {

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsPluginImplTest.kt
@@ -1009,6 +1009,30 @@ class CameraAnimationsPluginImplTest {
     verify(exactly = 0) { logD(TAG, any()) }
   }
 
+  @Test
+  fun catchExceptionOnSetCameraTest() {
+    executeSetCameraTest(Exception("Invalid camera options"))
+  }
+
+  private fun executeSetCameraTest(error: Throwable) {
+    val lastCameraOptions = cameraState.toCameraOptions()
+    val targetCameraOptions = CameraOptions.Builder().center(
+      Point.fromLngLat(50.0, 50.0)
+    ).pitch(50.0)
+      .bearing(50.0)
+      .zoom(5.0).build()
+    cameraAnimationsPluginImpl.lastCameraOptions = lastCameraOptions
+    every { mapCameraManagerDelegate.setCamera(any<CameraOptions>()) } throws error
+
+    cameraAnimationsPluginImpl.performMapJump(targetCameraOptions)
+    // assert camera options did not change
+    assertNotEquals(targetCameraOptions, cameraAnimationsPluginImpl.lastCameraOptions)
+
+    // assert camera states
+    assertNotNull(cameraAnimationsPluginImpl.lastCameraOptions)
+    assertEquals(lastCameraOptions, cameraAnimationsPluginImpl.lastCameraOptions)
+  }
+
   class LifecycleListener : CameraAnimationsLifecycleListener {
     var starting = false
     var interrupting = false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
- After gl-native bump to v10.8.0-rc.1, exceptions in set camera will be handled in native, which makes the fix in https://github.com/mapbox/mapbox-maps-android/pull/652 redundant. Reverting old fix in this pr. 

More context can be found in MAPSAND-389.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.9` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.9` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
