### PR TITLE
Allow resetting FPS listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
+## Bug fixes 🐞
+* Allow resetting `OnFpsChangedListener` by making it nullable in `setOnFpsChangedListener` methods. ([1770](https://github.com/mapbox/mapbox-maps-android/pull/1770))
+
 
 # 10.10.0-rc.1
 ## Bug fixes 🐞
@@ -34,8 +37,6 @@ Mapbox welcomes participation and contributions from everyone.
 ## Dependencies
 * Update gl-native to v10.10.0-beta.1 and common to v23.2.0-beta.1. ([1791](https://github.com/mapbox/mapbox-maps-android/pull/1791))
 
-
-
 # 10.9.0 October 21, 2022
 
 ## Features ✨ and improvements 🏁
@@ -47,6 +48,9 @@ Mapbox welcomes participation and contributions from everyone.
 * Add support to set location puck opacity. ([1659](https://github.com/mapbox/mapbox-maps-android/pull/1659))
 * Support `pitch` and `distanceFromCenter` filters in symbol layers. ([1662](https://github.com/mapbox/mapbox-maps-android/pull/1662))
 * Migrate telemetry APIs from [mobile-events-android](https://github.com/mapbox/mapbox-events-android) to common SDK implementation. ([1672](https://github.com/mapbox/mapbox-maps-android/pull/1672))
+## Bug fixes 🐞
+
+# 10.9.0
 
 ## Bug fixes 🐞
 * Fix frequent layout invalidation caused by view annotations calling `View.bringToFront()`. ([1744](https://github.com/mapbox/mapbox-maps-android/pull/1744))
@@ -120,7 +124,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Bug fixes 🐞
 * Make telemetry a single instance. Avoids module recreation when coming from background. ([#1695](https://github.com/mapbox/mapbox-maps-android/pull/1695))
-* Fix an issue where location engine doesn't produce bearing/accuracy/speed information with the location updates. ([1696](https://github.com/mapbox/mapbox-maps-android/pull/1696)) 
+* Fix an issue where location engine doesn't produce bearing/accuracy/speed information with the location updates. ([1696](https://github.com/mapbox/mapbox-maps-android/pull/1696))
 
 ## Dependencies
 * Bump common sdk to v23.1.0-beta.2. ([1696](https://github.com/mapbox/mapbox-maps-android/pull/1696))
@@ -214,7 +218,7 @@ Bump gl-native to v10.8.0-rc.1 and common to v23.0.0-rc.2. ([1623](https://githu
 ## Features ✨ and improvements 🏁
 * Introduce a callback to be invoked when the device compass sensors need to be re-calibrated. ([1513](https://github.com/mapbox/mapbox-maps-android/pull/1513))
 * Add support for `LocationComponentSettingsInterface.pulsingMaxRadius` to follow location's accuracy radius. ([1561](https://github.com/mapbox/mapbox-maps-android/pull/1561))
- 
+
 ## Bug fixes 🐞
 * Support altitude interpolation in location component, and pass through GPS altitude information from the DefaultLocationProvider. ([1478](https://github.com/mapbox/mapbox-maps-android/pull/1478))
 * Fix edge cases for renderer that could result in map not rendered. ([1538](https://github.com/mapbox/mapbox-maps-android/pull/1538))

--- a/sdk/api/metalava.txt
+++ b/sdk/api/metalava.txt
@@ -12,7 +12,7 @@ package com.mapbox.maps {
     method public void removeRendererSetupErrorListener(com.mapbox.maps.renderer.RendererSetupErrorListener rendererSetupErrorListener);
     method @com.mapbox.maps.MapboxExperimental public boolean removeWidget(com.mapbox.maps.renderer.widget.Widget widget);
     method public void setMaximumFps(int fps);
-    method public void setOnFpsChangedListener(com.mapbox.maps.renderer.OnFpsChangedListener listener);
+    method public void setOnFpsChangedListener(com.mapbox.maps.renderer.OnFpsChangedListener? listener);
     method public android.graphics.Bitmap? snapshot();
     method public void snapshot(com.mapbox.maps.MapView.OnSnapshotReady listener);
   }
@@ -96,7 +96,7 @@ package com.mapbox.maps {
     method public void removeRendererSetupErrorListener(com.mapbox.maps.renderer.RendererSetupErrorListener rendererSetupErrorListener);
     method @com.mapbox.maps.MapboxExperimental public boolean removeWidget(com.mapbox.maps.renderer.widget.Widget widget);
     method public void setMaximumFps(int fps);
-    method public void setOnFpsChangedListener(com.mapbox.maps.renderer.OnFpsChangedListener listener);
+    method public void setOnFpsChangedListener(com.mapbox.maps.renderer.OnFpsChangedListener? listener);
     method public android.graphics.Bitmap? snapshot();
     method public void snapshot(com.mapbox.maps.MapView.OnSnapshotReady listener);
     method public void surfaceChanged(int width, int height);
@@ -128,7 +128,7 @@ package com.mapbox.maps {
     method public void removeRendererSetupErrorListener(com.mapbox.maps.renderer.RendererSetupErrorListener rendererSetupErrorListener);
     method @com.mapbox.maps.MapboxExperimental public boolean removeWidget(com.mapbox.maps.renderer.widget.Widget widget);
     method public void setMaximumFps(@IntRange(from=1, to=Int.MAX_VALUE.toLong()) int fps);
-    method public void setOnFpsChangedListener(com.mapbox.maps.renderer.OnFpsChangedListener listener);
+    method public void setOnFpsChangedListener(com.mapbox.maps.renderer.OnFpsChangedListener? listener);
     method public android.graphics.Bitmap? snapshot();
     method public void snapshot(com.mapbox.maps.MapView.OnSnapshotReady listener);
     property public final com.mapbox.maps.viewannotation.ViewAnnotationManager viewAnnotationManager;

--- a/sdk/src/main/java/com/mapbox/maps/MapControllable.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapControllable.kt
@@ -73,8 +73,11 @@ interface MapControllable : MapboxLifecycleObserver {
 
   /**
    * Set [OnFpsChangedListener] to get map rendering FPS.
+   * Passing null resets the listener, listener is cleaned up automatically as part of onDestroy.
+   *
+   * @param listener The listener to be invoked when FPS data is reported
    */
-  fun setOnFpsChangedListener(listener: OnFpsChangedListener)
+  fun setOnFpsChangedListener(listener: OnFpsChangedListener?)
 
   /**
    * Add [Widget] to the map.

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -214,7 +214,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     renderer.setMaximumFps(fps)
   }
 
-  override fun setOnFpsChangedListener(listener: OnFpsChangedListener) {
+  override fun setOnFpsChangedListener(listener: OnFpsChangedListener?) {
     renderer.setOnFpsChangedListener(listener)
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapSurface.kt
@@ -182,8 +182,11 @@ class MapSurface : MapPluginProviderDelegate, MapControllable {
 
   /**
    * Set [OnFpsChangedListener] to get map rendering FPS.
+   * Passing null resets the listener, listener is cleaned up automatically as part of onDestroy.
+   *
+   * @param listener The listener to be invoked when FPS data is reported
    */
-  override fun setOnFpsChangedListener(listener: OnFpsChangedListener) {
+  override fun setOnFpsChangedListener(listener: OnFpsChangedListener?) {
     renderer.setOnFpsChangedListener(listener)
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/MapView.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapView.kt
@@ -369,8 +369,11 @@ open class MapView : FrameLayout, MapPluginProviderDelegate, MapControllable {
 
   /**
    * Set [OnFpsChangedListener] to get map rendering FPS.
+   * Passing null resets the listener, listener is cleaned up automatically as part of onDestroy.
+   *
+   * @param listener The listener to be invoked when FPS data is reported
    */
-  override fun setOnFpsChangedListener(listener: OnFpsChangedListener) {
+  override fun setOnFpsChangedListener(listener: OnFpsChangedListener?) {
     mapController.setOnFpsChangedListener(listener)
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
+++ b/sdk/src/main/java/com/mapbox/maps/renderer/MapboxRenderer.kt
@@ -191,7 +191,7 @@ internal abstract class MapboxRenderer : MapClient {
 
   @AnyThread
   @Synchronized
-  fun setOnFpsChangedListener(listener: OnFpsChangedListener) {
+  fun setOnFpsChangedListener(listener: OnFpsChangedListener?) {
     renderThread.fpsChangedListener = listener
   }
 


### PR DESCRIPTION
### Summary of changes
This PR allows to reset the OnFpsChangedListener. This allows users to stop listening to these types of event and avoid leaking any objects. This change also performs automatic cleanup as part of onDestroy. 

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.
