### PR TITLE
Fix incorrect MapView dimensions on background orientation change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Snap puck to north if puckBearingEnabled is set to false. ([1635] (https://github.com/mapbox/mapbox-maps-android/pull/1635))
 * Preserve cached properties if applied to the layer before during the `Style#getLayer` call. ([1622](https://github.com/mapbox/mapbox-maps-android/pull/1622))
 * Fix a `NullPointerException` in `StandardGestureListener`, where `MotionEvent` should be nullable. ([1645] (https://github.com/mapbox/mapbox-maps-android/pull/1645))
+* Fix incorrect `MapView` dimensions after background orientation change. ([1658](https://github.com/mapbox/mapbox-maps-android/pull/1658))
 
 ## Dependencies
 * Update mapbox-gestures-android dependency to [v0.8.0](https://github.com/mapbox/mapbox-gestures-android/releases/tag/v0.8.0). ([1645] (https://github.com/mapbox/mapbox-maps-android/pull/1645))

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -189,6 +189,9 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   }
 
   override fun onSizeChanged(w: Int, h: Int) {
+    renderer.queueNonRenderEvent {
+      renderer.onSurfaceChanged(w, h)
+    }
     pluginRegistry.onSizeChanged(w, h)
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -189,7 +189,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   }
 
   override fun onSizeChanged(w: Int, h: Int) {
-    renderer.queueNonRenderEvent {
+    renderer.queueRenderEvent {
       renderer.onSurfaceChanged(w, h)
     }
     pluginRegistry.onSizeChanged(w, h)

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -201,7 +201,7 @@ class MapControllerTest {
     every { mockPluginRegistry.onSizeChanged(0, 0) } just Runs
 
     val slotRunnable = slot<Runnable>()
-    every { mockRenderer.queueNonRenderEvent(capture(slotRunnable)) } answers { slotRunnable.captured.run() }
+    every { mockRenderer.queueRenderEvent(capture(slotRunnable)) } answers { slotRunnable.captured.run() }
     every { mockRenderer.onSurfaceChanged(any(), any()) } just Runs
 
     testMapController.onSizeChanged(0, 0)

--- a/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapControllerTest.kt
@@ -200,8 +200,13 @@ class MapControllerTest {
   fun onSizeChanged() {
     every { mockPluginRegistry.onSizeChanged(0, 0) } just Runs
 
+    val slotRunnable = slot<Runnable>()
+    every { mockRenderer.queueNonRenderEvent(capture(slotRunnable)) } answers { slotRunnable.captured.run() }
+    every { mockRenderer.onSurfaceChanged(any(), any()) } just Runs
+
     testMapController.onSizeChanged(0, 0)
 
+    verify { mockRenderer.onSurfaceChanged(0, 0) }
     verify { mockPluginRegistry.onSizeChanged(0, 0) }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

If `configChanges` is specified in AndroidManifest.xml and device is rotated when `MapView` in background - `MapView` was using incorrect old dimensions when bringing it back to front.

That is now fixed by checking if renderer dimensions should be updated if `MapView#onSizeChanged` was called by Android.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.

https://mapbox.atlassian.net/browse/MAPSAND-424
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
