### PR TITLE
MAPSAND-221 setting puck bearing enabled to false does not reset bearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Bug fixes 🐞
 * Fix scale bar truncated at high zoom levels near the poles. ([1620](https://github.com/mapbox/mapbox-maps-android/pull/1620))
 * Fix broken view annotation positioning when marking them `View.INVISIBLE` and then making `View.VISIBLE`. ([1616](https://github.com/mapbox/mapbox-maps-android/pull/1616))
+* Snap puck to north if puckBearingEnabled is set to false. ([1635] (https://github.com/mapbox/mapbox-maps-android/pull/1635))
 
 # 10.8.0-rc.1 August 24, 2022
 ## Bug fixes 🐞

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -180,13 +180,17 @@ internal class LocationPuckManager(
       animationManager.setEnabled(true)
       animateToBearing(bearings, options, forceUpdate)
     } else {
-      animateToBearing(doubleArrayOf(0.0), options = {
-        options?.invoke(this)
-        duration = 0
-        doOnEnd {
-          animationManager.setEnabled(false)
-        }
-      }, forceUpdate)
+      animateToBearing(
+        doubleArrayOf(0.0),
+        options = {
+          options?.invoke(this)
+          duration = 0
+          doOnEnd {
+            animationManager.setEnabled(false)
+          }
+        },
+        forceUpdate
+      )
     }
   }
 

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -176,38 +176,18 @@ internal class LocationPuckManager(
     options: (ValueAnimator.() -> Unit)? = null,
     forceUpdate: Boolean = false
   ) {
-    when (settings2.puckBearingEnabled) {
-      false -> {
-        // Puck bearing is disabled, snap back to north.
-        snapToNorth(options, false)
-      }
-      true -> {
-        // Puck bearing is enabled, animate to new bearing.
-        animateToBearing(bearings, options, forceUpdate)
-      }
-    }
-  }
-
-  @VisibleForTesting(otherwise = PRIVATE)
-  fun snapToNorth(
-    options: (ValueAnimator.() -> Unit)? = null,
-    forceUpdate: Boolean
-  ) {
-    // Skip bearing updates if the change from the lastBearing is too small, thus avoid unnecessary calls to gl-native.
-    if (!forceUpdate && lastBearing < BEARING_UPDATE_THRESHOLD) {
-      return
-    }
-    val targets = doubleArrayOf(lastBearing, 0.0)
-    animationManager.animateBearing(
-      *targets,
-      options = {
+    if (settings2.puckBearingEnabled) {
+      animationManager.setEnabled(true)
+      animateToBearing(bearings, options, forceUpdate)
+    } else {
+      animateToBearing(doubleArrayOf(0.0), options = {
         options?.invoke(this)
         duration = 0
         doOnEnd {
-          animationManager.setDisabled()
+          animationManager.setEnabled(false)
         }
-      }
-    )
+      }, forceUpdate)
+    }
   }
 
   @VisibleForTesting(otherwise = PRIVATE)
@@ -221,7 +201,6 @@ internal class LocationPuckManager(
       return
     }
     val targets = doubleArrayOf(lastBearing, *bearings)
-    animationManager.setEnabled()
     animationManager.animateBearing(
       *targets,
       options = options

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -183,7 +183,6 @@ internal class LocationPuckManager(
       animateToBearing(
         doubleArrayOf(0.0),
         options = {
-          options?.invoke(this)
           duration = 0
           doOnEnd {
             animationManager.setEnabled(false)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -58,7 +58,8 @@ internal class LocationPuckManager(
     }
   }
 
-  private var lastBearing: Double = delegateProvider.mapCameraManagerDelegate.cameraState.bearing
+  @VisibleForTesting(otherwise = PRIVATE)
+  internal var lastBearing: Double = delegateProvider.mapCameraManagerDelegate.cameraState.bearing
   private val onBearingUpdated: ((Double) -> Unit) = {
     lastBearing = it
   }
@@ -140,6 +141,10 @@ internal class LocationPuckManager(
   }
 
   fun updateSettings2(settings2: LocationComponentSettings2) {
+    if (!settings2.puckBearingEnabled && this.settings2.puckBearingEnabled) {
+      // Restore camera bearing if puck bearing is disabled.
+      updateCurrentBearing(delegateProvider.mapCameraManagerDelegate.cameraState.bearing)
+    }
     this.settings2 = settings2
     animationManager.applySettings2(settings2)
   }

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -177,7 +177,7 @@ internal class LocationPuckManager(
     forceUpdate: Boolean = false
   ) {
     if (settings2.puckBearingEnabled) {
-      animationManager.setEnabled(true)
+      animationManager.setPuckAnimationEnabled(true)
       animateToBearing(bearings, options, forceUpdate)
     } else {
       animateToBearing(
@@ -185,7 +185,7 @@ internal class LocationPuckManager(
         options = {
           duration = 0
           doOnEnd {
-            animationManager.setEnabled(false)
+            animationManager.setPuckAnimationEnabled(false)
           }
         },
         forceUpdate

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManager.kt
@@ -177,15 +177,15 @@ internal class LocationPuckManager(
     forceUpdate: Boolean = false
   ) {
     if (settings2.puckBearingEnabled) {
-      animationManager.setPuckAnimationEnabled(true)
+      animationManager.puckAnimationEnabled = true
       animateToBearing(bearings, options, forceUpdate)
-    } else {
+    } else if (animationManager.puckAnimationEnabled) {
       animateToBearing(
         doubleArrayOf(0.0),
         options = {
           duration = 0
           doOnEnd {
-            animationManager.setPuckAnimationEnabled(false)
+            animationManager.puckAnimationEnabled = false
           }
         },
         forceUpdate

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
@@ -117,9 +117,14 @@ internal class PuckAnimatorManager(
       accuracyCircleColor = settings2.accuracyRingColor
       accuracyCircleBorderColor = settings2.accuracyRingBorderColor
     }
-    bearingAnimator.apply {
-      enabled = settings2.puckBearingEnabled
-    }
+  }
+
+  internal fun setDisabled() {
+    bearingAnimator.enabled = false
+  }
+
+  internal fun setEnabled() {
+    bearingAnimator.enabled = true
   }
 
   fun applyPulsingAnimationSettings(settings: LocationComponentSettings) {

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
@@ -16,12 +16,17 @@ internal class PuckAnimatorManager(
   indicatorAccuracyRadiusChangedListener: OnIndicatorAccuracyRadiusChangedListener,
   pixelRatio: Float
 ) {
-
   private var bearingAnimator = PuckBearingAnimator(indicatorBearingChangedListener)
   private var positionAnimator = PuckPositionAnimator(indicatorPositionChangedListener)
   private var accuracyRadiusAnimator =
     PuckAccuracyRadiusAnimator(indicatorAccuracyRadiusChangedListener)
   private var pulsingAnimator = PuckPulsingAnimator(pixelRatio)
+
+  internal var puckAnimationEnabled: Boolean
+    get() = bearingAnimator.enabled
+    set(value) {
+      bearingAnimator.enabled = value
+    }
 
   @VisibleForTesting(otherwise = PRIVATE)
   constructor(
@@ -117,10 +122,6 @@ internal class PuckAnimatorManager(
       accuracyCircleColor = settings2.accuracyRingColor
       accuracyCircleBorderColor = settings2.accuracyRingBorderColor
     }
-  }
-
-  internal fun setPuckAnimationEnabled(enabled: Boolean) {
-    bearingAnimator.enabled = enabled
   }
 
   fun applyPulsingAnimationSettings(settings: LocationComponentSettings) {

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
@@ -119,7 +119,7 @@ internal class PuckAnimatorManager(
     }
   }
 
-  internal fun setEnabled(enabled: Boolean) {
+  internal fun setPuckAnimationEnabled(enabled: Boolean) {
     bearingAnimator.enabled = enabled
   }
 

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/animators/PuckAnimatorManager.kt
@@ -119,12 +119,8 @@ internal class PuckAnimatorManager(
     }
   }
 
-  internal fun setDisabled() {
-    bearingAnimator.enabled = false
-  }
-
-  internal fun setEnabled() {
-    bearingAnimator.enabled = true
+  internal fun setEnabled(enabled: Boolean) {
+    bearingAnimator.enabled = enabled
   }
 
   fun applyPulsingAnimationSettings(settings: LocationComponentSettings) {

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -419,6 +419,25 @@ class LocationPuckManagerTest {
     verify(exactly = 0) { animationManager.updatePulsingRadius(any(), settings) }
   }
 
+  @Test
+  fun testDisablePuckBearingRestoresCameraBearing() {
+    val cameraStateBearing = 180.0
+    val puckBearing = 90.0
+    val settings2 = LocationComponentSettings2().apply { puckBearingEnabled = false }
+    val bearingResults = mutableListOf<Double>()
+
+    every { mapCameraDelegate.cameraState.bearing } returns cameraStateBearing
+    every { accuracyRadiusSettings.puckBearingEnabled } returns true
+    every { animationManager.animateBearing(*varargAllDouble { bearingResults.add(it) }, options = null) } returns Unit
+
+    locationPuckManager.lastBearing = puckBearing
+    locationPuckManager.updateSettings2(settings2)
+    verify(exactly = 1) { locationPuckManager.updateCurrentBearing(cameraStateBearing) }
+    verify(exactly = 1) { animationManager.animateBearing(*anyDoubleVararg(), options = null) }
+    verify(exactly = 1) { animationManager.applySettings2(settings2) }
+    assertEquals(listOf(puckBearing, cameraStateBearing), bearingResults)
+  }
+
   private companion object {
     const val MODEL_SCALE_CONSTANT = 2965820.800757861
   }

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -56,6 +56,7 @@ class LocationPuckManagerTest {
     )
     every { settings.locationPuck } returns LocationPuck2D()
     every { settings.enabled } returns true
+    every { accuracyRadiusSettings.puckBearingEnabled } returns true
     locationPuckManager = LocationPuckManager(
       settings,
       accuracyRadiusSettings,
@@ -439,8 +440,6 @@ class LocationPuckManagerTest {
     val newBearing = 90.0
     val settings2 = LocationComponentSettings2().apply { puckBearingEnabled = false }
     val bearings = mutableListOf<Double>()
-
-    every { accuracyRadiusSettings.puckBearingEnabled } returns true
 
     locationPuckManager.lastBearing = lastBearing
     locationPuckManager.updateSettings2(settings2)

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationPuckManagerTest.kt
@@ -440,6 +440,7 @@ class LocationPuckManagerTest {
     val newBearing = 90.0
     val settings2 = LocationComponentSettings2().apply { puckBearingEnabled = false }
     val bearings = mutableListOf<Double>()
+    every { animationManager.puckAnimationEnabled } returns true
 
     locationPuckManager.lastBearing = lastBearing
     locationPuckManager.updateSettings2(settings2)


### PR DESCRIPTION
### Summary of changes

Disabling the puck in LocationPuckManager will now cause the puck direction to snap back to north.  This was requested by a customer.

### User impact (optional)

Calling LocationPuckManager.applySettings2 with LocationComponentSettings2.puckBearingEnabled == false will cause the puck to instantly animate to the north position.  When calling with puckBearingEnabled == true, the puck will animate smoothly back to the last reported heading.

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
        | <video src="https://user-images.githubusercontent.com/16490463/187616284-da6a58c8-9cc9-459c-9530-6c4b3e82487a.mp4" width = 250/>
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: 

https://mapbox.atlassian.net/jira/software/c/projects/MAPSAND/issues/MAPSAND-221

