### PR TITLE
[Android Auto] Remove experimental annotation

### DIFF
--- a/android-auto-app/build.gradle.kts
+++ b/android-auto-app/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 
   // Please review the compatibility guide. This app is showcasing the latest features.
   // https://github.com/mapbox/mapbox-maps-android/tree/main/extension-androidauto#compatibility-with-maps-sdk-v10
-  implementation("com.mapbox.maps:android:10.9.0")
+  implementation("com.mapbox.maps:android:10.10.0-beta.1")
 
   implementation(Dependencies.kotlin)
   implementation(Dependencies.androidxAppCompat)

--- a/android-auto-app/build.gradle.kts
+++ b/android-auto-app/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 
   // Please review the compatibility guide. This app is showcasing the latest features.
   // https://github.com/mapbox/mapbox-maps-android/tree/main/extension-androidauto#compatibility-with-maps-sdk-v10
-  implementation("com.mapbox.maps:android:10.9.0-beta.2")
+  implementation("com.mapbox.maps:android:10.9.0")
 
   implementation(Dependencies.kotlin)
   implementation(Dependencies.androidxAppCompat)

--- a/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/car/CarCameraController.kt
+++ b/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/car/CarCameraController.kt
@@ -4,7 +4,6 @@ import android.graphics.Rect
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraState
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.dsl.cameraOptions
 import com.mapbox.maps.extension.androidauto.DefaultMapboxCarMapGestureHandler
@@ -18,7 +17,6 @@ import com.mapbox.maps.plugin.locationcomponent.location
 /**
  * Controller class to handle map camera changes.
  */
-@OptIn(MapboxExperimental::class)
 class CarCameraController : MapboxCarMapObserver {
 
   private var lastGpsLocation: Point = HELSINKI

--- a/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/car/CarMapShowcase.kt
+++ b/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/car/CarMapShowcase.kt
@@ -1,7 +1,6 @@
 package com.mapbox.maps.testapp.auto.car
 
 import androidx.car.app.CarContext
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.Style
 import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
 import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface
@@ -15,7 +14,6 @@ import com.mapbox.maps.extension.style.terrain.generated.terrain
  * Example showing how you can add a sky layer that has a sun direction,
  * and adding a terrain layer to show mountains.
  */
-@OptIn(MapboxExperimental::class)
 class CarMapShowcase : MapboxCarMapObserver {
 
   private var mapboxCarMapSurface: MapboxCarMapSurface? = null

--- a/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/testing/CarJavaInterfaceChecker.java
+++ b/android-auto-app/src/main/java/com/mapbox/maps/testapp/auto/testing/CarJavaInterfaceChecker.java
@@ -29,11 +29,6 @@ class CarJavaInterfaceChecker {
     new MapboxCarMap();
   }
 
-  void constructorsCarMapSurfaceOwner(MapboxCarMapGestureHandler gestures) {
-    new CarMapSurfaceOwner();
-    new CarMapSurfaceOwner(gestures);
-  }
-
   void getters(MapboxCarMap mapboxCarMap) {
     CarContext carContext = mapboxCarMap.getCarContext();
     Rect visibleArea = mapboxCarMap.getVisibleArea();

--- a/extension-androidauto/CHANGELOG.md
+++ b/extension-androidauto/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 # main
 ## Features ✨ and improvements 🏁
 * Make the SDK compatible with any version of Mapbox Maps `v10.5.+`. ([#1706](https://github.com/mapbox/mapbox-maps-android/pull/1706))
+* Remove experimental annotation from `MapboxCarMap`, `MapboxCarMapObserver`, `MapboxCarMapSurface`, `MapboxCarMapGestureHandler`, and `DefaultMapboxCarMapGestureHandler`. ([#1767](https://github.com/mapbox/mapbox-maps-android/pull/1767))
 
 # 0.3.0 September 26, 2022
 

--- a/extension-androidauto/api/metalava.txt
+++ b/extension-androidauto/api/metalava.txt
@@ -1,11 +1,11 @@
 // Signature format: 3.0
 package com.mapbox.maps.extension.androidauto {
 
-  @com.mapbox.maps.MapboxExperimental public class DefaultMapboxCarMapGestureHandler implements com.mapbox.maps.extension.androidauto.MapboxCarMapGestureHandler {
+  public class DefaultMapboxCarMapGestureHandler implements com.mapbox.maps.extension.androidauto.MapboxCarMapGestureHandler {
     ctor public DefaultMapboxCarMapGestureHandler();
   }
 
-  @com.mapbox.maps.MapboxExperimental public final class MapboxCarMap {
+  public final class MapboxCarMap {
     ctor public MapboxCarMap();
     method public com.mapbox.maps.extension.androidauto.MapboxCarMap clearObservers();
     method public androidx.car.app.CarContext getCarContext();
@@ -34,7 +34,7 @@ package com.mapbox.maps.extension.androidauto {
     method @com.mapbox.maps.MapboxExperimental public static com.mapbox.maps.extension.androidauto.MapboxCarMapScreenInstaller mapboxMapInstaller(androidx.car.app.Screen, com.mapbox.maps.extension.androidauto.MapboxCarMap mapboxCarMap);
   }
 
-  @com.mapbox.maps.MapboxExperimental public interface MapboxCarMapGestureHandler {
+  public interface MapboxCarMapGestureHandler {
     method public default void onFling(com.mapbox.maps.extension.androidauto.MapboxCarMapSurface, float, float);
     method public default void onScale(com.mapbox.maps.extension.androidauto.MapboxCarMapSurface, float, float, float);
     method public default void onScroll(com.mapbox.maps.extension.androidauto.MapboxCarMapSurface, com.mapbox.maps.ScreenCoordinate, float, float);
@@ -44,7 +44,7 @@ package com.mapbox.maps.extension.androidauto {
     method public com.mapbox.maps.MapInitOptions onCreate(androidx.car.app.CarContext carContext);
   }
 
-  @com.mapbox.maps.MapboxExperimental public interface MapboxCarMapObserver {
+  public interface MapboxCarMapObserver {
     method public default void onAttached(com.mapbox.maps.extension.androidauto.MapboxCarMapSurface);
     method public default void onDetached(com.mapbox.maps.extension.androidauto.MapboxCarMapSurface);
     method public default void onStableAreaChanged(android.graphics.Rect, com.mapbox.maps.EdgeInsets);
@@ -69,7 +69,7 @@ package com.mapbox.maps.extension.androidauto {
     method public com.mapbox.maps.extension.androidauto.MapboxCarMapSessionInstaller onStarted(com.mapbox.maps.extension.androidauto.MapboxCarMapObserver... observers);
   }
 
-  @com.mapbox.maps.MapboxExperimental public final class MapboxCarMapSurface {
+  public final class MapboxCarMapSurface {
     method public androidx.car.app.CarContext getCarContext();
     method public com.mapbox.maps.MapSurface getMapSurface();
     method public androidx.car.app.SurfaceContainer getSurfaceContainer();

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/CarMapSurfaceOwner.kt
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/CarMapSurfaceOwner.kt
@@ -7,7 +7,6 @@ import androidx.car.app.SurfaceContainer
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapSurface
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.logI
 import java.util.concurrent.CopyOnWriteArraySet
@@ -17,7 +16,6 @@ import java.util.concurrent.CopyOnWriteArraySet
  *
  * Maintains the surface state for [MapboxCarMap].
  */
-@MapboxExperimental
 internal class CarMapSurfaceOwner @JvmOverloads constructor(
   internal var gestureHandler: MapboxCarMapGestureHandler? = DefaultMapboxCarMapGestureHandler()
 ) : SurfaceCallback {

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/DefaultMapboxCarMapGestureHandler.kt
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/DefaultMapboxCarMapGestureHandler.kt
@@ -9,7 +9,6 @@ import com.mapbox.maps.plugin.animation.camera
  * [SurfaceCallback] and applies them to the [MapboxMap] camera. If you would like to customize
  * the map gestures, use [MapboxCarMap.setGestureHandler].
  */
-@MapboxExperimental
 open class DefaultMapboxCarMapGestureHandler : MapboxCarMapGestureHandler {
 
   /**

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/DefaultMapboxCarMapGestureHandler.kt
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/DefaultMapboxCarMapGestureHandler.kt
@@ -8,6 +8,8 @@ import com.mapbox.maps.plugin.animation.camera
  * This class contains the default map gestures. It Handles the gestures received from
  * [SurfaceCallback] and applies them to the [MapboxMap] camera. If you would like to customize
  * the map gestures, use [MapboxCarMap.setGestureHandler].
+ *
+ * @since 1.0.0
  */
 open class DefaultMapboxCarMapGestureHandler : MapboxCarMapGestureHandler {
 

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMap.kt
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMap.kt
@@ -30,7 +30,6 @@ import com.mapbox.maps.MapboxExperimental
  * surface callback. Do not use setSurfaceCallback, and do not create multiple instances of
  * [MapboxCarMap].
  */
-@MapboxExperimental
 class MapboxCarMap {
   private val carMapSurfaceOwner = CarMapSurfaceOwner()
 

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMap.kt
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMap.kt
@@ -29,6 +29,8 @@ import com.mapbox.maps.MapboxExperimental
  * The internals of this class use [AppManager.setSurfaceCallback], which assumes there is a single
  * surface callback. Do not use setSurfaceCallback, and do not create multiple instances of
  * [MapboxCarMap].
+ *
+ * @since 1.0.0
  */
 class MapboxCarMap {
   private val carMapSurfaceOwner = CarMapSurfaceOwner()

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapGestureHandler.java
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapGestureHandler.java
@@ -9,6 +9,8 @@ import com.mapbox.maps.ScreenCoordinate;
  * This interface captures gesture events from Android Auto's {@link SurfaceCallback}. In order to
  * customize the map gestures provided, you can set your own gestures
  * with {@link MapboxCarMap#setGestureHandler}.
+ *
+ * @since 1.0.0
  */
 public interface MapboxCarMapGestureHandler {
 

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapGestureHandler.java
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapGestureHandler.java
@@ -3,7 +3,6 @@ package com.mapbox.maps.extension.androidauto;
 import androidx.annotation.NonNull;
 import androidx.car.app.SurfaceCallback;
 
-import com.mapbox.maps.MapboxExperimental;
 import com.mapbox.maps.ScreenCoordinate;
 
 /**
@@ -11,7 +10,6 @@ import com.mapbox.maps.ScreenCoordinate;
  * customize the map gestures provided, you can set your own gestures
  * with {@link MapboxCarMap#setGestureHandler}.
  */
-@MapboxExperimental
 public interface MapboxCarMapGestureHandler {
 
   /**

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapObserver.java
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapObserver.java
@@ -10,6 +10,8 @@ import com.mapbox.maps.EdgeInsets;
 /**
  * Many downstream services will not work until the surface has been created and the map has
  * loaded. This interface allows you to create custom Mapbox experiences for the car.
+ *
+ * @since 1.0.0
  */
 public interface MapboxCarMapObserver {
 

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapObserver.java
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapObserver.java
@@ -6,13 +6,11 @@ import androidx.annotation.NonNull;
 import androidx.car.app.SurfaceCallback;
 
 import com.mapbox.maps.EdgeInsets;
-import com.mapbox.maps.MapboxExperimental;
 
 /**
  * Many downstream services will not work until the surface has been created and the map has
  * loaded. This interface allows you to create custom Mapbox experiences for the car.
  */
-@MapboxExperimental
 public interface MapboxCarMapObserver {
 
   /**

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapSurface.kt
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapSurface.kt
@@ -8,6 +8,8 @@ import com.mapbox.maps.MapSurface
  * This contains the Android Auto head unit map information.
  * @see MapboxCarMap.registerObserver
  *
+ * @since 1.0.0
+ *
  * @property carContext reference to the context provided to the [MapboxCarMap]
  * @property mapSurface Mapbox controllable interface
  * @property surfaceContainer A container for the Surface created by the car.

--- a/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapSurface.kt
+++ b/extension-androidauto/src/main/java/com/mapbox/maps/extension/androidauto/MapboxCarMapSurface.kt
@@ -3,7 +3,6 @@ package com.mapbox.maps.extension.androidauto
 import androidx.car.app.CarContext
 import androidx.car.app.SurfaceContainer
 import com.mapbox.maps.MapSurface
-import com.mapbox.maps.MapboxExperimental
 
 /**
  * This contains the Android Auto head unit map information.
@@ -13,7 +12,6 @@ import com.mapbox.maps.MapboxExperimental
  * @property mapSurface Mapbox controllable interface
  * @property surfaceContainer A container for the Surface created by the car.
  */
-@MapboxExperimental
 class MapboxCarMapSurface internal constructor(
   val carContext: CarContext,
   val mapSurface: MapSurface,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Note that the next release will still be `0.4.0`. When the `1.0.0` is released, that is when these interfaces are actually locked down.

Removing `@MapboxExperimental` from the following
 - MapboxCarMap
 - MapboxCarMapObserver
 - MapboxCarMapSurface
 - MapboxCarMapGestureHandler
 - DefaultMapboxCarMapGestureHandler

All of these are required in order to use the default experience provided by the extension.

Intentionally keeping `@MapboxExperimental` on the following

 - MapboxCarMap.prepareSurfaceCallback
 - CompassWidget
 - LogoWidget
 - MapboxCarMapSessionInstaller
 - MapboxCarMapScreenInstaller
 - MapboxCarMapInitializer

`prepareSurfaceCallback` is a function to support an `androidx.car.app:app:1.3.0-beta` upgrade. The widgets depend on `BitmapWidget` which is experimental. The installers are optional helpers, there may be more variations of these in the future.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
