### PR TITLE
[Android Auto] Allow for downstream upgrades

### DIFF
--- a/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/testing/CarJavaInterfaceChecker.java
+++ b/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/testing/CarJavaInterfaceChecker.java
@@ -14,6 +14,7 @@ import com.mapbox.maps.MapSurface;
 import com.mapbox.maps.MapboxExperimental;
 import com.mapbox.maps.ResourceOptions;
 import com.mapbox.maps.ScreenCoordinate;
+import com.mapbox.maps.extension.androidauto.CarMapSurfaceOwner;
 import com.mapbox.maps.extension.androidauto.MapboxCarMap;
 import com.mapbox.maps.extension.androidauto.DefaultMapboxCarMapGestureHandler;
 import com.mapbox.maps.extension.androidauto.MapboxCarMapEx;
@@ -24,8 +25,13 @@ import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface;
 @MapboxExperimental
 class CarJavaInterfaceChecker {
 
-  void constructors(MapInitOptions mapInitOptions) {
-    MapboxCarMap mapboxCarMap = new MapboxCarMap();
+  void constructorMapboxCarMap(MapInitOptions mapInitOptions) {
+    new MapboxCarMap();
+  }
+
+  void constructorsCarMapSurfaceOwner(MapboxCarMapGestureHandler gestures) {
+    new CarMapSurfaceOwner();
+    new CarMapSurfaceOwner(gestures);
   }
 
   void getters(MapboxCarMap mapboxCarMap) {

--- a/extension-androidauto/CHANGELOG.md
+++ b/extension-androidauto/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Change `MapboxCarMapObserver` to an java interface so default methods can be added without breaking java backwards compatibility. ([#1670](https://github.com/mapbox/mapbox-maps-android/pull/1648))
 * Change `MapboxCarMap#getEdgeInsets()` to `mapboxCarMap.getVisibleEdgeInsets()` with the addition of `mapboxCarMap.getStableEdgeInsets()`. ([#1670](https://github.com/mapbox/mapbox-maps-android/pull/1648))
 * Add `MapboxCarMapObserver#onStableAreaChanged` to support all the available functions from the SurfaceCallback. ([#1670](https://github.com/mapbox/mapbox-maps-android/pull/1648))
+* Add support for intercepting the `SurfaceCallback#onClick` when using `MapboxCarMap.prepareSurfaceCallback`. ([#1683](https://github.com/mapbox/mapbox-maps-android/pull/1683)])
 
 ## Bug fixes 🐞
 

--- a/extension-androidauto/api/extension-androidauto.api
+++ b/extension-androidauto/api/extension-androidauto.api
@@ -7,7 +7,7 @@ public class com/mapbox/maps/extension/androidauto/DefaultMapboxCarMapGestureHan
 
 public final class com/mapbox/maps/extension/androidauto/MapboxCarMap {
 	public fun <init> ()V
-	public final fun clearObservers ()V
+	public final fun clearObservers ()Lcom/mapbox/maps/extension/androidauto/MapboxCarMap;
 	public final fun getCarContext ()Landroidx/car/app/CarContext;
 	public final fun getCarMapSurface ()Lcom/mapbox/maps/extension/androidauto/MapboxCarMapSurface;
 	public final fun getMapInitOptions ()Lcom/mapbox/maps/MapInitOptions;
@@ -15,10 +15,11 @@ public final class com/mapbox/maps/extension/androidauto/MapboxCarMap {
 	public final fun getStableEdgeInsets ()Lcom/mapbox/maps/EdgeInsets;
 	public final fun getVisibleArea ()Landroid/graphics/Rect;
 	public final fun getVisibleEdgeInsets ()Lcom/mapbox/maps/EdgeInsets;
+	public final fun prepareSurfaceCallback (Landroidx/car/app/CarContext;Lcom/mapbox/maps/MapInitOptions;)Landroidx/car/app/SurfaceCallback;
 	public final fun registerObserver (Lcom/mapbox/maps/extension/androidauto/MapboxCarMapObserver;)Lcom/mapbox/maps/extension/androidauto/MapboxCarMap;
-	public final fun setGestureHandler (Lcom/mapbox/maps/extension/androidauto/MapboxCarMapGestureHandler;)V
+	public final fun setGestureHandler (Lcom/mapbox/maps/extension/androidauto/MapboxCarMapGestureHandler;)Lcom/mapbox/maps/extension/androidauto/MapboxCarMap;
 	public final fun setup (Landroidx/car/app/CarContext;Lcom/mapbox/maps/MapInitOptions;)Lcom/mapbox/maps/extension/androidauto/MapboxCarMap;
-	public final fun unregisterObserver (Lcom/mapbox/maps/extension/androidauto/MapboxCarMapObserver;)V
+	public final fun unregisterObserver (Lcom/mapbox/maps/extension/androidauto/MapboxCarMapObserver;)Lcom/mapbox/maps/extension/androidauto/MapboxCarMap;
 }
 
 public final class com/mapbox/maps/extension/androidauto/MapboxCarMapEx {

--- a/extension-androidauto/api/metalava.txt
+++ b/extension-androidauto/api/metalava.txt
@@ -7,7 +7,7 @@ package com.mapbox.maps.extension.androidauto {
 
   @com.mapbox.maps.MapboxExperimental public final class MapboxCarMap {
     ctor public MapboxCarMap();
-    method public void clearObservers();
+    method public com.mapbox.maps.extension.androidauto.MapboxCarMap clearObservers();
     method public androidx.car.app.CarContext getCarContext();
     method public com.mapbox.maps.extension.androidauto.MapboxCarMapSurface? getCarMapSurface();
     method public com.mapbox.maps.MapInitOptions getMapInitOptions();
@@ -15,10 +15,11 @@ package com.mapbox.maps.extension.androidauto {
     method public com.mapbox.maps.EdgeInsets? getStableEdgeInsets();
     method public android.graphics.Rect? getVisibleArea();
     method public com.mapbox.maps.EdgeInsets? getVisibleEdgeInsets();
+    method @com.mapbox.maps.MapboxExperimental public androidx.car.app.SurfaceCallback prepareSurfaceCallback(androidx.car.app.CarContext carContext, com.mapbox.maps.MapInitOptions mapInitOptions);
     method public com.mapbox.maps.extension.androidauto.MapboxCarMap registerObserver(com.mapbox.maps.extension.androidauto.MapboxCarMapObserver mapboxCarMapObserver);
-    method public void setGestureHandler(com.mapbox.maps.extension.androidauto.MapboxCarMapGestureHandler? gestureHandler);
+    method public com.mapbox.maps.extension.androidauto.MapboxCarMap setGestureHandler(com.mapbox.maps.extension.androidauto.MapboxCarMapGestureHandler? gestureHandler);
     method public com.mapbox.maps.extension.androidauto.MapboxCarMap setup(androidx.car.app.CarContext carContext, com.mapbox.maps.MapInitOptions mapInitOptions);
-    method public void unregisterObserver(com.mapbox.maps.extension.androidauto.MapboxCarMapObserver mapboxCarMapObserver);
+    method public com.mapbox.maps.extension.androidauto.MapboxCarMap unregisterObserver(com.mapbox.maps.extension.androidauto.MapboxCarMapObserver mapboxCarMapObserver);
     property public final androidx.car.app.CarContext carContext;
     property public final com.mapbox.maps.extension.androidauto.MapboxCarMapSurface? carMapSurface;
     property public final com.mapbox.maps.MapInitOptions mapInitOptions;

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMap.kt
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMap.kt
@@ -4,6 +4,7 @@ import android.graphics.Rect
 import androidx.car.app.AppManager
 import androidx.car.app.CarContext
 import androidx.car.app.Session
+import androidx.car.app.SurfaceCallback
 import androidx.lifecycle.Lifecycle
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapInitOptions
@@ -71,11 +72,29 @@ class MapboxCarMap {
     carContext: CarContext,
     mapInitOptions: MapInitOptions,
   ) = apply {
+    val surfaceCallback = prepareSurfaceCallback(carContext, mapInitOptions)
+    carContext.getCarService(AppManager::class.java).setSurfaceCallback(surfaceCallback)
+  }
+
+  /**
+   * Instead of using [setup], this function allows you to create your own [SurfaceCallback] and
+   * forward the calls to the returned [SurfaceCallback]. This makes it possible for you to adopt
+   * new api versions or intercept the calls and continue to use the [MapboxCarMap] as designed.
+   *
+   * This may be a temporary solution, while androidx.car.app:app:1.3.0 is rolling out
+   * [SurfaceCallback.onClick]. If there is no use for this function in the future, it will be
+   * removed.
+   */
+  @MapboxExperimental
+  fun prepareSurfaceCallback(
+    carContext: CarContext,
+    mapInitOptions: MapInitOptions
+  ): SurfaceCallback {
     check(mapInitOptions.context is CarContext) {
-      "You must setup the MapboxCarMap MapInitOptions with a CarContext"
+      "You must set up the MapboxCarMap MapInitOptions with a CarContext"
     }
     carMapSurfaceOwner.setup(carContext, mapInitOptions)
-    carContext.getCarService(AppManager::class.java).setSurfaceCallback(carMapSurfaceOwner)
+    return carMapSurfaceOwner
   }
 
   /**
@@ -123,14 +142,14 @@ class MapboxCarMap {
   /**
    * @param mapboxCarMapObserver the instance used in [registerObserver]
    */
-  fun unregisterObserver(mapboxCarMapObserver: MapboxCarMapObserver) {
+  fun unregisterObserver(mapboxCarMapObserver: MapboxCarMapObserver) = apply {
     carMapSurfaceOwner.unregisterObserver(mapboxCarMapObserver)
   }
 
   /**
    * Optional function to clear all observers registered through [registerObserver]
    */
-  fun clearObservers() {
+  fun clearObservers() = apply {
     carMapSurfaceOwner.clearObservers()
   }
 
@@ -140,7 +159,7 @@ class MapboxCarMap {
    * interface, or override the [DefaultMapboxCarMapGestureHandler], or set to null to disable
    * gesture handling.
    */
-  fun setGestureHandler(gestureHandler: MapboxCarMapGestureHandler?) {
+  fun setGestureHandler(gestureHandler: MapboxCarMapGestureHandler?) = apply {
     carMapSurfaceOwner.gestureHandler = gestureHandler
   }
 }

--- a/extension-androidauto/src/test/java/com/mapbox/maps/extension/androidauto/MapboxCarMapTest.kt
+++ b/extension-androidauto/src/test/java/com/mapbox/maps/extension/androidauto/MapboxCarMapTest.kt
@@ -77,6 +77,26 @@ class MapboxCarMapTest {
   }
 
   @Test
+  fun `setup will call setSurfaceCallback`() {
+    MapboxCarMap().setup(carContext, mapInitOptions)
+
+    val appManager = carContext.getCarService(AppManager::class.java)
+    verify(exactly = 1) {
+      appManager.setSurfaceCallback(any())
+    }
+  }
+
+  @Test
+  fun `prepareSurfaceCallback does not call setSurfaceCallback`() {
+    MapboxCarMap().prepareSurfaceCallback(carContext, mapInitOptions)
+
+    val appManager = carContext.getCarService(AppManager::class.java)
+    verify(exactly = 0) {
+      appManager.setSurfaceCallback(any())
+    }
+  }
+
+  @Test
   fun `carMapSurface is valid after onSurfaceAvailable`() {
     val mapboxCarMap = MapboxCarMap().setup(carContext, mapInitOptions)
     assertNull(mapboxCarMap.carMapSurface)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Adding an example of `onClick` requires a compileVersion 33 and a kotlin upgrade. This pull request is adding support to add `onClick` downstread https://github.com/mapbox/mapbox-maps-android/pull/1682, except this change is not blocked by the repo upgrades.

Please see the full description and video in the example https://github.com/mapbox/mapbox-maps-android/pull/1682. This change creates no functional changes, but adds the ability to customize the `SurfaceCallback`.

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
