### PR TITLE
expose RenderWorldCopies property MAPSAND-588

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Avoid tiles re-layout on enabling terrain with zero exaggeration. ([1791](https://github.com/mapbox/mapbox-maps-android/pull/1791))
 * Asynchronous GeoJSON data parsing when adding a new style source. ([1791](https://github.com/mapbox/mapbox-maps-android/pull/1791))
 * Unify the `margin`/`translation` `Widget` APIs into the `WidgetPosition.offset`, rename `WidgetPosition.horizontal`/`WidgetPosition.vertical` to `WidgetPosition.horizontalAlignment`/`WidgetPosition.verticalAlignment`; Deprecate the original constructors and `setTranslation` APIs. ([1782](https://github.com/mapbox/mapbox-maps-android/pull/1782))
+* Added API to enable/disable rendering of world copies in mercator mode. ([1794](https://github.com/mapbox/mapbox-maps-android/pull/1794))
 
 ## Bug fixes 🐞
 * Fix an issue when touch events didn't pass through clickable view annotations. ([1745](https://github.com/mapbox/mapbox-maps-android/pull/1745))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 * Avoid tiles re-layout on enabling terrain with zero exaggeration. ([1791](https://github.com/mapbox/mapbox-maps-android/pull/1791))
 * Asynchronous GeoJSON data parsing when adding a new style source. ([1791](https://github.com/mapbox/mapbox-maps-android/pull/1791))
 * Unify the `margin`/`translation` `Widget` APIs into the `WidgetPosition.offset`, rename `WidgetPosition.horizontal`/`WidgetPosition.vertical` to `WidgetPosition.horizontalAlignment`/`WidgetPosition.verticalAlignment`; Deprecate the original constructors and `setTranslation` APIs. ([1782](https://github.com/mapbox/mapbox-maps-android/pull/1782))
-* Added API to enable/disable rendering of world copies in mercator mode. ([1794](https://github.com/mapbox/mapbox-maps-android/pull/1794))
+* Add APIs to enable/disable rendering of world copies. ([1794](https://github.com/mapbox/mapbox-maps-android/pull/1794), [1791](https://github.com/mapbox/mapbox-maps-android/pull/1791))
 
 ## Bug fixes 🐞
 * Fix an issue when touch events didn't pass through clickable view annotations. ([1745](https://github.com/mapbox/mapbox-maps-android/pull/1745))

--- a/sdk/api/metalava.txt
+++ b/sdk/api/metalava.txt
@@ -204,6 +204,7 @@ package com.mapbox.maps {
     method public double getMetersPerPixelAtLatitude(double latitude);
     method public byte getPrefetchZoomDelta();
     method @com.mapbox.maps.MapboxExperimental public com.mapbox.maps.RenderCacheOptions getRenderCacheOptions();
+    method public boolean getRenderWorldCopies();
     method public com.mapbox.maps.ResourceOptions getResourceOptions();
     method public com.mapbox.maps.Size getSize();
     method public void getStyle(com.mapbox.maps.Style.OnStyleLoaded onStyleLoaded);
@@ -263,6 +264,7 @@ package com.mapbox.maps {
     method public void setNorthOrientation(com.mapbox.maps.NorthOrientation northOrientation);
     method public void setPrefetchZoomDelta(byte delta);
     method @com.mapbox.maps.MapboxExperimental public void setRenderCacheOptions(com.mapbox.maps.RenderCacheOptions options);
+    method public void setRenderWorldCopies(boolean renderWorldCopies);
     method public void setUserAnimationInProgress(boolean inProgress);
     method public void setViewportMode(com.mapbox.maps.ViewportMode viewportMode);
     method public void subscribe(com.mapbox.maps.Observer observer, java.util.List<java.lang.String> events);

--- a/sdk/api/sdk.api
+++ b/sdk/api/sdk.api
@@ -207,6 +207,7 @@ public final class com/mapbox/maps/MapboxMap : com/mapbox/maps/ObservableInterfa
 	public fun getMetersPerPixelAtLatitude (DD)D
 	public final fun getPrefetchZoomDelta ()B
 	public final fun getRenderCacheOptions ()Lcom/mapbox/maps/RenderCacheOptions;
+	public final fun getRenderWorldCopies ()Z
 	public final fun getResourceOptions ()Lcom/mapbox/maps/ResourceOptions;
 	public fun getSize ()Lcom/mapbox/maps/Size;
 	public final fun getStyle ()Lcom/mapbox/maps/Style;
@@ -274,6 +275,7 @@ public final class com/mapbox/maps/MapboxMap : com/mapbox/maps/ObservableInterfa
 	public fun setNorthOrientation (Lcom/mapbox/maps/NorthOrientation;)V
 	public final fun setPrefetchZoomDelta (B)V
 	public final fun setRenderCacheOptions (Lcom/mapbox/maps/RenderCacheOptions;)V
+	public final fun setRenderWorldCopies (Z)V
 	public fun setUserAnimationInProgress (Z)V
 	public fun setViewportMode (Lcom/mapbox/maps/ViewportMode;)V
 	public fun subscribe (Lcom/mapbox/maps/Observer;Ljava/util/List;)V

--- a/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapboxMap.kt
@@ -1641,6 +1641,32 @@ class MapboxMap :
   }
 
   /**
+   * Sets whether multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude.
+   * If disabled, when the map is zoomed out far enough that a single representation of the world
+   * does not fill the map's entire container, there will be blank space beyond 180 and -180 degrees longitude.
+   * In this case, features that cross 180 and -180 degrees longitude will be cut in two
+   * (with one portion on the right edge of the map and the other on the left edge of the map) at every zoom level.
+   *
+   * By default, renderWorldCopies is set to `true`.
+   *
+   * @param renderWorldCopies The `boolean` value defining whether rendering world copies is going to be enabled or not.
+   */
+  fun setRenderWorldCopies(renderWorldCopies: Boolean) {
+    checkNativeMap("setRenderWorldCopies")
+    nativeMap.renderWorldCopies = renderWorldCopies
+  }
+
+  /**
+   * Returns whether multiple copies of the world are being rendered side by side beyond -180 and 180 degrees longitude.
+   *
+   * @return `true` if rendering world copies is enabled, `false` otherwise.
+   */
+  fun getRenderWorldCopies(): Boolean {
+    checkNativeMap("getRenderWorldCopies")
+    return nativeMap.renderWorldCopies
+  }
+
+  /**
    * Returns if the style has been fully loaded.
    */
   @Deprecated(

--- a/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/MapboxMapTest.kt
@@ -1118,6 +1118,18 @@ class PixelForCoordinatesTest(
     assertEquals(ScreenCoordinate(expectedX, expectedY), screenCoordinate)
   }
 
+  @Test
+  fun setRenderWorldCopies() {
+    mapboxMap.setRenderWorldCopies(true)
+    verify { nativeMap.renderWorldCopies = true }
+  }
+
+  @Test
+  fun getRenderWorldCopies() {
+    mapboxMap.getRenderWorldCopies()
+    verify { nativeMap.renderWorldCopies }
+  }
+
   @After
   fun cleanUp() {
     unmockkStatic(Map::class)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Expose `RenderWorldCopies` property that sets whether multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
