### PR TITLE
Fix view annotations triggering excessive onMeasure [MAPSAND-516]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 # main
 ## Bug fixes 🐞
-* Fix frequent layout invalidation caused by view annotations calling View.bringToFront(). ([1744](https://github.com/mapbox/mapbox-maps-android/pull/1744))
+* Fix frequent layout invalidation caused by view annotations calling `View.bringToFront()`. ([1744](https://github.com/mapbox/mapbox-maps-android/pull/1744))
 
 # 10.9.0-rc.1 October 07, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
+
+# 10.9.0
+
 ## Bug fixes 🐞
 * Fix frequent layout invalidation caused by view annotations calling `View.bringToFront()`. ([1744](https://github.com/mapbox/mapbox-maps-android/pull/1744))
+
 
 # 10.9.0-rc.1 October 07, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
-
+## Bug fixes 🐞
+* Fix frequent layout invalidation caused by view annotations calling View.bringToFront(). ([1744](https://github.com/mapbox/mapbox-maps-android/pull/1744))
 
 # 10.9.0-rc.1 October 07, 2022
 

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -75,7 +75,6 @@ dependencies {
   implementation(Dependencies.kotlin)
   implementation(Dependencies.androidxCoreKtx)
   implementation(Dependencies.androidxAnnotations)
-  implementation(Dependencies.androidxRecyclerView)
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.mockk)
   testImplementation(Dependencies.androidxTestCore)

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
   implementation(Dependencies.kotlin)
   implementation(Dependencies.androidxCoreKtx)
   implementation(Dependencies.androidxAnnotations)
+  implementation(Dependencies.androidxRecyclerView)
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.mockk)
   testImplementation(Dependencies.androidxTestCore)

--- a/sdk/src/androidTest/java/com/mapbox/maps/TestUtils.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/TestUtils.kt
@@ -1,14 +1,15 @@
 package com.mapbox.maps
 
 import android.view.View
+import android.widget.FrameLayout
 import androidx.core.view.children
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
-internal fun MapView.hasChildView(view: View) = children.any { it == view }
+internal fun FrameLayout.hasChildView(view: View) = children.any { it == view }
 
-internal fun MapView.getChildViewIndex(view: View) = children.indexOf(view)
+internal fun FrameLayout.getChildViewIndex(view: View) = children.indexOf(view)
 
 internal fun CountDownLatch.throwExceptionOnTimeoutMs(timeoutMs: Long = DEFAULT_LATCH_TIMEOUT_MS) {
   if (!await(timeoutMs, TimeUnit.MILLISECONDS)) {

--- a/sdk/src/androidTest/java/com/mapbox/maps/ViewAnnotationTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/ViewAnnotationTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.maps
 import android.os.Handler
 import android.os.Looper
 import android.view.View
+import android.widget.FrameLayout
 import androidx.annotation.LayoutRes
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -41,6 +42,7 @@ class ViewAnnotationTest(
 ) {
   private lateinit var mapboxMap: MapboxMap
   private lateinit var mapView: MapView
+  private lateinit var viewAnnotationsLayout: FrameLayout
   private lateinit var viewAnnotationManager: ViewAnnotationManager
   private val mainHandler = Handler(Looper.getMainLooper())
 
@@ -79,6 +81,7 @@ class ViewAnnotationTest(
           }
         })
       }
+      viewAnnotationsLayout = mapView.getChildAt(1) as FrameLayout
       mapboxMap = mapView.getMapboxMap().apply {
         loadStyleUri(
           Style.MAPBOX_STREETS
@@ -144,7 +147,7 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertEquals(
           mapboxMap.pixelForCoordinate(CAMERA_CENTER).x - firstView.width / 2.0,
           firstView.translationX.toDouble(),
@@ -178,7 +181,7 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).x, firstView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).y, firstView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
         assertArrayEquals(
@@ -208,7 +211,7 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertEquals(
           mapboxMap.pixelForCoordinate(CAMERA_CENTER).x + offsetX,
           firstView.translationX.toDouble(),
@@ -242,7 +245,7 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertFalse(mapView.hasChildView(firstView))
+        assertFalse(viewAnnotationsLayout.hasChildView(firstView))
         assertArrayEquals(
           arrayOf(),
           actualVisibilityUpdateList.toTypedArray()
@@ -273,15 +276,15 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertEquals(mapboxMap.pixelForCoordinate(SHIFTED_CENTER).x, firstView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(SHIFTED_CENTER).y, firstView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
-        assertTrue(mapView.hasChildView(secondView))
+        assertTrue(viewAnnotationsLayout.hasChildView(secondView))
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).x, secondView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).y, secondView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
         MatcherAssert.assertThat(
-          mapView.getChildViewIndex(secondView),
-          Matchers.greaterThan(mapView.getChildViewIndex(firstView))
+          viewAnnotationsLayout.getChildViewIndex(secondView),
+          Matchers.greaterThan(viewAnnotationsLayout.getChildViewIndex(firstView))
         )
         assertArrayEquals(
           arrayOf(
@@ -316,8 +319,8 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertFalse(mapView.hasChildView(firstView))
-        assertTrue(mapView.hasChildView(secondView))
+        assertFalse(viewAnnotationsLayout.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(secondView))
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).x, secondView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).y, secondView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
         assertArrayEquals(
@@ -353,15 +356,15 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertEquals(mapboxMap.pixelForCoordinate(SHIFTED_CENTER).x, firstView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(SHIFTED_CENTER).y, firstView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
-        assertTrue(mapView.hasChildView(secondView))
+        assertTrue(viewAnnotationsLayout.hasChildView(secondView))
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).x, secondView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).y, secondView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
         MatcherAssert.assertThat(
-          mapView.getChildViewIndex(secondView),
-          Matchers.lessThan(mapView.getChildViewIndex(firstView))
+          viewAnnotationsLayout.getChildViewIndex(secondView),
+          Matchers.lessThan(viewAnnotationsLayout.getChildViewIndex(firstView))
         )
         // although first view is selected - we still respect addition order
         assertArrayEquals(
@@ -397,15 +400,15 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertEquals(mapboxMap.pixelForCoordinate(SHIFTED_CENTER).x, firstView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(SHIFTED_CENTER).y, firstView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
-        assertTrue(mapView.hasChildView(secondView))
+        assertTrue(viewAnnotationsLayout.hasChildView(secondView))
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).x, secondView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).y, secondView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
         MatcherAssert.assertThat(
-          mapView.getChildViewIndex(secondView),
-          Matchers.greaterThan(mapView.getChildViewIndex(firstView))
+          viewAnnotationsLayout.getChildViewIndex(secondView),
+          Matchers.greaterThan(viewAnnotationsLayout.getChildViewIndex(firstView))
         )
         assertArrayEquals(
           arrayOf(
@@ -440,8 +443,8 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertFalse(mapView.hasChildView(firstView))
-        assertTrue(mapView.hasChildView(secondView))
+        assertFalse(viewAnnotationsLayout.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(secondView))
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).x, secondView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).y, secondView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
         assertArrayEquals(
@@ -477,10 +480,10 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertEquals(mapboxMap.pixelForCoordinate(SHIFTED_CENTER).x, firstView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(SHIFTED_CENTER).y, firstView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
-        assertFalse(mapView.hasChildView(secondView))
+        assertFalse(viewAnnotationsLayout.hasChildView(secondView))
         assertArrayEquals(
           arrayOf(
             Pair(firstView, true),
@@ -515,8 +518,8 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertFalse(mapView.hasChildView(firstView))
-        assertTrue(mapView.hasChildView(secondView))
+        assertFalse(viewAnnotationsLayout.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(secondView))
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).x, secondView.translationX.toDouble(), ADMISSIBLE_ERROR_PX)
         assertEquals(mapboxMap.pixelForCoordinate(CAMERA_CENTER).y, secondView.translationY.toDouble(), ADMISSIBLE_ERROR_PX)
         assertArrayEquals(
@@ -551,7 +554,7 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertEquals(
           mapboxMap.pixelForCoordinate(SHIFTED_CENTER).x - firstView.width / 2.0,
           firstView.translationX.toDouble(),
@@ -593,7 +596,7 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertEquals(updatedWidthPx, firstView.width)
         assertEquals(updatedHeightPx, firstView.height)
         assertEquals(
@@ -637,8 +640,8 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertFalse(mapView.hasChildView(firstView))
-        assertTrue(mapView.hasChildView(secondView))
+        assertFalse(viewAnnotationsLayout.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(secondView))
         // update allowOverlap only for underlying view annotation
         viewAnnotationManager.updateViewAnnotation(
           firstView,
@@ -648,8 +651,8 @@ class ViewAnnotationTest(
         )
         mainHandler.postDelayed(
           {
-            assertTrue(mapView.hasChildView(firstView))
-            assertTrue(mapView.hasChildView(secondView))
+            assertTrue(viewAnnotationsLayout.hasChildView(firstView))
+            assertTrue(viewAnnotationsLayout.hasChildView(secondView))
             assertArrayEquals(
               arrayOf(
                 Pair(secondView, true),
@@ -680,7 +683,7 @@ class ViewAnnotationTest(
         viewAnnotationManager.removeViewAnnotation(firstView)
       },
       makeChecks = {
-        assertFalse(mapView.hasChildView(firstView))
+        assertFalse(viewAnnotationsLayout.hasChildView(firstView))
         assertArrayEquals(
           arrayOf(),
           actualVisibilityUpdateList.toTypedArray()
@@ -710,13 +713,13 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertFalse(mapView.hasChildView(firstView))
-        assertTrue(mapView.hasChildView(secondView))
+        assertFalse(viewAnnotationsLayout.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(secondView))
         viewAnnotationManager.removeViewAnnotation(secondView)
         mainHandler.postDelayed(
           {
-            assertTrue(mapView.hasChildView(firstView))
-            assertFalse(mapView.hasChildView(secondView))
+            assertTrue(viewAnnotationsLayout.hasChildView(firstView))
+            assertFalse(viewAnnotationsLayout.hasChildView(secondView))
             assertArrayEquals(
               arrayOf(
                 Pair(secondView, true),
@@ -752,7 +755,7 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertTrue(mapView.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(firstView))
         assertArrayEquals(
           arrayOf(
             Pair(firstView, true),
@@ -780,7 +783,7 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertFalse(mapView.hasChildView(firstView))
+        assertFalse(viewAnnotationsLayout.hasChildView(firstView))
         // view does not even appear so update listener should not be triggered
         assertArrayEquals(
           arrayOf(),
@@ -848,14 +851,14 @@ class ViewAnnotationTest(
         )
       },
       makeChecks = {
-        assertFalse(mapView.hasChildView(firstView))
-        assertTrue(mapView.hasChildView(secondView))
+        assertFalse(viewAnnotationsLayout.hasChildView(firstView))
+        assertTrue(viewAnnotationsLayout.hasChildView(secondView))
         secondView.visibility = View.GONE
         mainHandler.postDelayed(
           {
-            // second view is not removed from parent MapView but as it's gone first view should appear now
-            assertTrue(mapView.hasChildView(secondView))
-            assertTrue(mapView.hasChildView(firstView))
+            // second view is not removed from parent viewAnnotationsLayout but as it's gone first view should appear now
+            assertTrue(viewAnnotationsLayout.hasChildView(secondView))
+            assertTrue(viewAnnotationsLayout.hasChildView(firstView))
             assertArrayEquals(
               arrayOf(
                 Pair(secondView, true),

--- a/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
@@ -370,8 +370,9 @@ internal class ViewAnnotationManagerImpl(
             height = descriptor.height
           }
         }
-        if (!currentlyDrawnViewIdSet.contains(descriptor.identifier)
-          && annotationsRootView.indexOfChild(annotation.view) == -1) {
+        if (!currentlyDrawnViewIdSet.contains(descriptor.identifier) &&
+          annotationsRootView.indexOfChild(annotation.view) == -1
+        ) {
           annotationsRootView.addView(annotation.view, annotation.viewLayoutParams)
           updateVisibilityAndNotifyUpdateListeners(
             annotation,
@@ -474,8 +475,9 @@ internal class ViewAnnotationManagerImpl(
           var updatedIndex = 0
           // descriptor of items removed from the new list
           val removedDescriptors = mutableSetOf<String>()
-          while (currentIndex < positionDescriptorCurrentList.size
-            && updatedIndex < positionDescriptorUpdatedList.size) {
+          while (currentIndex < positionDescriptorCurrentList.size &&
+            updatedIndex < positionDescriptorUpdatedList.size
+          ) {
             // skip equal items
             if (positionDescriptorCurrentList[currentIndex] == positionDescriptorUpdatedList[updatedIndex]) {
               currentIndex++
@@ -490,8 +492,9 @@ internal class ViewAnnotationManagerImpl(
             }
 
             // find the elements removed from the old list, add them to set
-            while (currentIndex < positionDescriptorCurrentList.size
-              && positionDescriptorCurrentList[currentIndex] != positionDescriptorUpdatedList[updatedIndex]) {
+            while (currentIndex < positionDescriptorCurrentList.size &&
+              positionDescriptorCurrentList[currentIndex] != positionDescriptorUpdatedList[updatedIndex]
+            ) {
               removedDescriptors.add(positionDescriptorCurrentList[currentIndex].identifier)
               currentIndex++
             }

--- a/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
@@ -477,7 +477,7 @@ internal class ViewAnnotationManagerImpl(
             updatedIndex < positionDescriptorUpdatedList.size
           ) {
             // skip equal items
-            if (positionDescriptorCurrentList[currentIndex] == positionDescriptorUpdatedList[updatedIndex]) {
+            if (positionDescriptorCurrentList[currentIndex].identifier == positionDescriptorUpdatedList[updatedIndex].identifier) {
               currentIndex++
               updatedIndex++
               continue
@@ -491,7 +491,7 @@ internal class ViewAnnotationManagerImpl(
 
             // find the elements removed from the old list, add them to set
             while (currentIndex < positionDescriptorCurrentList.size &&
-              positionDescriptorCurrentList[currentIndex] != positionDescriptorUpdatedList[updatedIndex]
+              positionDescriptorCurrentList[currentIndex].identifier != positionDescriptorUpdatedList[updatedIndex].identifier
             ) {
               removedDescriptors.add(positionDescriptorCurrentList[currentIndex].identifier)
               currentIndex++

--- a/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
@@ -23,7 +23,7 @@ internal class ViewAnnotationManagerImpl(
   private val renderThread = mapView.mapController.renderer.renderThread
 
   init {
-    mapView.layoutParams = FrameLayout.LayoutParams(
+    viewAnnotationsLayout.layoutParams = FrameLayout.LayoutParams(
       ViewGroup.LayoutParams.MATCH_PARENT,
       ViewGroup.LayoutParams.MATCH_PARENT,
     )

--- a/sdk/src/main/java/com/mapbox/maps/plugin/MapPluginRegistry.kt
+++ b/sdk/src/main/java/com/mapbox/maps/plugin/MapPluginRegistry.kt
@@ -37,7 +37,6 @@ internal class MapPluginRegistry(
     }
 
   private val plugins = mutableMapOf<String, MapPlugin>()
-  internal val viewPlugins = mutableMapOf<ViewPlugin, View>()
   private val cameraPlugins = CopyOnWriteArraySet<MapCameraPlugin>()
   private val gesturePlugins = CopyOnWriteArraySet<GesturesPlugin>()
   private val styleObserverPlugins = CopyOnWriteArraySet<MapStyleObserverPlugin>()
@@ -70,7 +69,6 @@ internal class MapPluginRegistry(
           )
           mapView.addView(pluginView)
           mapPlugin.onPluginView(pluginView)
-          viewPlugins[mapPlugin] = pluginView
         }
 
         if (mapPlugin is ContextBinder) {

--- a/sdk/src/main/java/com/mapbox/maps/plugin/MapPluginRegistry.kt
+++ b/sdk/src/main/java/com/mapbox/maps/plugin/MapPluginRegistry.kt
@@ -1,7 +1,6 @@
 package com.mapbox.maps.plugin
 
 import android.view.MotionEvent
-import android.view.View
 import com.mapbox.maps.*
 import com.mapbox.maps.plugin.delegates.MapDelegateProvider
 import com.mapbox.maps.plugin.gestures.GesturesPlugin

--- a/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerZOrderingTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerZOrderingTest.kt
@@ -35,6 +35,14 @@ internal class ViewAnnotationManagerZOrderingTest(
     fun data() = listOf(
       arrayOf(
         /* old descriptors */
+        descriptors(),
+        /* new descriptors */
+        descriptors(),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
         descriptors(
           "1",
           "2",
@@ -44,6 +52,55 @@ internal class ViewAnnotationManagerZOrderingTest(
         descriptors(
           "1",
           "2",
+          "3",
+        ),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+        ),
+        /* new descriptors */
+        descriptors(
+          "2",
+          "4",
+        ),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "4",
+        ),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
         ),
         /* change z order */
         false,

--- a/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerZOrderingTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerZOrderingTest.kt
@@ -26,7 +26,14 @@ internal class ViewAnnotationManagerZOrderingTest(
   companion object {
     private fun descriptors(vararg identifiers: String) = identifiers.map {
       ViewAnnotationPositionDescriptor(
-        it, 0, 0, ScreenCoordinate(0.0, 0.0)
+        it,
+        0,
+        0,
+        // different identifiers should have different screen coordinates
+        ScreenCoordinate(
+          (identifiers.hashCode() % 500).toDouble(),
+          (identifiers.hashCode() % 300).toDouble()
+        )
       )
     }
 
@@ -38,6 +45,22 @@ internal class ViewAnnotationManagerZOrderingTest(
         descriptors(),
         /* new descriptors */
         descriptors(),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors("1"),
+        /* new descriptors */
+        descriptors("1"),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors("1", "2", "3"),
+        /* new descriptors */
+        descriptors("1", "2", "3"),
         /* change z order */
         false,
       ),

--- a/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerZOrderingTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerZOrderingTest.kt
@@ -1,19 +1,7 @@
 package com.mapbox.maps
 
-import android.view.LayoutInflater
-import android.view.View
-import android.widget.FrameLayout
-import androidx.asynclayoutinflater.view.AsyncLayoutInflater
-import com.mapbox.bindgen.ExpectedFactory
-import com.mapbox.geojson.Point
-import com.mapbox.maps.ViewAnnotationManagerImpl.Companion.EXCEPTION_TEXT_GEOMETRY_IS_NULL
-import com.mapbox.maps.renderer.MapboxRenderThread
-import com.mapbox.maps.viewannotation.viewAnnotationOptions
 import io.mockk.*
-import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerZOrderingTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerZOrderingTest.kt
@@ -1,0 +1,264 @@
+package com.mapbox.maps
+
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.FrameLayout
+import androidx.asynclayoutinflater.view.AsyncLayoutInflater
+import com.mapbox.bindgen.ExpectedFactory
+import com.mapbox.geojson.Point
+import com.mapbox.maps.ViewAnnotationManagerImpl.Companion.EXCEPTION_TEXT_GEOMETRY_IS_NULL
+import com.mapbox.maps.renderer.MapboxRenderThread
+import com.mapbox.maps.viewannotation.viewAnnotationOptions
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class ViewAnnotationManagerZOrderingTest(
+  private val oldDescriptors: List<ViewAnnotationPositionDescriptor>,
+  private val newDescriptors: List<ViewAnnotationPositionDescriptor>,
+  private val shouldChangeZOrder: Boolean,
+) {
+
+  @Test
+  fun calculatesCorrectZOrder() {
+    assertEquals(
+      shouldChangeZOrder,
+      ViewAnnotationManagerImpl.needToReorderZ(
+        oldDescriptors, newDescriptors
+      ),
+    )
+  }
+
+  companion object {
+    private fun descriptors(vararg identifiers: String) = identifiers.map {
+      ViewAnnotationPositionDescriptor(
+        it, 0, 0, ScreenCoordinate(0.0, 0.0)
+      )
+    }
+
+    @JvmStatic
+    @Parameterized.Parameters
+    fun data() = listOf(
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "2",
+        ),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "3",
+          "2",
+        ),
+        /* change z order */
+        true,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+        ),
+        /* new descriptors */
+        listOf<String>(),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "3",
+          "2",
+        ),
+        /* change z order */
+        true,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "3",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "2",
+        ),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "2",
+          "3",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "2",
+        ),
+        /* change z order */
+        true,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "3",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "2",
+        ),
+        /* change z order */
+        true,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "2",
+          "7",
+          "8",
+          "9",
+        ),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+        ),
+        /* new descriptors */
+        descriptors(
+          "7",
+          "8",
+          "9",
+        ),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "5",
+          "7",
+          "8",
+          "9",
+        ),
+        /* change z order */
+        false,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "5",
+          "3",
+          "8",
+          "9",
+        ),
+        /* change z order */
+        true,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "5",
+          "8",
+          "3",
+          "9",
+        ),
+        /* change z order */
+        true,
+      ),
+      arrayOf(
+        /* old descriptors */
+        descriptors(
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+        ),
+        /* new descriptors */
+        descriptors(
+          "1",
+          "3",
+          "5",
+          "8",
+          "9",
+        ),
+        /* change z order */
+        false,
+      ),
+    )
+  }
+}


### PR DESCRIPTION
Problem was caused calling bringToFront() on every update of the annotations, that happens on any map animation or gesture.

bringToFront() was needed to guarantee that : 
- view annotations are displayed in the correct order (same as items in the `onViewAnnotationPositionsUpdate(@NonNull List<ViewAnnotationPositionDescriptor> positions);` callback). This order changes if some ViewAnnotation is being selected, for example
- plugins (compass, ruler etc) are displayed on top of ViewAnnotations

Also I've added separate FrameLayout to the MapView on top of the actual surface/texture view but below any other plugin - so that removing or adding new view annotation does not interfere with the plugins at all. 
MapView adds a SurfaceView/TextureView that actually displays map at the index 0 here, then additional views are added on top of it, thus before the fix the layout was looking the following way :

```
FrameLayout MapView : 
 - SurfaceView/TextureView
 - ViewAnnotation1
 - ViewAnnotation2
 - ...
 - CompassPlugin
 - LogoPlugin
```

After the fix it becomes :

```
FrameLayout MapView : 
 - SurfaceView/TextureView
 - FrameLayout for view annotations
   - ViewAnnotation1
   - ViewAnnotation2
   - ...
 - CompassPlugin
 - LogoPlugin
```

<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

Before changes, [simple map layout](https://github.com/mapbox/mapbox-maps-android/blob/main/app/src/main/java/com/mapbox/maps/testapp/examples/markersandcallouts/ViewAnnotationShowcaseActivity.kt) with 1 view annotation, browsing map (so onMeasure is called every frame): 
<img width="725" alt="image" src="https://user-images.githubusercontent.com/2265924/195607746-44c2136c-1d51-412b-9b61-7fdf9c7bd757.png">

onMeasure calls take `117.767` nanos out of `1.409.936` that choreographer.doFrame spent, roughly 8.3%. 

After changes, same layout and map : 
<img width="835" alt="image" src="https://user-images.githubusercontent.com/2265924/195608866-e9e5b3a8-154f-4de5-b155-3536a54b893d.png">

Tested on the Android emulator.
No onMeasure calls at all.
The difference will be more noticeable the more complex layout is used.

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
