### PR TITLE
Fix readme link to metalava dependencies

### DIFF
--- a/metalava/README.md
+++ b/metalava/README.md
@@ -39,4 +39,4 @@ org.ow2.asm:asm-tree:8.0
 // Metalava isn't released yet. Check in its jar and explicitly track its transitive deps.
 ```
 
-- Copy and paste (update) the new deps into [`gradle/metalava-dependencies.gradle`](../gradle/metalava-dependencies.gradle)
+- Copy and paste (update) the new deps into [`gradle/metalava.gradle`](../gradle/metalava.gradle)


### PR DESCRIPTION


<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes
- Update readme to use correct link to metalava gradle dependencies file.
- No tests were added as the change only affects the readme file and shouldn't affect any functionality.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] ~~Include before/after visuals or gifs if this PR includes visual changes.~~
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] ~~Write tests for all new functionality. If tests were not written, please explain why.~~
 - [x] ~~Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).~~
 - [x] ~~Add example if relevant.~~
 - [x] ~~Document any changes to public APIs.~~
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
