### PR TITLE
MAPSMBL-159 android auto wrong bitmap widget position after calling update bitmap with a bitmap that has different size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Mapbox welcomes participation and contributions from everyone.
 * Preserve cached properties if applied to the layer before during the `Style#getLayer` call. ([1622](https://github.com/mapbox/mapbox-maps-android/pull/1622))
 * Fix a `NullPointerException` in `StandardGestureListener`, where `MotionEvent` should be nullable. ([1645] (https://github.com/mapbox/mapbox-maps-android/pull/1645))
 * Fix incorrect `MapView` dimensions after background orientation change. ([1658](https://github.com/mapbox/mapbox-maps-android/pull/1658))
-* Wrong BitmapWidget position when using WidgetPosition.Horizontal.CENTER. ([1651](https://github.com/mapbox/mapbox-maps-android/pull/1651))
 * Fix wrong `BitmapWidget` position when using `WidgetPosition.Horizontal.CENTER` property. ([1651](https://github.com/mapbox/mapbox-maps-android/pull/1651))
 
 ## Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Mapbox welcomes participation and contributions from everyone.
 # main
+* Wrong BitmapWidget position when using WidgetPosition.Horizontal.CENTER. ([1651](https://github.com/mapbox/mapbox-maps-android/pull/1651))
 
 ## Features ✨ and improvements 🏁
 * Deprecated gesture settings `increaseRotateThresholdWhenPinchingToZoom` property. ([1632](https://github.com/mapbox/mapbox-maps-android/pull/1632))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix a `NullPointerException` in `StandardGestureListener`, where `MotionEvent` should be nullable. ([1645] (https://github.com/mapbox/mapbox-maps-android/pull/1645))
 * Fix incorrect `MapView` dimensions after background orientation change. ([1658](https://github.com/mapbox/mapbox-maps-android/pull/1658))
 * Wrong BitmapWidget position when using WidgetPosition.Horizontal.CENTER. ([1651](https://github.com/mapbox/mapbox-maps-android/pull/1651))
+* Fix wrong `BitmapWidget` position when using `WidgetPosition.Horizontal.CENTER` property. ([1651](https://github.com/mapbox/mapbox-maps-android/pull/1651))
 
 ## Dependencies
 * Update mapbox-gestures-android dependency to [v0.8.0](https://github.com/mapbox/mapbox-gestures-android/releases/tag/v0.8.0). ([1645] (https://github.com/mapbox/mapbox-maps-android/pull/1645))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 Mapbox welcomes participation and contributions from everyone.
 # main
-* Wrong BitmapWidget position when using WidgetPosition.Horizontal.CENTER. ([1651](https://github.com/mapbox/mapbox-maps-android/pull/1651))
 
 ## Features ✨ and improvements 🏁
 * Deprecated gesture settings `increaseRotateThresholdWhenPinchingToZoom` property. ([1632](https://github.com/mapbox/mapbox-maps-android/pull/1632))
@@ -14,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Preserve cached properties if applied to the layer before during the `Style#getLayer` call. ([1622](https://github.com/mapbox/mapbox-maps-android/pull/1622))
 * Fix a `NullPointerException` in `StandardGestureListener`, where `MotionEvent` should be nullable. ([1645] (https://github.com/mapbox/mapbox-maps-android/pull/1645))
 * Fix incorrect `MapView` dimensions after background orientation change. ([1658](https://github.com/mapbox/mapbox-maps-android/pull/1658))
+* Wrong BitmapWidget position when using WidgetPosition.Horizontal.CENTER. ([1651](https://github.com/mapbox/mapbox-maps-android/pull/1651))
 
 ## Dependencies
 * Update mapbox-gestures-android dependency to [v0.8.0](https://github.com/mapbox/mapbox-gestures-android/releases/tag/v0.8.0). ([1645] (https://github.com/mapbox/mapbox-maps-android/pull/1645))

--- a/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
@@ -16,10 +16,8 @@ internal class BitmapWidgetRenderer(
   private val marginY: Float,
 ) : WidgetRenderer {
 
-  private var bitmapWidth = bitmap?.width ?: 0
-  private var bitmapHeight = bitmap?.height ?: 0
-  private var halfBitmapWidth = bitmapWidth / 2f
-  private var halfBitmapHeight = bitmapHeight / 2f
+  private var halfBitmapWidth = (bitmap?.width ?: 0) / 2f
+  private var halfBitmapHeight = (bitmap?.height ?: 0) / 2f
   private var translationX = 0f
   private var translationY = 0f
 
@@ -69,7 +67,7 @@ internal class BitmapWidgetRenderer(
     )
 
     updateVertexBuffer()
-    setTranslation(this.translationX, this.translationY)
+    setTranslation(translationX, translationY)
   }
 
   private fun updateVertexBuffer() {
@@ -254,11 +252,8 @@ internal class BitmapWidgetRenderer(
 
   fun updateBitmap(bitmap: Bitmap) {
     this.bitmap = bitmap
-    this.bitmapWidth = bitmap.width
-    this.bitmapHeight = bitmap.height
-    this.halfBitmapWidth = bitmapWidth / 2f
-    this.halfBitmapHeight = bitmapHeight / 2f
-
+    this.halfBitmapWidth = bitmap.width / 2f
+    this.halfBitmapHeight = bitmap.height / 2f
     updateVertexBuffer()
     updateMatrix = true
     needRender = true

--- a/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
@@ -18,6 +18,8 @@ internal class BitmapWidgetRenderer(
 
   private var bitmapWidth = bitmap?.width ?: 0
   private var bitmapHeight = bitmap?.height ?: 0
+  private var halfBitmapWidth = bitmapWidth / 2f
+  private var halfBitmapHeight = bitmapHeight / 2f
 
   private var surfaceWidth = 0
   private var surfaceHeight = 0
@@ -80,32 +82,24 @@ internal class BitmapWidgetRenderer(
 
   private fun updateVertexBuffer() {
     // in pixels, (-bitmapWidth / 2, -bitmapHeight/2) - (bitmapWidth / 2, bitmapHeight/2)
-    when (position.horizontal) {
-      WidgetPosition.Horizontal.CENTER -> vertexPositionBuffer.put(
-        0f, 0f,
-        0f, bitmapHeight.toFloat(),
-        bitmapWidth.toFloat(), 0f,
-        bitmapWidth.toFloat(), bitmapHeight.toFloat()
-      )
-      else -> vertexPositionBuffer.put(
-        -bitmapWidth / 2f, -bitmapHeight / 2f,
-        -bitmapWidth / 2f, bitmapHeight / 2f,
-        bitmapWidth / 2f, -bitmapHeight / 2f,
-        bitmapWidth / 2f, bitmapHeight / 2f
-      )
-    }
+    vertexPositionBuffer.put(
+      -halfBitmapWidth, -halfBitmapHeight,
+      -halfBitmapWidth, halfBitmapHeight,
+      halfBitmapWidth, -halfBitmapHeight,
+      halfBitmapWidth, halfBitmapHeight
+    )
   }
 
   private fun topY() = when (position.vertical) {
-    WidgetPosition.Vertical.BOTTOM -> surfaceHeight.toFloat() - bitmapHeight.toFloat() / 2f - marginY
-    WidgetPosition.Vertical.CENTER -> surfaceHeight.toFloat() / 2 - bitmapHeight.toFloat() / 2f + marginY
-    WidgetPosition.Vertical.TOP -> marginY + bitmapHeight.toFloat() / 2f
+    WidgetPosition.Vertical.BOTTOM -> surfaceHeight.toFloat() - halfBitmapHeight - marginY
+    WidgetPosition.Vertical.CENTER -> surfaceHeight.toFloat() / 2 + marginY
+    WidgetPosition.Vertical.TOP -> marginY + halfBitmapHeight
   }
 
   private fun leftX() = when (position.horizontal) {
-    WidgetPosition.Horizontal.LEFT -> marginX + bitmapWidth.toFloat() / 2f
-    WidgetPosition.Horizontal.CENTER -> surfaceWidth.toFloat() / 2 - bitmapWidth.toFloat() / 2f + marginX
-    WidgetPosition.Horizontal.RIGHT -> surfaceWidth.toFloat() - bitmapWidth.toFloat() / 2f - marginX
+    WidgetPosition.Horizontal.LEFT -> marginX + halfBitmapWidth
+    WidgetPosition.Horizontal.CENTER -> surfaceWidth.toFloat() / 2 + marginX
+    WidgetPosition.Horizontal.RIGHT -> surfaceWidth.toFloat() - halfBitmapWidth - marginX
   }
 
   override fun prepare() {
@@ -270,6 +264,9 @@ internal class BitmapWidgetRenderer(
     this.bitmap = bitmap
     this.bitmapWidth = bitmap.width
     this.bitmapHeight = bitmap.height
+    this.halfBitmapWidth = bitmapWidth / 2f
+    this.halfBitmapHeight = bitmapHeight / 2f
+
     updateVertexBuffer()
     updateMatrix = true
     needRender = true

--- a/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
@@ -80,12 +80,22 @@ internal class BitmapWidgetRenderer(
 
   private fun updateVertexBuffer() {
     // in pixels, (-bitmapWidth / 2, -bitmapHeight/2) - (bitmapWidth / 2, bitmapHeight/2)
-    vertexPositionBuffer.put(
-      -bitmapWidth / 2f, -bitmapHeight / 2f,
-      -bitmapWidth / 2f, bitmapHeight / 2f,
-      bitmapWidth / 2f, -bitmapHeight / 2f,
-      bitmapWidth / 2f, bitmapHeight / 2f,
-    )
+    // TODO do we need to specially handle other WidgetPosition.Horizontal values?
+    // TODO does Vertical have any similar issue?
+    when (position.horizontal) {
+      WidgetPosition.Horizontal.CENTER -> vertexPositionBuffer.put(
+        0f, 0f,
+        0f, bitmapHeight.toFloat(),
+        bitmapWidth.toFloat(), 0f,
+        bitmapWidth.toFloat(), bitmapHeight.toFloat()
+      )
+      else -> vertexPositionBuffer.put(
+        -bitmapWidth / 2f, -bitmapHeight / 2f,
+        -bitmapWidth / 2f, bitmapHeight / 2f,
+        bitmapWidth / 2f, -bitmapHeight / 2f,
+        bitmapWidth / 2f, bitmapHeight / 2f
+      )
+    }
   }
 
   private fun topY() = when (position.vertical) {

--- a/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
@@ -20,6 +20,8 @@ internal class BitmapWidgetRenderer(
   private var bitmapHeight = bitmap?.height ?: 0
   private var halfBitmapWidth = bitmapWidth / 2f
   private var halfBitmapHeight = bitmapHeight / 2f
+  private var translationX = 0f
+  private var translationY = 0f
 
   private var surfaceWidth = 0
   private var surfaceHeight = 0
@@ -66,18 +68,8 @@ internal class BitmapWidgetRenderer(
       -1f, 1f, 0f, 1f
     )
 
-    Matrix.translateM(
-      translateMatrix,
-      0,
-      leftX(),
-      topY(),
-      0f
-    )
-
     updateVertexBuffer()
-
-    updateMatrix = true
-    needRender = true
+    setTranslation(this.translationX, this.translationY)
   }
 
   private fun updateVertexBuffer() {
@@ -280,6 +272,8 @@ internal class BitmapWidgetRenderer(
   }
 
   override fun setTranslation(translationX: Float, translationY: Float) {
+    this.translationX = translationX
+    this.translationY = translationY
     Matrix.setIdentityM(translateMatrix, 0)
     Matrix.translateM(
       translateMatrix,

--- a/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
@@ -83,15 +83,15 @@ internal class BitmapWidgetRenderer(
   }
 
   private fun topY() = when (position.vertical) {
-    WidgetPosition.Vertical.BOTTOM -> surfaceHeight.toFloat() - halfBitmapHeight - marginY
-    WidgetPosition.Vertical.CENTER -> surfaceHeight.toFloat() / 2 + marginY
     WidgetPosition.Vertical.TOP -> marginY + halfBitmapHeight
+    WidgetPosition.Vertical.CENTER -> surfaceHeight.toFloat() / 2 + marginY
+    WidgetPosition.Vertical.BOTTOM -> surfaceHeight.toFloat() - (halfBitmapHeight + marginY)
   }
 
   private fun leftX() = when (position.horizontal) {
     WidgetPosition.Horizontal.LEFT -> marginX + halfBitmapWidth
     WidgetPosition.Horizontal.CENTER -> surfaceWidth.toFloat() / 2 + marginX
-    WidgetPosition.Horizontal.RIGHT -> surfaceWidth.toFloat() - halfBitmapWidth - marginX
+    WidgetPosition.Horizontal.RIGHT -> surfaceWidth.toFloat() - (halfBitmapWidth + marginX)
   }
 
   override fun prepare() {

--- a/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
@@ -254,6 +254,7 @@ internal class BitmapWidgetRenderer(
     this.bitmap = bitmap
     this.halfBitmapWidth = bitmap.width / 2f
     this.halfBitmapHeight = bitmap.height / 2f
+    setTranslation(this.translationX, this.translationY)
     updateVertexBuffer()
     updateMatrix = true
     needRender = true

--- a/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/widget/BitmapWidgetRenderer.kt
@@ -80,8 +80,6 @@ internal class BitmapWidgetRenderer(
 
   private fun updateVertexBuffer() {
     // in pixels, (-bitmapWidth / 2, -bitmapHeight/2) - (bitmapWidth / 2, bitmapHeight/2)
-    // TODO do we need to specially handle other WidgetPosition.Horizontal values?
-    // TODO does Vertical have any similar issue?
     when (position.horizontal) {
       WidgetPosition.Horizontal.CENTER -> vertexPositionBuffer.put(
         0f, 0f,


### PR DESCRIPTION
### Summary of changes

Horizontally and/or vertically centred widgets in BitmapWidgetRenderer were right aligned, this PR should fix them.

### User impact (optional)

Widget positions may be affected which have `WidgetPosition.Horizontal.CENTER` or `WidgetPosition.Vertical.CENTER`

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.

After change:

<img width="402" alt="Screenshot 2022-09-07 at 13 52 54" src="https://user-images.githubusercontent.com/16490463/188862378-952b087d-db4c-4194-8bc3-07c5eb0d8910.png">

Before change:

<img width="399" alt="Screenshot 2022-09-07 at 13 58 02" src="https://user-images.githubusercontent.com/16490463/188862405-d802d0c4-131a-4251-8d13-c1df004ef8b9.png">

 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: https://github.com/mapbox/mapbox-maps-android/issues/1531

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
