### PR TITLE
Provide telemetry module as a singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Mapbox welcomes participation and contributions from everyone.
 # main
 
+# 10.9.0-beta.2
+## Bug fixes 🐞
+* Make telemetry a single instance. Avoids module recreation when coming from background. ([#1695](https://github.com/mapbox/mapbox-maps-android/pull/1695))
+
 # 10.9.0-beta.1 September 22, 2022
 
 ## Features ✨ and improvements 🏁

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -1,14 +1,9 @@
 package com.mapbox.maps
 
-import android.content.Context
 import android.view.MotionEvent
 import androidx.annotation.VisibleForTesting
-import com.mapbox.annotation.module.MapboxModuleType
-import com.mapbox.common.module.provider.MapboxModuleProvider
-import com.mapbox.common.module.provider.ModuleProviderArgument
 import com.mapbox.maps.assets.AssetManagerProvider
 import com.mapbox.maps.extension.observable.model.StyleDataType
-import com.mapbox.maps.module.MapTelemetry
 import com.mapbox.maps.plugin.InvalidViewPluginHostException
 import com.mapbox.maps.plugin.MapPlugin
 import com.mapbox.maps.plugin.MapPluginRegistry
@@ -53,6 +48,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   internal val pluginRegistry: MapPluginRegistry
   private val onStyleDataLoadedListener: OnStyleDataLoadedListener
   private val onCameraChangedListener: OnCameraChangeListener
+
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var lifecycleState: LifecycleState = LifecycleState.STATE_STOPPED
   private var style: Style? = null
@@ -75,7 +71,10 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     this.pluginRegistry = MapProvider.getMapPluginRegistry(
       mapboxMap,
       this,
-      dispatchTelemetryTurnstileEvent()
+      MapProvider.getMapTelemetryInstance(
+        mapInitOptions.context,
+        mapInitOptions.resourceOptions.accessToken
+      )
     )
     this.onCameraChangedListener = OnCameraChangeListener {
       pluginRegistry.onCameraMove(nativeMap.cameraState)
@@ -248,44 +247,6 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
   }
 
   //
-  // Telemetry
-  //
-
-  private fun dispatchTelemetryTurnstileEvent(): MapTelemetry {
-    val telemetry: MapTelemetry =
-      MapboxModuleProvider.createModule(MapboxModuleType.MapTelemetry) {
-        paramsProvider(MapboxModuleType.MapTelemetry)
-      }
-    telemetry.onAppUserTurnstileEvent()
-    return telemetry
-  }
-
-  /**
-   * Provides parameters for Mapbox default modules, recursively if a module depends on other Mapbox modules.
-   */
-  private fun paramsProvider(type: MapboxModuleType): Array<ModuleProviderArgument> {
-    val context = mapInitOptions.context
-    return when (type) {
-      MapboxModuleType.CommonLibraryLoader -> arrayOf(
-        ModuleProviderArgument(
-          Context::class.java,
-          context.applicationContext
-        )
-      )
-      MapboxModuleType.CommonHttpClient -> arrayOf()
-      MapboxModuleType.CommonLogger -> arrayOf()
-      MapboxModuleType.MapTelemetry -> arrayOf(
-        ModuleProviderArgument(
-          Context::class.java,
-          context.applicationContext
-        ),
-        ModuleProviderArgument(String::class.java, mapInitOptions.resourceOptions.accessToken)
-      )
-      else -> throw IllegalArgumentException("${type.name} module is not supported by the Maps SDK")
-    }
-  }
-
-  //
   // Plugin API
   //
 
@@ -342,7 +303,8 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
             ViewportPluginImpl()
           }
           else -> {
-            plugin.instance ?: throw MapboxConfigurationException("Custom non Mapbox plugins must have non-null `instance` parameter!")
+            plugin.instance
+              ?: throw MapboxConfigurationException("Custom non Mapbox plugins must have non-null `instance` parameter!")
           }
         }
         createPlugin(mapView, Plugin.Custom(plugin.id, pluginObject))

--- a/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
@@ -59,14 +59,6 @@ internal object MapProvider {
     type: MapboxModuleType
   ): Array<ModuleProviderArgument> {
     return when (type) {
-      MapboxModuleType.CommonLibraryLoader -> arrayOf(
-        ModuleProviderArgument(
-          Context::class.java,
-          context.applicationContext
-        )
-      )
-      MapboxModuleType.CommonHttpClient -> arrayOf()
-      MapboxModuleType.CommonLogger -> arrayOf()
       MapboxModuleType.MapTelemetry -> arrayOf(
         ModuleProviderArgument(
           Context::class.java,

--- a/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
@@ -1,10 +1,16 @@
 package com.mapbox.maps
 
+import android.content.Context
+import com.mapbox.annotation.module.MapboxModuleType
+import com.mapbox.common.module.provider.MapboxModuleProvider
+import com.mapbox.common.module.provider.ModuleProviderArgument
 import com.mapbox.maps.module.MapTelemetry
 import com.mapbox.maps.plugin.MapDelegateProviderImpl
 import com.mapbox.maps.plugin.MapPluginRegistry
 
 internal object MapProvider {
+
+  private lateinit var mapTelemetry: MapTelemetry
 
   fun getNativeMapWrapper(
     mapInitOptions: MapInitOptions,
@@ -33,6 +39,44 @@ internal object MapProvider {
     mapController: MapController,
     telemetry: MapTelemetry
   ) = MapPluginRegistry(MapDelegateProviderImpl(mapboxMap, mapController, telemetry))
+
+  fun getMapTelemetryInstance(context: Context, accessToken: String): MapTelemetry {
+    if (!::mapTelemetry.isInitialized) {
+      mapTelemetry = MapboxModuleProvider.createModule(MapboxModuleType.MapTelemetry) {
+        paramsProvider(context, accessToken, MapboxModuleType.MapTelemetry)
+      }
+    }
+    mapTelemetry.onAppUserTurnstileEvent()
+    return mapTelemetry
+  }
+
+  /**
+   * Provides parameters for Mapbox default modules, recursively if a module depends on other Mapbox modules.
+   */
+  private fun paramsProvider(
+    context: Context,
+    accessToken: String,
+    type: MapboxModuleType
+  ): Array<ModuleProviderArgument> {
+    return when (type) {
+      MapboxModuleType.CommonLibraryLoader -> arrayOf(
+        ModuleProviderArgument(
+          Context::class.java,
+          context.applicationContext
+        )
+      )
+      MapboxModuleType.CommonHttpClient -> arrayOf()
+      MapboxModuleType.CommonLogger -> arrayOf()
+      MapboxModuleType.MapTelemetry -> arrayOf(
+        ModuleProviderArgument(
+          Context::class.java,
+          context.applicationContext
+        ),
+        ModuleProviderArgument(String::class.java, accessToken)
+      )
+      else -> throw IllegalArgumentException("${type.name} module is not supported by the Maps SDK")
+    }
+  }
 
   private fun MapView.getController(): MapController = this.mapController
 }


### PR DESCRIPTION
### Summary of changes

This is an alternative approach to https://github.com/mapbox/mapbox-maps-android/pull/1693.
It's less intrusive as it doesn't remove the module setup but makes a singleton instance of MapTelemetry. This avoids recreation that could occur when coming from background. This aligns with our http stack setup which we haven't seen issues with. 

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
