### PR TITLE
Deprecate gesture settings increaseRotateThresholdWhenPinchingToZoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 # main
 ## Features ✨ and improvements 🏁
+* Deprecated gesture settings `increaseRotateThresholdWhenPinchingToZoom` property. ([1632](https://github.com/mapbox/mapbox-maps-android/pull/1632))
 
 ## Bug fixes 🐞
 * Fix scale bar truncated at high zoom levels near the poles. ([1620](https://github.com/mapbox/mapbox-maps-android/pull/1620))

--- a/plugin-gestures/src/main/res-public/values/public.xml
+++ b/plugin-gestures/src/main/res-public/values/public.xml
@@ -43,7 +43,8 @@
     <!-- Whether a deceleration animation following a scroll gesture is enabled. True by default. -->
     <public name="mapbox_gesturesScrollDecelerationEnabled" type="attr" />
 
-    <!-- Whether rotate threshold increases when pinching to zoom. true by default. -->
+    <!-- Whether rotate threshold increases when pinching to zoom. true by default.
+         {@deprecated This property has no effect} -->
     <public name="mapbox_gesturesIncreaseRotateThresholdWhenPinchingToZoom" type="attr" />
 
     <!-- Whether pinch to zoom threshold increases when rotating. true by default. -->

--- a/sdk-base/api/metalava.txt
+++ b/sdk-base/api/metalava.txt
@@ -1839,7 +1839,7 @@ package com.mapbox.maps.plugin.gestures.generated {
     method public boolean getDoubleTouchToZoomOutEnabled();
     method public com.mapbox.maps.ScreenCoordinate? getFocalPoint();
     method public boolean getIncreasePinchToZoomThresholdWhenRotating();
-    method public boolean getIncreaseRotateThresholdWhenPinchingToZoom();
+    method @Deprecated public boolean getIncreaseRotateThresholdWhenPinchingToZoom();
     method public boolean getPinchScrollEnabled();
     method public boolean getPinchToZoomDecelerationEnabled();
     method public boolean getPinchToZoomEnabled();
@@ -1857,7 +1857,7 @@ package com.mapbox.maps.plugin.gestures.generated {
     method public void setDoubleTouchToZoomOutEnabled(boolean doubleTouchToZoomOutEnabled);
     method public void setFocalPoint(com.mapbox.maps.ScreenCoordinate? focalPoint);
     method public void setIncreasePinchToZoomThresholdWhenRotating(boolean increasePinchToZoomThresholdWhenRotating);
-    method public void setIncreaseRotateThresholdWhenPinchingToZoom(boolean increaseRotateThresholdWhenPinchingToZoom);
+    method @Deprecated public void setIncreaseRotateThresholdWhenPinchingToZoom(boolean increaseRotateThresholdWhenPinchingToZoom);
     method public void setPinchScrollEnabled(boolean pinchScrollEnabled);
     method public void setPinchToZoomDecelerationEnabled(boolean pinchToZoomDecelerationEnabled);
     method public void setPinchToZoomEnabled(boolean pinchToZoomEnabled);
@@ -1875,7 +1875,7 @@ package com.mapbox.maps.plugin.gestures.generated {
     property public abstract boolean doubleTouchToZoomOutEnabled;
     property public abstract com.mapbox.maps.ScreenCoordinate? focalPoint;
     property public abstract boolean increasePinchToZoomThresholdWhenRotating;
-    property public abstract boolean increaseRotateThresholdWhenPinchingToZoom;
+    property @Deprecated public abstract boolean increaseRotateThresholdWhenPinchingToZoom;
     property public abstract boolean pinchScrollEnabled;
     property public abstract boolean pinchToZoomDecelerationEnabled;
     property public abstract boolean pinchToZoomEnabled;

--- a/sdk-base/src/main/java/com/mapbox/maps/plugin/gestures/generated/GesturesSettingsInterface.kt
+++ b/sdk-base/src/main/java/com/mapbox/maps/plugin/gestures/generated/GesturesSettingsInterface.kt
@@ -91,6 +91,7 @@ interface GesturesSettingsInterface {
   /**
    * Whether rotate threshold increases when pinching to zoom. true by default.
    */
+  @Deprecated(message = "This property has no effect")
   var increaseRotateThresholdWhenPinchingToZoom: Boolean
 
   /**


### PR DESCRIPTION
### Summary of changes
Deprecate gesture settings `increaseRotateThresholdWhenPinchingToZoom` property.

### User impact (optional)
None. The property was not used and had no effect.

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
