### PR TITLE
MAPSAND-397 Attempt to detect invalid Activity when calling MapView.getMapboxMap

### DIFF
--- a/app/src/androidTest/java/com/mapbox/maps/testapp/BaseMapTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/BaseMapTest.kt
@@ -56,7 +56,7 @@ abstract class BaseMapTest {
     val latch = CountDownLatch(1)
     rule.scenario.onActivity {
       it.runOnUiThread {
-        mapboxMap = mapView.getMapboxMap()
+        mapboxMap = mapView.getMapboxMapWithoutActivityCheck()
         mapboxMap.loadStyleUri(
           Style.MAPBOX_STREETS
         ) { style ->

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/featurestate/FeatureStateTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/featurestate/FeatureStateTest.kt
@@ -28,7 +28,7 @@ class FeatureStateTest : BaseMapTest() {
     val countDownLatch = CountDownLatch(1)
     rule.scenario.onActivity {
       it.runOnUiThread {
-        mapboxMap = mapView.getMapboxMap()
+        mapboxMap = mapView.getMapboxMapWithoutActivityCheck()
         mapboxMap.loadStyle(
           style(Style.MAPBOX_STREETS) {
             +geoJsonSource("source") {

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/observable/ObservableExtensionTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/observable/ObservableExtensionTest.kt
@@ -48,7 +48,7 @@ class ObservableExtensionTest : BaseMapTest() {
   override fun loadMap() {
     rule.scenario.onActivity {
       it.runOnUiThread {
-        mapboxMap = mapView.getMapboxMap()
+        mapboxMap = mapView.getMapboxMapWithoutActivityCheck()
       }
     }
   }

--- a/sdk/src/test/java/com/mapbox/maps/MapViewTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapViewTest.kt
@@ -67,6 +67,13 @@ class MapViewTest {
   @Test
   fun getMapboxMap() {
     mapView.getMapboxMap()
+    verify { mapController.onDestroy() }
+    verify { mapController.getMapboxMap() }
+  }
+
+  @Test
+  fun getMapboxMapWithoutActivityCheck() {
+    mapView.getMapboxMapWithoutActivityCheck()
     verify { mapController.getMapboxMap() }
   }
 


### PR DESCRIPTION
Covers the situation where a MapView can be in a Fragment which is removed from the Activity before onAttachedToWindow is called. Not sure whether we should really be trying to handle this case in the SDK, looks more like an issue with the user's application logic.

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
