### PR TITLE
Fix a crash after removing the view annotation if view has an attached animation or transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 # 10.10.0-rc.1
 ## Bug fixes 🐞
 * Trigger repaint after `BitmapWidget` is updated. ([1797](https://github.com/mapbox/mapbox-maps-android/pull/1797))
+* Fix a crash after removing the view annotation if view has an attached animation or transition. ([1831](https://github.com/mapbox/mapbox-maps-android/pull/1831))
 
 # 10.9.1 November 7, 2022
 

--- a/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
@@ -89,6 +89,7 @@ internal class ViewAnnotationManagerImpl(
   override fun removeViewAnnotation(view: View): Boolean {
     val id = idLookupMap.remove(view) ?: return false
     val annotation = annotationMap.remove(id) ?: return false
+    currentlyDrawnViewIdSet.remove(id)
     remove(id, annotation)
     return true
   }
@@ -571,6 +572,7 @@ internal class ViewAnnotationManagerImpl(
   private fun remove(internalId: String, annotation: ViewAnnotation) {
     viewAnnotationsLayout.removeView(annotation.view)
     updateVisibilityAndNotifyUpdateListeners(annotation, ViewAnnotationVisibility.INVISIBLE)
+    annotation.attachStateListener?.onViewDetachedFromWindow(annotation.view)
     annotation.view.removeOnAttachStateChangeListener(annotation.attachStateListener)
     annotation.attachStateListener = null
     getValue(mapboxMap.removeViewAnnotation(internalId))

--- a/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
+++ b/sdk/src/main/java/com/mapbox/maps/ViewAnnotationManagerImpl.kt
@@ -572,6 +572,8 @@ internal class ViewAnnotationManagerImpl(
   private fun remove(internalId: String, annotation: ViewAnnotation) {
     viewAnnotationsLayout.removeView(annotation.view)
     updateVisibilityAndNotifyUpdateListeners(annotation, ViewAnnotationVisibility.INVISIBLE)
+    // explicit onViewDetachedFromWindow call is needed to handle use-case
+    // if the view has an animation attached
     annotation.attachStateListener?.onViewDetachedFromWindow(annotation.view)
     annotation.view.removeOnAttachStateChangeListener(annotation.attachStateListener)
     annotation.attachStateListener = null

--- a/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerTest.kt
+++ b/sdk/src/test/java/com/mapbox/maps/ViewAnnotationManagerTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps
 
 import android.graphics.Rect
 import android.view.View
+import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.bindgen.Value
@@ -26,6 +27,7 @@ class ViewAnnotationManagerTest {
   private lateinit var view: View
   private lateinit var viewAnnotationsLayout: FrameLayout
   private lateinit var renderer: MapboxRenderThread
+  private lateinit var viewTreeObserver: ViewTreeObserver
   private val style: Style = mockk(relaxUnitFun = true)
 
   @Before
@@ -34,6 +36,7 @@ class ViewAnnotationManagerTest {
     every { mapView.layoutParams = any() } just Runs
     every { mapView.context } returns mockk()
     renderer = mockk(relaxUnitFun = true)
+    viewTreeObserver = mockk(relaxed = true)
     every { mapView.mapController.renderer.renderThread } returns renderer
     frameLayoutParams = FrameLayout.LayoutParams(0, 0)
     frameLayoutParams.width = DEFAULT_WIDTH
@@ -52,7 +55,7 @@ class ViewAnnotationManagerTest {
   private fun mockView(): View = mockk<View>().also {
     every { it.layoutParams } returns frameLayoutParams
     every { it.visibility } returns View.VISIBLE
-    every { it.viewTreeObserver } returns mockk(relaxed = true)
+    every { it.viewTreeObserver } returns viewTreeObserver
     every { it.addOnAttachStateChangeListener(any()) } just Runs
     every { it.removeOnAttachStateChangeListener(any()) } just Runs
   }
@@ -193,6 +196,8 @@ class ViewAnnotationManagerTest {
     verify(exactly = 1) { view.removeOnAttachStateChangeListener(any()) }
     verify(exactly = 1) { mapboxMap.removeViewAnnotation(id!!) }
     verify(exactly = 1) { viewAnnotationsLayout.removeView(view) }
+    verify(exactly = 1) { viewTreeObserver.removeOnDrawListener(any()) }
+    verify(exactly = 1) { viewTreeObserver.removeOnGlobalLayoutListener(any()) }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Opened instead of https://github.com/mapbox/mapbox-maps-android/pull/1829 to let CI pass.
Fixes: #1723

1. remove view annotation from currentlyDrawnViewIdSet as well
2. on edge cases (view has animation or transition) onViewDetachedFromWindow will not be called on view removal from viewAnnotationsLayout, so make sure we call it to cleanup viewTreeObserver listener

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [x] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
