### PR TITLE
[camera] Fix immediate camera animation on API level 23 or below - MAPSAND-614

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
+* Fix immediate camera animation on API level 23. ([1842](https://github.com/mapbox/mapbox-maps-android/pull/1842))
 
 # 10.10.0-rc.1
 ## Bug fixes 🐞

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
-* Fix immediate camera animation on API level 23. ([1842](https://github.com/mapbox/mapbox-maps-android/pull/1842))
+* Fix immediate camera animation on API level 23 or below. ([1842](https://github.com/mapbox/mapbox-maps-android/pull/1842))
 
 # 10.10.0-rc.1
 ## Bug fixes 🐞

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/viewport/ViewportPluginTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/viewport/ViewportPluginTest.kt
@@ -91,7 +91,8 @@ class ViewportPluginTest : BaseMapTest() {
       }
     }
 
-    latch.await(10, TimeUnit.SECONDS)
+    // Wait for 5 seconds since the default transition time is 3.5 seconds
+    latch.await(5000, TimeUnit.SECONDS)
     handler.post {
       val cameraState = mapView.getMapboxMap().cameraState
       cameraState.center.assertEquals(TEST_POINT)
@@ -124,7 +125,7 @@ class ViewportPluginTest : BaseMapTest() {
       }
     }
 
-    if (!latch.await(10, TimeUnit.SECONDS)) {
+    if (!latch.await(2, TimeUnit.SECONDS)) {
       throw TimeoutException()
     }
 

--- a/app/src/androidTest/java/com/mapbox/maps/testapp/viewport/ViewportPluginTest.kt
+++ b/app/src/androidTest/java/com/mapbox/maps/testapp/viewport/ViewportPluginTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.maps.testapp.viewport
 
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -16,7 +15,6 @@ import com.mapbox.maps.plugin.viewport.viewport
 import com.mapbox.maps.testapp.BaseMapTest
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -70,10 +68,6 @@ class ViewportPluginTest : BaseMapTest() {
 
   @Test
   fun transitionToDefaultTransition() {
-    assumeTrue(
-      "Can only run on API Level 24 or newer because of difference of animator behaviour.",
-      Build.VERSION.SDK_INT > 23
-    )
     handler.post {
       viewportPlugin.transitionTo(followPuckViewportState)
       assertEquals(0.0, mapView.getMapboxMap().cameraState.bearing, EPS)

--- a/plugin-animation/api/plugin-animation.api
+++ b/plugin-animation/api/plugin-animation.api
@@ -97,6 +97,7 @@ public abstract class com/mapbox/maps/plugin/animation/animator/CameraAnimator :
 	public final fun addListener (Landroid/animation/Animator$AnimatorListener;)V
 	public final fun addUpdateListener (Landroid/animation/ValueAnimator$AnimatorUpdateListener;)V
 	public final fun cancel ()V
+	public fun getAnimatedValue ()Ljava/lang/Object;
 	public final fun getOwner ()Ljava/lang/String;
 	public final fun getStartValue ()Ljava/lang/Object;
 	public final fun getTargets ()[Ljava/lang/Object;

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
@@ -83,7 +83,7 @@ abstract class CameraAnimator<out T> (
    */
   final override fun start() {
     postOnAnimatorThread {
-      if (handleImmediateAnimationOnAPI23()) {
+      if (handleImmediateAnimationOnAPI23OrBelow()) {
         return@postOnAnimatorThread
       }
       if (registered) {
@@ -111,7 +111,7 @@ abstract class CameraAnimator<out T> (
    * returns the animated value for the first of those objects.
    */
   override fun getAnimatedValue(): Any {
-    // For immediate animations on API 23, as we introduced the bypass logic in handleImmediateAnimationOnAPI23(),
+    // For immediate animations on API <= 23, as we introduced the bypass logic in handleImmediateAnimationOnAPI23OrBelow(),
     // the returned ValueAnimator.getAnimatedValue() will be null, in this case, we should return the
     // last configured target value, so we immediately jump to the target value.
     if (Build.VERSION.SDK_INT <= 23) {
@@ -128,7 +128,7 @@ abstract class CameraAnimator<out T> (
    *
    * @return true if the animation is handled, false otherwise
    */
-  private fun handleImmediateAnimationOnAPI23(): Boolean {
+  private fun handleImmediateAnimationOnAPI23OrBelow(): Boolean {
     // Devices with API <= 23 animating with duration = 0 will send initial value from Looper with some small delay as a result.
     // Hence multiple immediate animations sent close to each other may cancel previous ones.
     // For these cases, we bypass the ValueAnimator and emit the user registered AnimatorListeners and AnimatorUpdateListeners immediately.

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
@@ -3,11 +3,13 @@ package com.mapbox.maps.plugin.animation.animator
 import android.animation.TypeEvaluator
 import android.animation.ValueAnimator
 import android.annotation.SuppressLint
+import android.os.Build
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.logW
 import com.mapbox.maps.plugin.animation.CameraAnimatorOptions
 import com.mapbox.maps.plugin.animation.CameraAnimatorType
 import com.mapbox.maps.threading.AnimationThreadController.postOnAnimatorThread
+import java.util.concurrent.CopyOnWriteArraySet
 
 /**
  * Base generic class for all camera animators.
@@ -42,8 +44,8 @@ abstract class CameraAnimator<out T> (
   private var internalUpdateListener: AnimatorUpdateListener? = null
   private var internalListener: AnimatorListener? = null
 
-  private val userUpdateListeners = mutableListOf<AnimatorUpdateListener?>()
-  private val userListeners = mutableListOf<AnimatorListener?>()
+  private val userUpdateListeners = CopyOnWriteArraySet<AnimatorUpdateListener?>()
+  private val userListeners = CopyOnWriteArraySet<AnimatorListener?>()
 
   internal var canceled = false
   internal var isInternal = false
@@ -81,6 +83,9 @@ abstract class CameraAnimator<out T> (
    */
   final override fun start() {
     postOnAnimatorThread {
+      if (handleImmediateAnimationOnAPI23()) {
+        return@postOnAnimatorThread
+      }
       if (registered) {
         canceled = false
         super.start()
@@ -91,6 +96,54 @@ abstract class CameraAnimator<out T> (
         )
       }
     }
+  }
+
+  /**
+   * The most recent value calculated by this <code>ValueAnimator</code> when there is just one
+   * property being animated. This value is only sensible while the animation is running. The main
+   * purpose for this read-only property is to retrieve the value from the <code>ValueAnimator</code>
+   * during a call to {@link AnimatorUpdateListener#onAnimationUpdate(ValueAnimator)}, which
+   * is called during each animation frame, immediately after the value is calculated.
+   *
+   * @return animatedValue The value most recently calculated by this <code>ValueAnimator</code> for
+   * the single property being animated. If there are several properties being animated
+   * (specified by several PropertyValuesHolder objects in the constructor), this function
+   * returns the animated value for the first of those objects.
+   */
+  override fun getAnimatedValue(): Any {
+    // For immediate animations on API 23, as we introduced the bypass logic in handleImmediateAnimationOnAPI23(),
+    // the returned ValueAnimator.getAnimatedValue() will be null, in this case, we should return the
+    // last configured target value, so we immediately jump to the target value.
+    return super.getAnimatedValue() ?: targets.last() as Any
+  }
+
+  /**
+   * Handle immediate animation(when duration and startDelay of the animation is 0) on devices running
+   * API 23 or below, by sending updates to animator listeners directly without triggering [ValueAnimator]'s start().
+   *
+   * @return true if the animation is handled, false otherwise
+   */
+  private fun handleImmediateAnimationOnAPI23(): Boolean {
+    // Devices with API <= 23 animating with duration = 0 will send initial value from Looper with some small delay as a result.
+    // Hence multiple immediate animations sent close to each other may cancel previous ones.
+    // For these cases, we bypass the ValueAnimator and emit the user registered AnimatorListeners and AnimatorUpdateListeners immediately.
+    if (Build.VERSION.SDK_INT <= 23) {
+      if (duration == 0L && startDelay == 0L) {
+        val tmpListeners = listeners.toList()
+        tmpListeners.forEach {
+          it.onAnimationStart(this)
+        }
+        internalUpdateListener?.onAnimationUpdate(this)
+        userUpdateListeners.forEach {
+          it?.onAnimationUpdate(this)
+        }
+        tmpListeners.forEach {
+          it.onAnimationEnd(this)
+        }
+        return true
+      }
+    }
+    return false
   }
 
   /**

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
@@ -114,7 +114,12 @@ abstract class CameraAnimator<out T> (
     // For immediate animations on API 23, as we introduced the bypass logic in handleImmediateAnimationOnAPI23(),
     // the returned ValueAnimator.getAnimatedValue() will be null, in this case, we should return the
     // last configured target value, so we immediately jump to the target value.
-    return super.getAnimatedValue() ?: targets.last() as Any
+    if (Build.VERSION.SDK_INT <= 23) {
+      if (duration == 0L && startDelay == 0L) {
+        return super.getAnimatedValue() ?: targets.last() as Any
+      }
+    }
+    return super.getAnimatedValue()
   }
 
   /**

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/animator/CameraAnimator.kt
@@ -83,11 +83,11 @@ abstract class CameraAnimator<out T> (
    */
   final override fun start() {
     postOnAnimatorThread {
-      if (handleImmediateAnimationOnAPI23OrBelow()) {
-        return@postOnAnimatorThread
-      }
       if (registered) {
         canceled = false
+        if (handleImmediateAnimationOnAPI23OrBelow()) {
+          return@postOnAnimatorThread
+        }
         super.start()
       } else {
         logW(

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsListenersTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimationsListenersTest.kt
@@ -273,7 +273,7 @@ class CameraAnimationsListenersTest {
     bearingAnimator.start()
     Shadows.shadowOf(Looper.getMainLooper()).idle()
 
-    Assert.assertEquals(5, valuesList.size)
+    Assert.assertEquals(3, valuesList.size)
     Assert.assertArrayEquals(intArrayOf(0, 1, 1), valuesList.slice(0..2).toIntArray())
   }
 

--- a/sdk/src/androidTest/java/com/mapbox/maps/CameraAnimationsPluginTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/CameraAnimationsPluginTest.kt
@@ -185,6 +185,9 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testAnimatorWithAnimatorDelay() {
+    if (ignoreTestForGivenAbi()) {
+      return
+    }
     val duration = 2000L
     val delay = 1000L
     val animatorListener = CameraAnimatorListener()
@@ -227,6 +230,9 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testCancelAnimatorWithDelayed() {
+    if (ignoreTestForGivenAbi()) {
+      return
+    }
     val duration = 2000L
     val delay = 500L
     val animatorListener = CameraAnimatorListener()
@@ -270,6 +276,9 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testAnimatorWithHandlerPostDelay() {
+    if (ignoreTestForGivenAbi()) {
+      return
+    }
     val duration = 1000L
     val delay = 2000L
     val animatorListener = CameraAnimatorListener()
@@ -316,6 +325,9 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testCameraUpdateFrequency() {
+    if (ignoreTestForGivenAbi()) {
+      return
+    }
     val duration = 3000L
 
     // Considering min update frequency is not less than 20 ms assuming running on x86 emulator on CI
@@ -346,6 +358,9 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testRegisterExistedAnimatorTypeAndStart() {
+    if (ignoreTestForGivenAbi()) {
+      return
+    }
     val duration = 2000L
 
     val animatorListener1 = CameraAnimatorListener()
@@ -431,6 +446,9 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testEaseToSingleDurationShort() {
+    if (ignoreTestForGivenAbi()) {
+      return
+    }
     val targetBearing = 5.0
     val cameraOptions = CameraOptions.Builder().bearing(targetBearing).build()
     val expectedValues = mutableSetOf(-0.0, targetBearing)
@@ -460,6 +478,7 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testEaseToSequenceDurationZero() {
+
     val targetBearing1 = 5.0
     val targetBearing2 = 10.0
     val targetBearing3 = 15.0
@@ -613,6 +632,9 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testEaseToSequenceDurationShort() {
+    if (ignoreTestForGivenAbi()) {
+      return
+    }
     val targetBearing1 = 5.0
     val targetBearing2 = 10.0
     val targetBearing3 = 15.0
@@ -663,6 +685,9 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testEaseToAnimatorSequenceLessThenFrameUpdate() {
+    if (ignoreTestForGivenAbi()) {
+      return
+    }
     val targetBearing1 = 5.0
     val targetBearing2 = 10.0
     val targetBearing3 = 15.0
@@ -741,6 +766,9 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testPostDelayedAndStartDelayedAnimators() {
+    if (ignoreTestForGivenAbi()) {
+      return
+    }
     val pitchAnimatorOne = createPitchAnimator(cameraAnimationPlugin, 10.0, 0, 1000L)
     val pitchListenerOne = CameraAnimatorListener()
     pitchAnimatorOne.addListener(pitchListenerOne)

--- a/sdk/src/androidTest/java/com/mapbox/maps/CameraAnimationsPluginTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/CameraAnimationsPluginTest.kt
@@ -460,7 +460,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testEaseToSequenceDurationZero() {
-
     val targetBearing1 = 5.0
     val targetBearing2 = 10.0
     val targetBearing3 = 15.0

--- a/sdk/src/androidTest/java/com/mapbox/maps/CameraAnimationsPluginTest.kt
+++ b/sdk/src/androidTest/java/com/mapbox/maps/CameraAnimationsPluginTest.kt
@@ -185,9 +185,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testAnimatorWithAnimatorDelay() {
-    if (ignoreTestForGivenAbi()) {
-      return
-    }
     val duration = 2000L
     val delay = 1000L
     val animatorListener = CameraAnimatorListener()
@@ -230,9 +227,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testCancelAnimatorWithDelayed() {
-    if (ignoreTestForGivenAbi()) {
-      return
-    }
     val duration = 2000L
     val delay = 500L
     val animatorListener = CameraAnimatorListener()
@@ -276,9 +270,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testAnimatorWithHandlerPostDelay() {
-    if (ignoreTestForGivenAbi()) {
-      return
-    }
     val duration = 1000L
     val delay = 2000L
     val animatorListener = CameraAnimatorListener()
@@ -325,9 +316,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testCameraUpdateFrequency() {
-    if (ignoreTestForGivenAbi()) {
-      return
-    }
     val duration = 3000L
 
     // Considering min update frequency is not less than 20 ms assuming running on x86 emulator on CI
@@ -358,9 +346,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testRegisterExistedAnimatorTypeAndStart() {
-    if (ignoreTestForGivenAbi()) {
-      return
-    }
     val duration = 2000L
 
     val animatorListener1 = CameraAnimatorListener()
@@ -446,9 +431,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testEaseToSingleDurationShort() {
-    if (ignoreTestForGivenAbi()) {
-      return
-    }
     val targetBearing = 5.0
     val cameraOptions = CameraOptions.Builder().bearing(targetBearing).build()
     val expectedValues = mutableSetOf(-0.0, targetBearing)
@@ -632,9 +614,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testEaseToSequenceDurationShort() {
-    if (ignoreTestForGivenAbi()) {
-      return
-    }
     val targetBearing1 = 5.0
     val targetBearing2 = 10.0
     val targetBearing3 = 15.0
@@ -685,9 +664,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testEaseToAnimatorSequenceLessThenFrameUpdate() {
-    if (ignoreTestForGivenAbi()) {
-      return
-    }
     val targetBearing1 = 5.0
     val targetBearing2 = 10.0
     val targetBearing3 = 15.0
@@ -766,9 +742,6 @@ class CameraAnimationsPluginTest : BaseAnimationMapTest() {
 
   @Test
   fun testPostDelayedAndStartDelayedAnimators() {
-    if (ignoreTestForGivenAbi()) {
-      return
-    }
     val pitchAnimatorOne = createPitchAnimator(cameraAnimationPlugin, 10.0, 0, 1000L)
     val pitchListenerOne = CameraAnimatorListener()
     pitchAnimatorOne.addListener(pitchListenerOne)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

This PR bypasses the immediate camera animation(where duration and start delay of the animation is 0) on the animator, and emit a single animator update instead of trying to start the ValueAnimator directly.

More context on the issue with animators on API 23 or below:
> Devices with API <= 23 animating with duration = 0 will send initial value from Looper with some small delay as a result.
> Hence multiple immediate animations sent close to each other may cancel previous ones.

### User impact (optional)

This change particularly affects the camera animation and viewport plugin on API level 23 or below.
For example viewport plugin's `FollowPuckViewportState` behaviour will be fixed as shown below:

| Before | After |
| ----- | ----- |
| <video src="https://user-images.githubusercontent.com/2764714/202478245-d6b1ebc4-cbae-4a44-9cbf-90f81b2008fe.webm" width = 250/> | <video src="https://user-images.githubusercontent.com/2764714/202478303-2d5a7f57-6f75-479a-aa69-0063d620a086.webm" width = 250/> |


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [x] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
