### PR TITLE
Fix raster dem crash style reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Mapbox welcomes participation and contributions from everyone.
 ## Bug fixes 🐞
 
 * Fix scale bar text being cut ([1716](https://github.com/mapbox/mapbox-maps-android/pull/1716))
+## Bug fixes 🐞
+* Fix possible crash adding terrain using Style DSL after consecutive style changes ([1717](https://github.com/mapbox/mapbox-maps-android/pull/1717))
 
 # 10.8.1 September 30, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Mapbox welcomes participation and contributions from everyone.
 ## Bug fixes 🐞
 
 * Fix scale bar text being cut ([1716](https://github.com/mapbox/mapbox-maps-android/pull/1716))
-## Bug fixes 🐞
 * Fix possible crash adding terrain using Style DSL after consecutive style changes ([1717](https://github.com/mapbox/mapbox-maps-android/pull/1717))
 
 # 10.8.1 September 30, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Bug fixes 🐞
 
 * Fix scale bar text being cut ([1716](https://github.com/mapbox/mapbox-maps-android/pull/1716))
-* Fix possible crash adding terrain using Style DSL after consecutive style changes ([1717](https://github.com/mapbox/mapbox-maps-android/pull/1717))
+* Fix possible crash when adding terrain using Style DSL after consecutive style changes. ([1717](https://github.com/mapbox/mapbox-maps-android/pull/1717))
 
 # 10.8.1 September 30, 2022
 

--- a/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
@@ -177,7 +177,7 @@ class StyleLoadTest {
     fun loadStyleWithTerrain(
       uri: String = Style.DARK,
       terrainSource: String = "TERRAIN_SOURCE",
-      demSourceUri : String= "mapbox://mapbox.mapbox-terrain-dem-v1"
+      demSourceUri: String = "mapbox://mapbox.mapbox-terrain-dem-v1"
     ) {
       mapboxMap.loadStyle(
         styleExtension = style(uri) {

--- a/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/StyleLoadTest.kt
@@ -12,6 +12,7 @@ import junit.framework.TestCase.*
 import org.junit.*
 import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
+import kotlin.random.Random
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
@@ -201,21 +202,25 @@ class StyleLoadTest {
       it.runOnUiThread {
         mapView.onStart()
 
-        countDownLatch = CountDownLatch(200)
-        for (i in 0..100) {
+        countDownLatch = CountDownLatch(300)
+        for (i in 0 until 100) {
           loadStyleWithTerrain(counter = countDownLatch)
         }
 
-        var i = 0
-        val runnable = object : Runnable {
-          override fun run() {
-            if (i++ < 100) {
-              loadStyleWithTerrain(counter = countDownLatch)
-              mapView.postDelayed(this, 1)
-            }
-          }
+        val random = Random(0)
+        for (i in 0 until 100) {
+          loadStyleWithTerrain(counter = countDownLatch)
+          Thread.sleep(random.nextLong(from = 0, until = 5))
         }
-        mapView.post(runnable)
+
+        for (i in 0 until 100) {
+          mapView.postDelayed(
+            {
+              loadStyleWithTerrain(counter = countDownLatch)
+            },
+            i.toLong()
+          )
+        }
       }
     }
     countDownLatch.throwExceptionOnTimeoutMs()

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -326,7 +326,7 @@ class MapboxMap :
 
   private fun initializeStyleLoad(
     onStyleLoaded: Style.OnStyleLoaded? = null,
-    styleDataStyleLoadedListener: Style.OnStyleLoaded? = null,
+    styleDataStyleLoadedListener: Style.OnStyleLoaded,
     styleDataSpritesLoadedListener: Style.OnStyleLoaded? = null,
     styleDataSourcesLoadedListener: Style.OnStyleLoaded? = null,
     onMapLoadErrorListener: OnMapLoadErrorListener? = null,

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -22,8 +22,15 @@ internal class StyleObserver(
 
   private var userStyleLoadedListener: Style.OnStyleLoaded? = null
 
+  // fired when [StyleDataType.STYLE] arrives, first of all style data loaded events
   private var styleDataStyleLoadedListener: Style.OnStyleLoaded? = null
+  // it the listener is not null - style load has been started
+  // but the initial event has NOT arrived yet
+  private val isWaitingStyleDataStyleEvent
+    get() = styleDataStyleLoadedListener == null
+  // fired when [StyleDataType.SPRITE] arrives
   private var styleDataSpritesLoadedListener: Style.OnStyleLoaded? = null
+  // fired when [StyleDataType.SOURCES] arrives
   private var styleDataSourcesLoadedListener: Style.OnStyleLoaded? = null
 
   private var loadStyleErrorListener: OnMapLoadErrorListener? = null
@@ -50,7 +57,7 @@ internal class StyleObserver(
    */
   fun setLoadStyleListener(
     userOnStyleLoaded: Style.OnStyleLoaded?,
-    styleDataStyleLoadedListener: Style.OnStyleLoaded? = null,
+    styleDataStyleLoadedListener: Style.OnStyleLoaded,
     styleDataSpritesLoadedListener: Style.OnStyleLoaded? = null,
     styleDataSourcesLoadedListener: Style.OnStyleLoaded? = null,
     onMapLoadErrorListener: OnMapLoadErrorListener?
@@ -115,10 +122,18 @@ internal class StyleObserver(
         styleDataStyleLoadedListener = null
       }
       StyleDataType.SPRITE -> {
-        onStyleSpritesReady()
+        // if we're waiting for the [StyleDataType.STYLE] event - then this [StyleDataType.SPRITE]
+        // is related to the previously loaded style, don't notify style extension DSL about it
+        if (!isWaitingStyleDataStyleEvent) {
+          onStyleSpritesReady()
+        }
       }
       StyleDataType.SOURCES -> {
-        onStyleSourcesReady()
+        // if we're waiting for the [StyleDataType.STYLE] event - then this [StyleDataType.SOURCES]
+        // is related to the previously loaded style, don't notify style extension DSL about it
+        if (!isWaitingStyleDataStyleEvent) {
+          onStyleSourcesReady()
+        }
       }
     }
   }

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -24,7 +24,7 @@ internal class StyleObserver(
 
   // fired when [StyleDataType.STYLE] arrives, first of all style data loaded events
   private var styleDataStyleLoadedListener: Style.OnStyleLoaded? = null
-  // it the listener is not null - style load has been started
+  // if the listener is not null - style load has been started
   // but the initial event has NOT arrived yet
   private val isWaitingStyleDataStyleEvent
     get() = styleDataStyleLoadedListener != null

--- a/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
+++ b/sdk/src/main/java/com/mapbox/maps/StyleObserver.kt
@@ -27,7 +27,7 @@ internal class StyleObserver(
   // it the listener is not null - style load has been started
   // but the initial event has NOT arrived yet
   private val isWaitingStyleDataStyleEvent
-    get() = styleDataStyleLoadedListener == null
+    get() = styleDataStyleLoadedListener != null
   // fired when [StyleDataType.SPRITE] arrives
   private var styleDataSpritesLoadedListener: Style.OnStyleLoaded? = null
   // fired when [StyleDataType.SOURCES] arrives

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -169,7 +169,7 @@ class MapboxMapTest {
     val styleLoadCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
 
     val userCallbackStyleSlots = mutableListOf<Style.OnStyleLoaded?>()
-    val callbackStyleSlots = mutableListOf<Style.OnStyleLoaded?>()
+    val callbackStyleSlots = mutableListOf<Style.OnStyleLoaded>()
     val callbackStyleSpritesSlots = mutableListOf<Style.OnStyleLoaded?>()
     val callbackStyleSourcesSlots = mutableListOf<Style.OnStyleLoaded?>()
 
@@ -178,7 +178,7 @@ class MapboxMapTest {
     verify {
       styleObserver.setLoadStyleListener(
         captureNullable(userCallbackStyleSlots),
-        captureNullable(callbackStyleSlots),
+        capture(callbackStyleSlots),
         captureNullable(callbackStyleSpritesSlots),
         captureNullable(callbackStyleSourcesSlots),
         any(),
@@ -194,7 +194,7 @@ class MapboxMapTest {
     verifyNo { atmosphere.bindTo(style) }
     verifyNo { styleLoadCallback.onStyleLoaded(style) }
 
-    callbackStyleSlots.first()!!.onStyleLoaded(style)
+    callbackStyleSlots.first().onStyleLoaded(style)
 
     verify { light.bindTo(style) }
     verify { terrain.bindTo(style) }

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -4,6 +4,7 @@ import com.mapbox.maps.extension.observable.eventdata.StyleDataLoadedEventData
 import com.mapbox.maps.extension.observable.model.StyleDataType
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.verifyNo
+import com.mapbox.verifyOnce
 import io.mockk.*
 import org.junit.After
 import org.junit.Assert.assertThrows
@@ -68,7 +69,7 @@ class StyleObserverTest {
   @Test
   fun onStyleLoadSuccess() {
     val styleLoaded = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(styleLoaded, null, null, null, null)
+    styleObserver.setLoadStyleListener(styleLoaded, mockk(relaxed = true), null, null, null)
     styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE)) // needed to initialize style internally
     styleObserver.onStyleLoaded(mockk())
     verify { styleLoaded.onStyleLoaded(any()) }
@@ -83,7 +84,7 @@ class StyleObserverTest {
     val userLoadStyleListener = mockk<Style.OnStyleLoaded>(relaxed = true)
     styleObserver.setLoadStyleListener(
       userLoadStyleListener,
-      null,
+      mockk(relaxed = true),
       null,
       null,
       null
@@ -105,12 +106,12 @@ class StyleObserverTest {
   @Test
   fun onStyleLoadedOverwritten() {
     val styleLoadedFail = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(styleLoadedFail, null, null, null, null)
+    styleObserver.setLoadStyleListener(styleLoadedFail, mockk(relaxed = true), null, null, null)
     val styleLoadedSuccess = mockk<Style.OnStyleLoaded>(relaxed = true)
-    styleObserver.setLoadStyleListener(styleLoadedSuccess, null, null, null, null)
+    styleObserver.setLoadStyleListener(styleLoadedSuccess, mockk(relaxed = true), null, null, null)
     styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE)) // needed to initialize style internally
     styleObserver.onStyleLoaded(mockk())
-    verify(exactly = 0) { styleLoadedFail.onStyleLoaded(any()) }
+    verifyNo { styleLoadedFail.onStyleLoaded(any()) }
     verify { styleLoadedSuccess.onStyleLoaded(any()) }
   }
 
@@ -120,7 +121,7 @@ class StyleObserverTest {
   @Test
   fun onStyleLoadError() {
     val errorListener = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.setLoadStyleListener(null, null, null, null, errorListener)
+    styleObserver.setLoadStyleListener(null, mockk(relaxed = true), null, null, errorListener)
     styleObserver.onMapLoadError(mockk(relaxed = true))
     verify { errorListener.onMapLoadError(any()) }
   }
@@ -131,11 +132,11 @@ class StyleObserverTest {
   @Test
   fun onStyleLoadErrorNotCalled() {
     val errorListenerFail = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.setLoadStyleListener(null, null, null, null, errorListenerFail)
+    styleObserver.setLoadStyleListener(null, mockk(relaxed = true), null, null, errorListenerFail)
     val errorListenerSuccess = mockk<OnMapLoadErrorListener>(relaxed = true)
-    styleObserver.setLoadStyleListener(null, null, null, null, errorListenerSuccess)
+    styleObserver.setLoadStyleListener(null, mockk(relaxed = true), null, null, errorListenerSuccess)
     styleObserver.onMapLoadError(mockk(relaxed = true))
-    verify(exactly = 0) { errorListenerFail.onMapLoadError(any()) }
+    verifyNo { errorListenerFail.onMapLoadError(any()) }
     verify { errorListenerSuccess.onMapLoadError(any()) }
   }
 
@@ -313,5 +314,33 @@ class StyleObserverTest {
     styleObserver.onStyleLoaded(mockk())
 
     verify { styleSourcesCallback.onStyleLoaded(any()) }
+  }
+
+  @Test
+  fun onStyleDataSourcesAndSpritesEventsAreIgnoredUntilStyleDataLoadedNotCalledOnStyleChange() {
+    val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+    val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    styleObserver.setLoadStyleListener(
+      null,
+      styleCallback,
+      styleSpritesCallback,
+      styleSourcesCallback,
+      null
+    )
+
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SOURCES))
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SPRITE))
+
+    verifyNo { styleSourcesCallback.onStyleLoaded(any()) }
+    verifyNo { styleSpritesCallback.onStyleLoaded(any()) }
+
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.STYLE))
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SOURCES))
+    styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SPRITE))
+
+    verifyOnce { styleSourcesCallback.onStyleLoaded(any()) }
+    verifyOnce { styleSpritesCallback.onStyleLoaded(any()) }
   }
 }

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -340,6 +340,7 @@ class StyleObserverTest {
     styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SOURCES))
     styleObserver.onStyleDataLoaded(StyleDataLoadedEventData(0, 0, StyleDataType.SPRITE))
 
+    verifyOnce { styleCallback.onStyleLoaded(any()) }
     verifyOnce { styleSourcesCallback.onStyleLoaded(any()) }
     verifyOnce { styleSpritesCallback.onStyleLoaded(any()) }
   }

--- a/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/StyleObserverTest.kt
@@ -317,7 +317,7 @@ class StyleObserverTest {
   }
 
   @Test
-  fun onStyleDataSourcesAndSpritesEventsAreIgnoredUntilStyleDataLoadedNotCalledOnStyleChange() {
+  fun `StyleDataType - Sources and Sprites events are ignored until StyleDataType - Style is not received on style change`() {
     val styleCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSourcesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)
     val styleSpritesCallback = mockk<Style.OnStyleLoaded>(relaxed = true)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

When we load styles many times in a row there's a possibility that `style data : sources` event from the previous style will arrive after new style has been started loading. Here we add the fix for it and actually wait for the `style data : style` event after the style load has been initiated and skip all the other events. 

This is actually part of MAPSNAT-516 that couldn't be fixed in gl-native. 

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
