### PR TITLE
[locationcomponent] Emit the last indicator state when new listeners are added to the location component. MAPSAND-570

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Bug fixes 🐞
 * Trigger repaint after `BitmapWidget` is updated. ([1797](https://github.com/mapbox/mapbox-maps-android/pull/1797))
 * Fix a crash after removing the view annotation if view has an attached animation or transition. ([1831](https://github.com/mapbox/mapbox-maps-android/pull/1831))
+* Emit the last indicator state when new listeners are added to the location component. ([1827](https://github.com/mapbox/mapbox-maps-android/pull/1827))
 
 # 10.9.1 November 7, 2022
 

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/viewport/ViewportPluginTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/viewport/ViewportPluginTest.kt
@@ -1,5 +1,6 @@
 package com.mapbox.maps.testapp.viewport
 
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -15,6 +16,7 @@ import com.mapbox.maps.plugin.viewport.viewport
 import com.mapbox.maps.testapp.BaseMapTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -68,6 +70,10 @@ class ViewportPluginTest : BaseMapTest() {
 
   @Test
   fun transitionToDefaultTransition() {
+    assumeTrue(
+      "Can only run on API Level 24 or newer because of difference of animator behaviour.",
+      Build.VERSION.SDK_INT > 23
+    )
     handler.post {
       viewportPlugin.transitionTo(followPuckViewportState)
       assertEquals(0.0, mapView.getMapboxMap().cameraState.bearing, EPS)

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImpl.kt
@@ -38,6 +38,12 @@ class LocationComponentPluginImpl : LocationComponentPlugin2, LocationConsumer2,
   @VisibleForTesting(otherwise = PRIVATE)
   internal var isLocationComponentActivated = false
 
+  private var lastIndicatorPosition: Point? = null
+
+  private var lastIndicatorBearing: Double? = null
+
+  private var lastIndicatorAccuracyRadius: Double? = null
+
   private val onIndicatorPositionChangedListeners =
     CopyOnWriteArraySet<OnIndicatorPositionChangedListener>()
 
@@ -54,6 +60,9 @@ class LocationComponentPluginImpl : LocationComponentPlugin2, LocationConsumer2,
    */
   override fun addOnIndicatorPositionChangedListener(listener: OnIndicatorPositionChangedListener) {
     onIndicatorPositionChangedListeners.add(listener)
+    lastIndicatorPosition?.let {
+      listener.onIndicatorPositionChanged(it)
+    }
   }
 
   /**
@@ -67,6 +76,7 @@ class LocationComponentPluginImpl : LocationComponentPlugin2, LocationConsumer2,
 
   @VisibleForTesting(otherwise = PRIVATE)
   internal val indicatorPositionChangedListener = OnIndicatorPositionChangedListener {
+    lastIndicatorPosition = it
     for (listener in onIndicatorPositionChangedListeners) {
       listener.onIndicatorPositionChanged(it)
     }
@@ -79,6 +89,9 @@ class LocationComponentPluginImpl : LocationComponentPlugin2, LocationConsumer2,
    */
   override fun addOnIndicatorBearingChangedListener(listener: OnIndicatorBearingChangedListener) {
     onIndicatorBearingChangedListeners.add(listener)
+    lastIndicatorBearing?.let {
+      listener.onIndicatorBearingChanged(it)
+    }
   }
 
   /**
@@ -97,6 +110,9 @@ class LocationComponentPluginImpl : LocationComponentPlugin2, LocationConsumer2,
    */
   override fun addOnIndicatorAccuracyRadiusChangedListener(listener: OnIndicatorAccuracyRadiusChangedListener) {
     onIndicatorAccuracyRadiusChangedListeners.add(listener)
+    lastIndicatorAccuracyRadius?.let {
+      listener.onIndicatorAccuracyRadiusChanged(it)
+    }
   }
 
   /**
@@ -140,6 +156,7 @@ class LocationComponentPluginImpl : LocationComponentPlugin2, LocationConsumer2,
 
   @VisibleForTesting(otherwise = PRIVATE)
   internal val indicatorBearingChangedListener = OnIndicatorBearingChangedListener {
+    lastIndicatorBearing = it
     for (listener in onIndicatorBearingChangedListeners) {
       listener.onIndicatorBearingChanged(it)
     }
@@ -147,6 +164,7 @@ class LocationComponentPluginImpl : LocationComponentPlugin2, LocationConsumer2,
 
   @VisibleForTesting(otherwise = PRIVATE)
   internal val indicatorAccuracyRadiusChangedListener = OnIndicatorAccuracyRadiusChangedListener {
+    lastIndicatorAccuracyRadius = it
     for (listener in onIndicatorAccuracyRadiusChangedListeners) {
       listener.onIndicatorAccuracyRadiusChanged(it)
     }

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
@@ -202,7 +202,6 @@ class LocationComponentPluginImplTest {
     verify(exactly = 0) { bearingListener.onIndicatorBearingChanged(0.0) }
   }
 
-
   @Test
   fun testAddOnIndicatorAccuracyRadiusChangedListener() {
     val accuracyListener = mockk<OnIndicatorAccuracyRadiusChangedListener>(relaxed = true)

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
@@ -148,14 +148,23 @@ class LocationComponentPluginImplTest {
   @Test
   fun testAddOnIndicatorPositionChangedListener() {
     val positionListener = mockk<OnIndicatorPositionChangedListener>(relaxed = true)
-    locationComponentPlugin.addOnIndicatorPositionChangedListener(positionListener)
     locationComponentPlugin.indicatorPositionChangedListener.onIndicatorPositionChanged(
       Point.fromLngLat(
         0.0,
         0.0
       )
     )
-    verify { positionListener.onIndicatorPositionChanged(Point.fromLngLat(0.0, 0.0)) }
+    locationComponentPlugin.addOnIndicatorPositionChangedListener(positionListener)
+    // Verify the newly added listener will get the last updated indicator position
+    verify(exactly = 1) { positionListener.onIndicatorPositionChanged(Point.fromLngLat(0.0, 0.0)) }
+    locationComponentPlugin.indicatorPositionChangedListener.onIndicatorPositionChanged(
+      Point.fromLngLat(
+        1.0,
+        0.0
+      )
+    )
+    // Verify the listener will get notified when new location arrives.
+    verify(exactly = 1) { positionListener.onIndicatorPositionChanged(Point.fromLngLat(1.0, 0.0)) }
   }
 
   @Test
@@ -175,9 +184,13 @@ class LocationComponentPluginImplTest {
   @Test
   fun testAddOnIndicatorBearingChangedListener() {
     val bearingListener = mockk<OnIndicatorBearingChangedListener>(relaxed = true)
-    locationComponentPlugin.addOnIndicatorBearingChangedListener(bearingListener)
     locationComponentPlugin.indicatorBearingChangedListener.onIndicatorBearingChanged(0.0)
-    verify { bearingListener.onIndicatorBearingChanged(0.0) }
+    locationComponentPlugin.addOnIndicatorBearingChangedListener(bearingListener)
+    // Verify the newly added listener will get the last updated indicator bearing
+    verify(exactly = 1) { bearingListener.onIndicatorBearingChanged(0.0) }
+    // Verify the listener will get notified when new bearing arrives.
+    locationComponentPlugin.indicatorBearingChangedListener.onIndicatorBearingChanged(1.0)
+    verify(exactly = 1) { bearingListener.onIndicatorBearingChanged(1.0) }
   }
 
   @Test
@@ -187,6 +200,28 @@ class LocationComponentPluginImplTest {
     locationComponentPlugin.removeOnIndicatorBearingChangedListener(bearingListener)
     locationComponentPlugin.indicatorBearingChangedListener.onIndicatorBearingChanged(0.0)
     verify(exactly = 0) { bearingListener.onIndicatorBearingChanged(0.0) }
+  }
+
+
+  @Test
+  fun testAddOnIndicatorAccuracyRadiusChangedListener() {
+    val accuracyListener = mockk<OnIndicatorAccuracyRadiusChangedListener>(relaxed = true)
+    locationComponentPlugin.indicatorAccuracyRadiusChangedListener.onIndicatorAccuracyRadiusChanged(0.0)
+    locationComponentPlugin.addOnIndicatorAccuracyRadiusChangedListener(accuracyListener)
+    // Verify the newly added listener will get the last updated indicator accuracy radius
+    verify(exactly = 1) { accuracyListener.onIndicatorAccuracyRadiusChanged(0.0) }
+    // Verify the listener will get notified when new accuracy radius arrives.
+    locationComponentPlugin.indicatorAccuracyRadiusChangedListener.onIndicatorAccuracyRadiusChanged(1.0)
+    verify(exactly = 1) { accuracyListener.onIndicatorAccuracyRadiusChanged(1.0) }
+  }
+
+  @Test
+  fun testRemoveOnIndicatorAccuracyRadiusChangedListener() {
+    val accuracyRadiusListener = mockk<OnIndicatorAccuracyRadiusChangedListener>(relaxed = true)
+    locationComponentPlugin.addOnIndicatorAccuracyRadiusChangedListener(accuracyRadiusListener)
+    locationComponentPlugin.removeOnIndicatorAccuracyRadiusChangedListener(accuracyRadiusListener)
+    locationComponentPlugin.indicatorAccuracyRadiusChangedListener.onIndicatorAccuracyRadiusChanged(.0)
+    verify(exactly = 0) { accuracyRadiusListener.onIndicatorAccuracyRadiusChanged(0.0) }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

This PR emits the last indicator state when new listeners are added to the location component.

### User impact (optional)

We have [introduced a threshold](https://github.com/mapbox/mapbox-maps-android/pull/1398) of 0.01 to update the puck when the bearing is changed, so if the change in bearing is too small, we will not trigger a puck update, thus the `IndicatorBearingChangedListener` is not triggered if the bearing does not change. This will cause troubles that the new subscriber don't get the last status in a timely manner. 

In this PR, we emit the last know puck status immediately when a new listener is added, so they don't need to wait for the new data points, this is especially helpful in the viewport plugin, as we consume the location puck's position update in the `FollowPuckViewportState`.


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
