### PR TITLE
Changed job `verify-api-revapi` to use Large machine in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,7 +538,7 @@ jobs:
   verify-api-revapi:
     executor:
       name: ubuntu
-      machine: xlarge
+      machine: large
     steps:
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,7 +536,9 @@ jobs:
       - run: exit 0
 
   verify-api-revapi:
-    executor: ubuntu
+    executor:
+      name: ubuntu
+      machine: xlarge
     steps:
       - when:
           condition:


### PR DESCRIPTION
### Summary of changes

Increased docker machine in Circleci for job `verify-api-revapi` to `Large` which is sometimes failing since the changes introduced in #1756.

### User impact (optional)

N/A

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
