### PR TITLE
Set events as queued by default

### DIFF
--- a/module-telemetry/build.gradle.kts
+++ b/module-telemetry/build.gradle.kts
@@ -8,18 +8,12 @@ plugins {
   id("io.gitlab.arturbosch.detekt").version(Versions.detekt)
 }
 
-val VERSION_NAME: String by project
-
 android {
   compileSdk = AndroidVersions.compileSdkVersion
   defaultConfig {
     minSdk = AndroidVersions.minSdkVersion
     targetSdk = AndroidVersions.targetSdkVersion
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    buildConfigField("String", "MAPBOX_SDK_IDENTIFIER", String.format("\"%s\"", "mapbox-maps-android"))
-    buildConfigField("String", "MAPBOX_SDK_VERSION", String.format("\"%s\"", VERSION_NAME))
-    buildConfigField("String", "MAPBOX_VERSION_STRING", String.format("\"Mapbox/%s\"", VERSION_NAME))
-    buildConfigField("String", "MAPBOX_EVENTS_USER_AGENT", String.format("\"mapbox-maps-android/%s\"", VERSION_NAME))
   }
 }
 

--- a/module-telemetry/src/main/java/com/mapbox/maps/module/telemetry/MapLoadEvent.kt
+++ b/module-telemetry/src/main/java/com/mapbox/maps/module/telemetry/MapLoadEvent.kt
@@ -3,6 +3,7 @@ package com.mapbox.maps.module.telemetry
 import android.annotation.SuppressLint
 import android.os.Build
 import com.google.gson.annotations.SerializedName
+import com.mapbox.maps.base.BuildConfig
 
 /**
  * Event will be sent while map is loaded.

--- a/module-telemetry/src/main/java/com/mapbox/maps/module/telemetry/MapTelemetryImpl.kt
+++ b/module-telemetry/src/main/java/com/mapbox/maps/module/telemetry/MapTelemetryImpl.kt
@@ -86,7 +86,7 @@ class MapTelemetryImpl : MapTelemetry {
 
   private fun sendEvent(event: String) {
     val eventAttributes = Value.fromJson(event)
-    val mapEvent = eventAttributes.value?.let { Event(EventPriority.IMMEDIATE, it, null) }
+    val mapEvent = eventAttributes.value?.let { Event(EventPriority.QUEUED, it, null) }
     if (mapEvent != null) {
       eventsService.sendEvent(mapEvent) { eventsServiceError ->
         eventsServiceError?.let {

--- a/module-telemetry/src/main/java/com/mapbox/maps/module/telemetry/MapTelemetryImpl.kt
+++ b/module-telemetry/src/main/java/com/mapbox/maps/module/telemetry/MapTelemetryImpl.kt
@@ -17,6 +17,7 @@ import com.mapbox.common.TelemetryService
 import com.mapbox.common.TelemetryUtils
 import com.mapbox.common.TurnstileEvent
 import com.mapbox.common.UserSKUIdentifier
+import com.mapbox.maps.base.BuildConfig
 import com.mapbox.maps.logE
 import com.mapbox.maps.module.MapTelemetry
 import java.util.*

--- a/module-telemetry/src/test/java/com/mapbox/maps/module/telemetry/MapEventFactoryTest.kt
+++ b/module-telemetry/src/test/java/com/mapbox/maps/module/telemetry/MapEventFactoryTest.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import android.os.Bundle
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.mapbox.maps.base.BuildConfig
 import com.mapbox.maps.module.telemetry.PerformanceEvent.PerformanceAttribute
 import io.mockk.every
 import io.mockk.mockk

--- a/module-telemetry/src/test/java/com/mapbox/maps/module/telemetry/MapTelemetryTest.kt
+++ b/module-telemetry/src/test/java/com/mapbox/maps/module/telemetry/MapTelemetryTest.kt
@@ -7,8 +7,7 @@ import android.view.WindowManager
 import com.mapbox.common.*
 import io.mockk.*
 import org.junit.After
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
@@ -121,6 +120,7 @@ class MapTelemetryTest {
     }
     val slot = slot<Event>()
     verify { eventsService.sendEvent(capture(slot), any()) }
+    assertEquals(EventPriority.QUEUED, slot.captured.priority)
     assertTrue(slot.captured.attributes.toJson().contains("\"event\":\"map.load\""))
     assertTrue(slot.captured.attributes.toJson().contains("\"sdkIdentifier\":\"mapbox-maps-android\""))
   }
@@ -170,6 +170,7 @@ class MapTelemetryTest {
     telemetry.onPerformanceEvent(null)
     val slot = slot<Event>()
     verify { eventsService.sendEvent(capture(slot), any()) }
+    assertEquals(EventPriority.QUEUED, slot.captured.priority)
     assertTrue(slot.captured.attributes.toJson().contains("\"event\":\"mobile.performance_trace\""))
   }
 }

--- a/module-telemetry/src/test/java/com/mapbox/maps/module/telemetry/MapTelemetryTest.kt
+++ b/module-telemetry/src/test/java/com/mapbox/maps/module/telemetry/MapTelemetryTest.kt
@@ -5,6 +5,7 @@ import android.telephony.TelephonyManager
 import android.view.Display
 import android.view.WindowManager
 import com.mapbox.common.*
+import com.mapbox.maps.base.BuildConfig
 import io.mockk.*
 import org.junit.After
 import org.junit.Assert.*

--- a/sdk-base/build.gradle.kts
+++ b/sdk-base/build.gradle.kts
@@ -10,12 +10,18 @@ plugins {
   id("io.gitlab.arturbosch.detekt").version(Versions.detekt)
 }
 
+val VERSION_NAME: String by project
+
 android {
   compileSdk = AndroidVersions.compileSdkVersion
   defaultConfig {
     minSdk = AndroidVersions.minSdkVersion
     targetSdk = AndroidVersions.targetSdkVersion
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    buildConfigField("String", "MAPBOX_SDK_IDENTIFIER", String.format("\"%s\"", "mapbox-maps-android"))
+    buildConfigField("String", "MAPBOX_SDK_VERSION", String.format("\"%s\"", VERSION_NAME))
+    buildConfigField("String", "MAPBOX_VERSION_STRING", String.format("\"Mapbox/%s\"", VERSION_NAME))
+    buildConfigField("String", "MAPBOX_EVENTS_USER_AGENT", String.format("\"mapbox-maps-android/%s\"", VERSION_NAME))
   }
 }
 val buildFromSource: String by project

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -161,6 +161,8 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     }
     renderer.onStop()
     pluginRegistry.onStop()
+    // flush the queued events before destroy to avoid lost telemetry events
+    MapProvider.flushPendingEvents(mapInitOptions.resourceOptions.accessToken)
   }
 
   override fun onDestroy() {
@@ -168,8 +170,6 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       return
     }
     lifecycleState = LifecycleState.STATE_DESTROYED
-    // flush the queued events before destroy to avoid lost telemetry events
-    MapProvider.flushPendingEvents(mapInitOptions.resourceOptions.accessToken)
     pluginRegistry.onDestroy()
     nativeObserver.onDestroy()
     renderer.onDestroy()

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -169,11 +169,7 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
     }
     lifecycleState = LifecycleState.STATE_DESTROYED
     // flush the queued events before destroy to avoid lost telemetry events
-    MapProvider.getEventService(mapInitOptions.resourceOptions.accessToken).flush { expected ->
-      expected.error?.let { error ->
-        logE(TAG, "EventService flush error: $error")
-      }
-    }
+    MapProvider.flushPendingEvents(mapInitOptions.resourceOptions.accessToken)
     pluginRegistry.onDestroy()
     nativeObserver.onDestroy()
     renderer.onDestroy()

--- a/sdk/src/main/java/com/mapbox/maps/MapController.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapController.kt
@@ -168,6 +168,12 @@ internal class MapController : MapPluginProviderDelegate, MapControllable {
       return
     }
     lifecycleState = LifecycleState.STATE_DESTROYED
+    // flush the queued events before destroy to avoid lost telemetry events
+    MapProvider.getEventService(mapInitOptions.resourceOptions.accessToken).flush { expected ->
+      expected.error?.let { error ->
+        logE(TAG, "EventService flush error: $error")
+      }
+    }
     pluginRegistry.onDestroy()
     nativeObserver.onDestroy()
     renderer.onDestroy()

--- a/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
@@ -53,10 +53,14 @@ internal object MapProvider {
     return mapTelemetry
   }
 
-  fun getEventService(accessToken: String): EventsService {
+  fun flushPendingEvents(accessToken: String) {
     val eventsServiceOptions =
       EventsServerOptions(accessToken, BuildConfig.MAPBOX_EVENTS_USER_AGENT, null)
-    return EventsService.getOrCreate(eventsServiceOptions)
+    EventsService.getOrCreate(eventsServiceOptions).flush { expected ->
+      expected.error?.let { error ->
+        logE(MapController.TAG, "EventsService flush error: $error")
+      }
+    }
   }
 
   /**

--- a/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
@@ -2,8 +2,11 @@ package com.mapbox.maps
 
 import android.content.Context
 import com.mapbox.annotation.module.MapboxModuleType
+import com.mapbox.common.EventsServerOptions
+import com.mapbox.common.EventsService
 import com.mapbox.common.module.provider.MapboxModuleProvider
 import com.mapbox.common.module.provider.ModuleProviderArgument
+import com.mapbox.maps.base.BuildConfig
 import com.mapbox.maps.module.MapTelemetry
 import com.mapbox.maps.plugin.MapDelegateProviderImpl
 import com.mapbox.maps.plugin.MapPluginRegistry
@@ -48,6 +51,12 @@ internal object MapProvider {
     }
     mapTelemetry.onAppUserTurnstileEvent()
     return mapTelemetry
+  }
+
+  fun getEventService(accessToken: String): EventsService {
+    val eventsServiceOptions =
+      EventsServerOptions(accessToken, BuildConfig.MAPBOX_EVENTS_USER_AGENT, null)
+    return EventsService.getOrCreate(eventsServiceOptions)
   }
 
   /**

--- a/sdk/src/test/java/com/mapbox/maps/shadows/ShadowEventsService.kt
+++ b/sdk/src/test/java/com/mapbox/maps/shadows/ShadowEventsService.kt
@@ -1,0 +1,22 @@
+package com.mapbox.maps.shadows
+
+import com.mapbox.common.EventsServerOptions
+import com.mapbox.common.EventsService
+import com.mapbox.common.FlushOperationResultCallback
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@Implements(EventsService::class)
+class ShadowEventsService {
+  @Implementation
+  fun flush(callback: FlushOperationResultCallback?) {
+    TODO("mocked implementation")
+  }
+
+  companion object {
+    @Implementation
+    fun getOrCreate(options: EventsServerOptions): EventsService {
+      TODO("mocked implementation")
+    }
+  }
+}


### PR DESCRIPTION
### Summary of changes

This is a one-liner change that changes the events priority to queued by default. Queued events are batched in groups of up to 180 events and sent as a single gzip-compressed HTTP request, thus reducing network bandwidth consumption.

Interaction and feedback events are not time-critical, so there is no need for marking these as immediate priority.

No added tests as this logic implementation is part of Common SDK.

### User impact (optional)

Because we're marking Maps SDK interaction and feedback events as queued, there will be a reduction in terms of HTTP requests generated from the SDK.

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [x] Add example if relevant.
 - [x] Document any changes to public APIs.
 - [x] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
