### PR TITLE
fix: view annotation removal edge cases causes crash

### DIFF
--- a/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
@@ -89,6 +89,7 @@ internal class ViewAnnotationManagerImpl(
   override fun removeViewAnnotation(view: View): Boolean {
     val id = idLookupMap.remove(view) ?: return false
     val annotation = annotationMap.remove(id) ?: return false
+    currentlyDrawnViewIdSet.remove(id)
     remove(id, annotation)
     return true
   }
@@ -571,6 +572,7 @@ internal class ViewAnnotationManagerImpl(
   private fun remove(internalId: String, annotation: ViewAnnotation) {
     viewAnnotationsLayout.removeView(annotation.view)
     updateVisibilityAndNotifyUpdateListeners(annotation, ViewAnnotationVisibility.INVISIBLE)
+    annotation.attachStateListener?.onViewDetachedFromWindow(annotation.view)
     annotation.view.removeOnAttachStateChangeListener(annotation.attachStateListener)
     annotation.attachStateListener = null
     getValue(mapboxMap.removeViewAnnotation(internalId))


### PR DESCRIPTION

<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Fixes: #1723

1. remove view annotation from currentlyDrawnViewIdSet as well
2. on edge cases (view has animation or transition) onViewDetachedFromWindow will not be called on view removal from viewAnnotationsLayout, so make sure we call it to cleanup viewTreeObserver listener

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: #1723

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
