### PR TITLE
Use daemons in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -861,4 +861,4 @@ executors:
     environment:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
-      GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
+      GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -861,4 +861,4 @@ executors:
     environment:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
-      GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false
+      GRADLE_OPTS: -Xmx4096m

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,13 @@ tasks.withType<Test> {
   maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
 }
 
+val stdout = java.io.ByteArrayOutputStream()
+exec {
+  commandLine("jps", "-v")
+  standardOutput = stdout;
+}
+println("Output:\n$stdout")
+
 apiValidation {
   /**
    * Packages that are excluded from public API dumps even if they

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,13 +69,6 @@ tasks.withType<Test> {
   maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
 }
 
-val stdout = java.io.ByteArrayOutputStream()
-exec {
-  commandLine("jps", "-v")
-  standardOutput = stdout;
-}
-println("Output:\n$stdout")
-
 apiValidation {
   /**
    * Packages that are excluded from public API dumps even if they


### PR DESCRIPTION
### Summary of changes

While doing #1742 and #1750 I played with the different Gradle options we pass to CI.

It turns out that it is faster to use daemons. Specially jobs like `verify-api-revapi` where multiple `gradle` commands are called within the same job.
For example:
- `verify-api-revapi` went from ~9 minutes to ~5 minutes.
- `build-modules-and-instrumentation-tests` from ~7.5 minutes to ~4.5 minutes

### User impact (optional)

N/A


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
