### PR TITLE
Added `pitch` and `distance-from-center` expressions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Enable asynchronous tile uploader by default to improve animation performance. ([1679](https://github.com/mapbox/mapbox-maps-android/pull/1679))
 * Vector tiles without symbols are not hold for fade-out animation so that less amount of vector tiles are managed at a time. ([1679](https://github.com/mapbox/mapbox-maps-android/pull/1679))
 * Add support to set location puck opacity. ([1659](https://github.com/mapbox/mapbox-maps-android/pull/1659))
+* Support `pitch` and `distanceFromCenter` filters in symbol layers. ([1662](https://github.com/mapbox/mapbox-maps-android/pull/1662))
 
 ## Bug fixes 🐞
 * Fix scale bar truncated at high zoom levels near the poles. ([1620](https://github.com/mapbox/mapbox-maps-android/pull/1620))

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/DSLStylingActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/DSLStylingActivity.kt
@@ -6,8 +6,21 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.bindgen.Expected
 import com.mapbox.geojson.Point
-import com.mapbox.maps.*
-import com.mapbox.maps.extension.style.expressions.dsl.generated.*
+import com.mapbox.maps.MapView
+import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.QueriedFeature
+import com.mapbox.maps.RenderedQueryGeometry
+import com.mapbox.maps.RenderedQueryOptions
+import com.mapbox.maps.ScreenBox
+import com.mapbox.maps.ScreenCoordinate
+import com.mapbox.maps.Style
+import com.mapbox.maps.extension.style.expressions.dsl.generated.concat
+import com.mapbox.maps.extension.style.expressions.dsl.generated.format
+import com.mapbox.maps.extension.style.expressions.dsl.generated.get
+import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
+import com.mapbox.maps.extension.style.expressions.dsl.generated.rgb
+import com.mapbox.maps.extension.style.expressions.dsl.generated.subtract
+import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.all
 import com.mapbox.maps.extension.style.layers.generated.circleLayer
 import com.mapbox.maps.extension.style.layers.generated.rasterLayer
 import com.mapbox.maps.extension.style.layers.generated.symbolLayer
@@ -18,13 +31,12 @@ import com.mapbox.maps.extension.style.style
 import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.addOnMapClickListener
 import java.text.DateFormat.getDateTimeInstance
-import java.util.*
+import java.util.Date
 
 /**
  * Example showcasing usage of style extension.
  */
 class DSLStylingActivity : AppCompatActivity(), OnMapClickListener {
-
   private lateinit var mapboxMap: MapboxMap
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -92,12 +104,19 @@ class DSLStylingActivity : AppCompatActivity(), OnMapClickListener {
         layerId = "earthquakeText",
         sourceId = "earthquakes"
       ) {
+        // Only show the magnitude scale if the value is >5.0 and the map pitch is < 70º
         filter(
-          gt {
-            get {
-              literal("mag")
+          all {
+            gt {
+              get {
+                literal("mag")
+              }
+              literal(5.0)
             }
-            literal(5.0)
+            lt {
+              pitch()
+              literal(70.0)
+            }
           }
         )
         textField(

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/DSLStylingActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/DSLStylingActivity.kt
@@ -104,18 +104,34 @@ class DSLStylingActivity : AppCompatActivity(), OnMapClickListener {
         layerId = "earthquakeText",
         sourceId = "earthquakes"
       ) {
-        // Only show the magnitude scale if the value is >5.0 and the map pitch is < 70º
+        // Only show the magnitude scale if the value is >4.0 and:
+        // - the map pitch is < 70º or
+        // - objects are close to the camera
         filter(
           all {
             gt {
               get {
                 literal("mag")
               }
-              literal(5.0)
+              literal(4.0)
             }
-            lt {
-              pitch()
-              literal(70.0)
+            switchCase {
+              // 1st case: return true if pitch <70º
+              lt {
+                pitch()
+                literal(70.0)
+              }
+              literal(true)
+
+              // 2nd case: return true if close to camera
+              lte {
+                distanceFromCenter()
+                literal(-0.5)
+              }
+              literal(true)
+
+              // otherwise: return false
+              literal(false)
             }
           }
         )

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/expressions/ExpressionTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/expressions/ExpressionTest.kt
@@ -1903,4 +1903,44 @@ class ExpressionTest : BaseStyleTest() {
       layer.filter.toString()
     )
   }
+
+  /**
+   * Verify that symbol layers can be filtered using distance-from-center
+   */
+  @Test
+  @UiThreadTest
+  fun symbolLayerDistanceFromCenterFilterTest() {
+    val expression = lt {
+      distanceFromCenter()
+      literal(1.0)
+    }
+    val layer = symbolLayer("id", "source") {
+      filter(expression)
+    }
+    setupLayer(layer)
+    assertEquals(
+      "[<, [distance-from-center], 1.0]",
+      layer.filter.toString()
+    )
+  }
+
+  /**
+   * Verify that symbol layers can be filtered using pitch
+   */
+  @Test
+  @UiThreadTest
+  fun symbolLayerPitchFilterTest() {
+    val expression = lt {
+      pitch()
+      literal(20.0)
+    }
+    val layer = symbolLayer("id", "source") {
+      filter(expression)
+    }
+    setupLayer(layer)
+    assertEquals(
+      "[<, [pitch], 20.0]",
+      layer.filter.toString()
+    )
+  }
 }

--- a/extension-style/api/extension-style.api
+++ b/extension-style/api/extension-style.api
@@ -166,6 +166,7 @@ public final class com/mapbox/maps/extension/style/expressions/dsl/generated/Exp
 	public static final fun cos (D)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun cos (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun distance (Lcom/mapbox/geojson/GeoJson;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
+	public static final fun distanceFromCenter ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun division (DD)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun division (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun downcase (Ljava/lang/String;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
@@ -228,6 +229,7 @@ public final class com/mapbox/maps/extension/style/expressions/dsl/generated/Exp
 	public static final fun numberFormat (Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun objectExpression (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun pi ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
+	public static final fun pitch ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun pow (DD)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun pow (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun product (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
@@ -305,6 +307,7 @@ public final class com/mapbox/maps/extension/style/expressions/generated/Express
 	public static final fun cos ([Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun cubicBezier (Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun distance (Lcom/mapbox/geojson/GeoJson;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
+	public static final fun distanceFromCenter ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun division (DD)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun division ([Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun downcase (Ljava/lang/String;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
@@ -373,6 +376,7 @@ public final class com/mapbox/maps/extension/style/expressions/generated/Express
 	public static final fun numberFormat (Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun objectExpression ([Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun pi ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
+	public static final fun pitch ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun pow (DD)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun pow ([Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public static final fun product ([D)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
@@ -483,6 +487,7 @@ public final class com/mapbox/maps/extension/style/expressions/generated/Express
 	public final fun cubicBezier (Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun cubicBezier (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun distance (Lcom/mapbox/geojson/GeoJson;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
+	public final fun distanceFromCenter ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun division (DD)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun division (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun division ([Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
@@ -580,6 +585,7 @@ public final class com/mapbox/maps/extension/style/expressions/generated/Express
 	public final fun objectExpression (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun objectExpression ([Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun pi ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
+	public final fun pitch ()Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun pow (DD)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun pow (Lkotlin/jvm/functions/Function1;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
 	public final fun pow ([Lcom/mapbox/maps/extension/style/expressions/generated/Expression;)Lcom/mapbox/maps/extension/style/expressions/generated/Expression;
@@ -673,6 +679,7 @@ public class com/mapbox/maps/extension/style/expressions/generated/Expression$Ex
 	public final fun cos (D)V
 	public final fun cos (Lkotlin/jvm/functions/Function1;)V
 	public final fun distance (Lcom/mapbox/geojson/GeoJson;)V
+	public final fun distanceFromCenter ()V
 	public final fun division (DD)V
 	public final fun division (Lkotlin/jvm/functions/Function1;)V
 	public final fun downcase (Ljava/lang/String;)V
@@ -736,6 +743,7 @@ public class com/mapbox/maps/extension/style/expressions/generated/Expression$Ex
 	public final fun numberFormat (Lcom/mapbox/maps/extension/style/expressions/generated/Expression;Lkotlin/jvm/functions/Function1;)V
 	public final fun objectExpression (Lkotlin/jvm/functions/Function1;)V
 	public final fun pi ()V
+	public final fun pitch ()V
 	public final fun pow (DD)V
 	public final fun pow (Lkotlin/jvm/functions/Function1;)V
 	public final fun product (Lkotlin/jvm/functions/Function1;)V

--- a/extension-style/api/metalava.txt
+++ b/extension-style/api/metalava.txt
@@ -191,6 +191,7 @@ package com.mapbox.maps.extension.style.expressions.dsl.generated {
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression cos(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression cos(double value);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression distance(com.mapbox.geojson.GeoJson geojson);
+    method public static com.mapbox.maps.extension.style.expressions.generated.Expression distanceFromCenter();
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression division(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression division(double first, double second);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression downcase(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
@@ -253,6 +254,7 @@ package com.mapbox.maps.extension.style.expressions.dsl.generated {
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression numberFormat(com.mapbox.maps.extension.style.expressions.generated.Expression input, kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.NumberFormatBuilder,kotlin.Unit> block);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression objectExpression(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression pi();
+    method public static com.mapbox.maps.extension.style.expressions.generated.Expression pitch();
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression pow(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression pow(double first, double second);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression product(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
@@ -328,6 +330,7 @@ package com.mapbox.maps.extension.style.expressions.generated {
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression cos(double value);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression cubicBezier(com.mapbox.maps.extension.style.expressions.generated.Expression x1, com.mapbox.maps.extension.style.expressions.generated.Expression x2, com.mapbox.maps.extension.style.expressions.generated.Expression x3, com.mapbox.maps.extension.style.expressions.generated.Expression x4);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression distance(com.mapbox.geojson.GeoJson geojson);
+    method public static com.mapbox.maps.extension.style.expressions.generated.Expression distanceFromCenter();
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression division(com.mapbox.maps.extension.style.expressions.generated.Expression... expressions);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression division(double first, double second);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression downcase(com.mapbox.maps.extension.style.expressions.generated.Expression... expressions);
@@ -395,6 +398,7 @@ package com.mapbox.maps.extension.style.expressions.generated {
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression numberFormat(double value, kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.NumberFormatBuilder,kotlin.Unit> block);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression objectExpression(com.mapbox.maps.extension.style.expressions.generated.Expression... expressions);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression pi();
+    method public static com.mapbox.maps.extension.style.expressions.generated.Expression pitch();
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression pow(com.mapbox.maps.extension.style.expressions.generated.Expression... expressions);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression pow(double first, double second);
     method public static com.mapbox.maps.extension.style.expressions.generated.Expression product(com.mapbox.maps.extension.style.expressions.generated.Expression... expressions);
@@ -502,6 +506,7 @@ package com.mapbox.maps.extension.style.expressions.generated {
     method public com.mapbox.maps.extension.style.expressions.generated.Expression cubicBezier(com.mapbox.maps.extension.style.expressions.generated.Expression x1, com.mapbox.maps.extension.style.expressions.generated.Expression x2, com.mapbox.maps.extension.style.expressions.generated.Expression x3, com.mapbox.maps.extension.style.expressions.generated.Expression x4);
     method public com.mapbox.maps.extension.style.expressions.generated.Expression cubicBezier(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.expressions.generated.Expression distance(com.mapbox.geojson.GeoJson geojson);
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression distanceFromCenter();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression division(com.mapbox.maps.extension.style.expressions.generated.Expression... expressions);
     method public com.mapbox.maps.extension.style.expressions.generated.Expression division(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.expressions.generated.Expression division(double first, double second);
@@ -598,6 +603,7 @@ package com.mapbox.maps.extension.style.expressions.generated {
     method public com.mapbox.maps.extension.style.expressions.generated.Expression objectExpression(com.mapbox.maps.extension.style.expressions.generated.Expression... expressions);
     method public com.mapbox.maps.extension.style.expressions.generated.Expression objectExpression(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.expressions.generated.Expression pi();
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression pitch();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression pow(com.mapbox.maps.extension.style.expressions.generated.Expression... expressions);
     method public com.mapbox.maps.extension.style.expressions.generated.Expression pow(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.expressions.generated.Expression pow(double first, double second);
@@ -691,6 +697,7 @@ package com.mapbox.maps.extension.style.expressions.generated {
     method public final void cos(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public final void cos(double value);
     method public final void distance(com.mapbox.geojson.GeoJson geojson);
+    method public final void distanceFromCenter();
     method public final void division(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public final void division(double first, double second);
     method public final void downcase(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
@@ -754,6 +761,7 @@ package com.mapbox.maps.extension.style.expressions.generated {
     method public final void numberFormat(double value, kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.NumberFormatBuilder,kotlin.Unit> block);
     method public final void objectExpression(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public final void pi();
+    method public final void pitch();
     method public final void pow(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);
     method public final void pow(double first, double second);
     method public final void product(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder,kotlin.Unit> block);

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/dsl/generated/ExpressionDsl.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/dsl/generated/ExpressionDsl.kt
@@ -161,7 +161,7 @@ fun distance(geojson: GeoJson) = Expression.distance(geojson)
 /**
  * Returns the distance of a `symbol` instance from the center of the map. The distance is measured in pixels divided by the height of the map container. It measures 0 at the center, decreases towards the camera and increase away from the camera. For example, if the height of the map is 1000px, a value of -1 means 1000px away from the center towards the camera, and a value of 1 means a distance of 1000px away from the camera from the center. `["distance-from-center"]` may only be used in the `filter` expression for a `symbol` layer.
  */
-fun distanceFromCenter(block: Expression.ExpressionBuilder.() -> Unit) = Expression.distanceFromCenter(block)
+fun distanceFromCenter() = Expression.distanceFromCenter()
 
 /**
  * Returns the input string converted to lowercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.
@@ -354,7 +354,7 @@ fun pi() = Expression.pi()
 /**
  * Returns the current pitch in degrees. `["pitch"]` may only be used in the `filter` expression for a `symbol` layer.
  */
-fun pitch(block: Expression.ExpressionBuilder.() -> Unit) = Expression.pitch(block)
+fun pitch() = Expression.pitch()
 
 /**
  * Returns the feature properties object.  Note that in some cases, it may be more efficient to use `["get", "property_name"]` directly.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/dsl/generated/ExpressionDsl.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/dsl/generated/ExpressionDsl.kt
@@ -159,6 +159,11 @@ fun cos(block: Expression.ExpressionBuilder.() -> Unit) = Expression.cos(block)
 fun distance(geojson: GeoJson) = Expression.distance(geojson)
 
 /**
+ * Returns the distance of a `symbol` instance from the center of the map. The distance is measured in pixels divided by the height of the map container. It measures 0 at the center, decreases towards the camera and increase away from the camera. For example, if the height of the map is 1000px, a value of -1 means 1000px away from the center towards the camera, and a value of 1 means a distance of 1000px away from the camera from the center. `["distance-from-center"]` may only be used in the `filter` expression for a `symbol` layer.
+ */
+fun distanceFromCenter(block: Expression.ExpressionBuilder.() -> Unit) = Expression.distanceFromCenter(block)
+
+/**
  * Returns the input string converted to lowercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.
  */
 fun downcase(block: Expression.ExpressionBuilder.() -> Unit) = Expression.downcase(block)
@@ -345,6 +350,11 @@ fun objectExpression(block: Expression.ExpressionBuilder.() -> Unit) = Expressio
  * Returns the mathematical constant pi.
  */
 fun pi() = Expression.pi()
+
+/**
+ * Returns the current pitch in degrees. `["pitch"]` may only be used in the `filter` expression for a `symbol` layer.
+ */
+fun pitch(block: Expression.ExpressionBuilder.() -> Unit) = Expression.pitch(block)
 
 /**
  * Returns the feature properties object.  Note that in some cases, it may be more efficient to use `["get", "property_name"]` directly.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
@@ -422,6 +422,18 @@ class Expression : Value {
     }
 
     /**
+     * Returns the distance of a `symbol` instance from the center of the map. The distance is
+     * measured in pixels divided by the height of the map container. It measures 0 at the
+     * center, decreases towards the camera and increase away from the camera. For example, if the height
+     * of the map is 1000px, a value of -1 means 1000px away from the center towards
+     * the camera, and a value of 1 means a distance of 1000px away from the camera
+     * from the center. `["distance-from-center"]` may only be used in the `filter` expression for a `symbol` layer.
+     */
+    fun distanceFromCenter(block: ExpressionBuilder.() -> Unit) {
+      this@ExpressionBuilder.arguments.add(Expression.distanceFromCenter(block))
+    }
+
+    /**
      * Returns the input string converted to lowercase. Follows the Unicode Default Case Conversion algorithm and the
      * locale-insensitive case mappings in the Unicode Character Database.
      */
@@ -720,6 +732,14 @@ class Expression : Value {
      */
     fun pi() {
       this@ExpressionBuilder.arguments.add(Expression.pi())
+    }
+
+    /**
+     * Returns the current pitch in degrees. `["pitch"]` may only be used in the `filter` expression for
+     * a `symbol` layer.
+     */
+    fun pitch(block: ExpressionBuilder.() -> Unit) {
+      this@ExpressionBuilder.arguments.add(Expression.pitch(block))
     }
 
     /**
@@ -2300,6 +2320,29 @@ class Expression : Value {
     }
 
     /**
+     * Returns the distance of a `symbol` instance from the center of the map. The distance is
+     * measured in pixels divided by the height of the map container. It measures 0 at the
+     * center, decreases towards the camera and increase away from the camera. For example, if the height
+     * of the map is 1000px, a value of -1 means 1000px away from the center towards
+     * the camera, and a value of 1 means a distance of 1000px away from the camera
+     * from the center. `["distance-from-center"]` may only be used in the `filter` expression for a `symbol` layer.
+     */
+    @JvmStatic
+    fun distanceFromCenter(vararg expressions: Expression): Expression {
+      val builder = ExpressionBuilder("distance-from-center")
+      expressions.forEach {
+        builder.addArgument(it)
+      }
+      return builder.build()
+    }
+
+    /**
+     * DSL function for "distance-from-center".
+     */
+    fun distanceFromCenter(block: ExpressionBuilder.() -> Unit): Expression =
+      ExpressionBuilder("distance-from-center").apply(block).build()
+
+    /**
      * Returns the input string converted to lowercase. Follows the Unicode Default Case Conversion algorithm and the
      * locale-insensitive case mappings in the Unicode Character Database.
      */
@@ -2855,6 +2898,25 @@ class Expression : Value {
      */
     @JvmStatic
     fun pi() = ExpressionBuilder("pi").build()
+
+    /**
+     * Returns the current pitch in degrees. `["pitch"]` may only be used in the `filter` expression for
+     * a `symbol` layer.
+     */
+    @JvmStatic
+    fun pitch(vararg expressions: Expression): Expression {
+      val builder = ExpressionBuilder("pitch")
+      expressions.forEach {
+        builder.addArgument(it)
+      }
+      return builder.build()
+    }
+
+    /**
+     * DSL function for "pitch".
+     */
+    fun pitch(block: ExpressionBuilder.() -> Unit): Expression =
+      ExpressionBuilder("pitch").apply(block).build()
 
     /**
      * Returns the feature properties object.  Note that in some cases, it may be more efficient

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/expressions/generated/Expression.kt
@@ -429,8 +429,8 @@ class Expression : Value {
      * the camera, and a value of 1 means a distance of 1000px away from the camera
      * from the center. `["distance-from-center"]` may only be used in the `filter` expression for a `symbol` layer.
      */
-    fun distanceFromCenter(block: ExpressionBuilder.() -> Unit) {
-      this@ExpressionBuilder.arguments.add(Expression.distanceFromCenter(block))
+    fun distanceFromCenter() {
+      this@ExpressionBuilder.arguments.add(Expression.distanceFromCenter())
     }
 
     /**
@@ -738,8 +738,8 @@ class Expression : Value {
      * Returns the current pitch in degrees. `["pitch"]` may only be used in the `filter` expression for
      * a `symbol` layer.
      */
-    fun pitch(block: ExpressionBuilder.() -> Unit) {
-      this@ExpressionBuilder.arguments.add(Expression.pitch(block))
+    fun pitch() {
+      this@ExpressionBuilder.arguments.add(Expression.pitch())
     }
 
     /**
@@ -2328,19 +2328,7 @@ class Expression : Value {
      * from the center. `["distance-from-center"]` may only be used in the `filter` expression for a `symbol` layer.
      */
     @JvmStatic
-    fun distanceFromCenter(vararg expressions: Expression): Expression {
-      val builder = ExpressionBuilder("distance-from-center")
-      expressions.forEach {
-        builder.addArgument(it)
-      }
-      return builder.build()
-    }
-
-    /**
-     * DSL function for "distance-from-center".
-     */
-    fun distanceFromCenter(block: ExpressionBuilder.() -> Unit): Expression =
-      ExpressionBuilder("distance-from-center").apply(block).build()
+    fun distanceFromCenter() = ExpressionBuilder("distance-from-center").build()
 
     /**
      * Returns the input string converted to lowercase. Follows the Unicode Default Case Conversion algorithm and the
@@ -2904,19 +2892,7 @@ class Expression : Value {
      * a `symbol` layer.
      */
     @JvmStatic
-    fun pitch(vararg expressions: Expression): Expression {
-      val builder = ExpressionBuilder("pitch")
-      expressions.forEach {
-        builder.addArgument(it)
-      }
-      return builder.build()
-    }
-
-    /**
-     * DSL function for "pitch".
-     */
-    fun pitch(block: ExpressionBuilder.() -> Unit): Expression =
-      ExpressionBuilder("pitch").apply(block).build()
+    fun pitch() = ExpressionBuilder("pitch").build()
 
     /**
      * Returns the feature properties object.  Note that in some cases, it may be more efficient

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/expressions/generated/ExpressionTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/expressions/generated/ExpressionTest.kt
@@ -486,6 +486,21 @@ class ExpressionTest {
   }
 
   @Test
+  fun dsl_expression_distanceFromCenter() {
+    val expression = distanceFromCenter {
+      // test builder function
+      distanceFromCenter {}
+    }
+    assertEquals("assert distance-from-center expression", "[distance-from-center, [distance-from-center]]", expression.toString())
+  }
+
+  @Test
+  fun expression_distanceFromCenter() {
+    val expression = Expression.distanceFromCenter(Expression.literal("abc"))
+    assertEquals("assert distance-from-center expression", "[distance-from-center, abc]", expression.toString())
+  }
+
+  @Test
   fun dsl_expression_downcase() {
     val expression = downcase {
       // test builder function
@@ -1114,6 +1129,21 @@ class ExpressionTest {
   fun expression_pi() {
     val expression = pi()
     assertEquals("assert pi expression", "[pi]", expression.toString())
+  }
+
+  @Test
+  fun dsl_expression_pitch() {
+    val expression = pitch {
+      // test builder function
+      pitch {}
+    }
+    assertEquals("assert pitch expression", "[pitch, [pitch]]", expression.toString())
+  }
+
+  @Test
+  fun expression_pitch() {
+    val expression = Expression.pitch(Expression.literal("abc"))
+    assertEquals("assert pitch expression", "[pitch, abc]", expression.toString())
   }
 
   @Test

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/expressions/generated/ExpressionTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/expressions/generated/ExpressionTest.kt
@@ -486,18 +486,9 @@ class ExpressionTest {
   }
 
   @Test
-  fun dsl_expression_distanceFromCenter() {
-    val expression = distanceFromCenter {
-      // test builder function
-      distanceFromCenter {}
-    }
-    assertEquals("assert distance-from-center expression", "[distance-from-center, [distance-from-center]]", expression.toString())
-  }
-
-  @Test
   fun expression_distanceFromCenter() {
-    val expression = Expression.distanceFromCenter(Expression.literal("abc"))
-    assertEquals("assert distance-from-center expression", "[distance-from-center, abc]", expression.toString())
+    val expression = distanceFromCenter()
+    assertEquals("assert distance-from-center expression", "[distance-from-center]", expression.toString())
   }
 
   @Test
@@ -1132,18 +1123,9 @@ class ExpressionTest {
   }
 
   @Test
-  fun dsl_expression_pitch() {
-    val expression = pitch {
-      // test builder function
-      pitch {}
-    }
-    assertEquals("assert pitch expression", "[pitch, [pitch]]", expression.toString())
-  }
-
-  @Test
   fun expression_pitch() {
-    val expression = Expression.pitch(Expression.literal("abc"))
-    assertEquals("assert pitch expression", "[pitch, abc]", expression.toString())
+    val expression = pitch()
+    assertEquals("assert pitch expression", "[pitch]", expression.toString())
   }
 
   @Test


### PR DESCRIPTION
### Summary of changes

Added support for `pitch` and `distanceFromCenter` in filter expressions for symbol layers.

See counterpart `gl-js` https://github.com/mapbox/mapbox-gl-js/pull/10795

### User impact (optional)

Users can now use `pitch {...}` and `distanceFromCenter {..}` expressions in symbol layers.

See following capture where `mag x` text symbols are hidden when the pitch is higher than 70º.

https://user-images.githubusercontent.com/691172/191190437-90876320-c207-4726-9edb-5a83cf98d5ca.mp4


## Pull request checklist:

 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [x] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
