### PR TITLE
Update GesturesActivity example to match documentation

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
@@ -77,11 +77,11 @@ class GesturesActivity : AppCompatActivity() {
   }
 
   override fun onDestroy() {
-    super.onDestroy()
     gesturesPlugin.removeOnMoveListener(moveListener)
     gesturesPlugin.removeOnRotateListener(rotateListener)
     gesturesPlugin.removeOnScaleListener(scaleListener)
     gesturesPlugin.removeOnShoveListener(shoveListener)
+    super.onDestroy()
   }
 
   private fun initializeMap() {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
@@ -42,36 +42,36 @@ class GesturesActivity : AppCompatActivity() {
   private var pointAnnotationManager: PointAnnotationManager? = null
   private lateinit var binding: ActivityGesturesBinding
   private val rotateListener: OnRotateListener = object : OnRotateListener {
-    override fun onRotateBegin(@NonNull detector: RotateGestureDetector) {
+    override fun onRotateBegin(detector: RotateGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "ROTATE START"))
     }
 
-    override fun onRotate(@NonNull detector: RotateGestureDetector) {
+    override fun onRotate(detector: RotateGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "ROTATE PROGRESS"))
       recalculateFocalPoint()
     }
 
-    override fun onRotateEnd(@NonNull detector: RotateGestureDetector) {
+    override fun onRotateEnd(detector: RotateGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "ROTATE END"))
     }
   }
   private val moveListener: OnMoveListener = object : OnMoveListener {
-    override fun onMoveBegin(@NonNull detector: MoveGestureDetector) {
+    override fun onMoveBegin(detector: MoveGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "MOVE START"))
     }
 
-    override fun onMove(@NonNull detector: MoveGestureDetector): Boolean {
+    override fun onMove(detector: MoveGestureDetector): Boolean {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "MOVE PROGRESS"))
       return false
     }
 
-    override fun onMoveEnd(@NonNull detector: MoveGestureDetector) {
+    override fun onMoveEnd(detector: MoveGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "MOVE END"))
       recalculateFocalPoint()
     }
   }
   private val scaleListener: OnScaleListener = object : OnScaleListener {
-    override fun onScaleBegin(@NonNull detector: StandardScaleGestureDetector) {
+    override fun onScaleBegin(detector: StandardScaleGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "SCALE START"))
       if (focalPointLatLng != null) {
         gestureAlertsAdapter.addAlert(
@@ -93,11 +93,11 @@ class GesturesActivity : AppCompatActivity() {
       recalculateFocalPoint()
     }
 
-    override fun onScale(@NonNull detector: StandardScaleGestureDetector) {
+    override fun onScale(detector: StandardScaleGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "SCALE PROGRESS"))
     }
 
-    override fun onScaleEnd(@NonNull detector: StandardScaleGestureDetector) {
+    override fun onScaleEnd(detector: StandardScaleGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "SCALE END"))
 
       if (focalPointLatLng != null) {
@@ -112,15 +112,15 @@ class GesturesActivity : AppCompatActivity() {
     }
   }
   private val shoveListener: OnShoveListener = object : OnShoveListener {
-    override fun onShoveBegin(@NonNull detector: ShoveGestureDetector) {
+    override fun onShoveBegin(detector: ShoveGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "SHOVE START"))
     }
 
-    override fun onShove(@NonNull detector: ShoveGestureDetector) {
+    override fun onShove(detector: ShoveGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "SHOVE PROGRESS"))
     }
 
-    override fun onShoveEnd(@NonNull detector: ShoveGestureDetector) {
+    override fun onShoveEnd(detector: ShoveGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "SHOVE END"))
     }
   }

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
@@ -25,7 +25,6 @@ import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.gestures.*
-import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.maps.testapp.R
 import com.mapbox.maps.testapp.databinding.ActivityGesturesBinding
 import java.util.*
@@ -71,7 +70,7 @@ class GesturesActivity : AppCompatActivity() {
       recalculateFocalPoint()
     }
   }
-    private val scaleListener: OnScaleListener = object : OnScaleListener {
+  private val scaleListener: OnScaleListener = object : OnScaleListener {
     override fun onScaleBegin(@NonNull detector: StandardScaleGestureDetector) {
       gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "SCALE START"))
       if (focalPointLatLng != null) {

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
@@ -38,14 +38,93 @@ class GesturesActivity : AppCompatActivity() {
   private lateinit var mapboxMap: MapboxMap
   private lateinit var gesturesPlugin: GesturesPlugin
   private lateinit var gesturesManager: AndroidGesturesManager
-  private lateinit var gestureAlertsAdapter: GestureAlertsAdapter
+  private val gestureAlertsAdapter: GestureAlertsAdapter = GestureAlertsAdapter()
   private var focalPointLatLng: Point? = null
   private var pointAnnotationManager: PointAnnotationManager? = null
   private lateinit var binding: ActivityGesturesBinding
-  private lateinit var rotateListener: OnRotateListener
-  private lateinit var moveListener: OnMoveListener
-  private lateinit var scaleListener: OnScaleListener
-  private lateinit var shoveListener: OnShoveListener
+  private val rotateListener: OnRotateListener = object : OnRotateListener {
+    override fun onRotateBegin(@NonNull detector: RotateGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "ROTATE START"))
+    }
+
+    override fun onRotate(@NonNull detector: RotateGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "ROTATE PROGRESS"))
+      recalculateFocalPoint()
+    }
+
+    override fun onRotateEnd(@NonNull detector: RotateGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "ROTATE END"))
+    }
+  }
+  private val moveListener: OnMoveListener = object : OnMoveListener {
+    override fun onMoveBegin(@NonNull detector: MoveGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "MOVE START"))
+    }
+
+    override fun onMove(@NonNull detector: MoveGestureDetector): Boolean {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "MOVE PROGRESS"))
+      return false
+    }
+
+    override fun onMoveEnd(@NonNull detector: MoveGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "MOVE END"))
+      recalculateFocalPoint()
+    }
+  }
+    private val scaleListener: OnScaleListener = object : OnScaleListener {
+    override fun onScaleBegin(@NonNull detector: StandardScaleGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "SCALE START"))
+      if (focalPointLatLng != null) {
+        gestureAlertsAdapter.addAlert(
+          GestureAlert(
+            GestureAlert.TYPE_OTHER,
+            "INCREASING MOVE THRESHOLD"
+          )
+        )
+        gesturesManager.moveGestureDetector.moveThreshold = 175 * resources.displayMetrics.density
+
+        gestureAlertsAdapter.addAlert(
+          GestureAlert(
+            GestureAlert.TYPE_OTHER,
+            "MANUALLY INTERRUPTING MOVE"
+          )
+        )
+        gesturesManager.moveGestureDetector.interrupt()
+      }
+      recalculateFocalPoint()
+    }
+
+    override fun onScale(@NonNull detector: StandardScaleGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "SCALE PROGRESS"))
+    }
+
+    override fun onScaleEnd(@NonNull detector: StandardScaleGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "SCALE END"))
+
+      if (focalPointLatLng != null) {
+        gestureAlertsAdapter.addAlert(
+          GestureAlert(
+            GestureAlert.TYPE_OTHER,
+            "REVERTING MOVE THRESHOLD"
+          )
+        )
+        gesturesManager.moveGestureDetector.moveThreshold = 0f
+      }
+    }
+  }
+  private val shoveListener: OnShoveListener = object : OnShoveListener {
+    override fun onShoveBegin(@NonNull detector: ShoveGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "SHOVE START"))
+    }
+
+    override fun onShove(@NonNull detector: ShoveGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "SHOVE PROGRESS"))
+    }
+
+    override fun onShoveEnd(@NonNull detector: ShoveGestureDetector) {
+      gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "SHOVE END"))
+    }
+  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -67,7 +146,6 @@ class GesturesActivity : AppCompatActivity() {
     }
 
     binding.recycler.layoutManager = LinearLayoutManager(this)
-    gestureAlertsAdapter = GestureAlertsAdapter()
     binding.recycler.adapter = gestureAlertsAdapter
   }
 
@@ -99,96 +177,9 @@ class GesturesActivity : AppCompatActivity() {
   }
 
   private fun attachListeners() {
-    moveListener = object : OnMoveListener {
-      override fun onMoveBegin(@NonNull detector: MoveGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "MOVE START"))
-      }
-
-      override fun onMove(@NonNull detector: MoveGestureDetector): Boolean {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "MOVE PROGRESS"))
-        return false
-      }
-
-      override fun onMoveEnd(@NonNull detector: MoveGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "MOVE END"))
-        recalculateFocalPoint()
-      }
-    }
     gesturesPlugin.addOnMoveListener(moveListener)
-
-
-    rotateListener = object : OnRotateListener {
-      override fun onRotateBegin(@NonNull detector: RotateGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "ROTATE START"))
-      }
-
-      override fun onRotate(@NonNull detector: RotateGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "ROTATE PROGRESS"))
-        recalculateFocalPoint()
-      }
-
-      override fun onRotateEnd(@NonNull detector: RotateGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "ROTATE END"))
-      }
-    }
     gesturesPlugin.addOnRotateListener(rotateListener)
-
-    scaleListener = object : OnScaleListener {
-      override fun onScaleBegin(@NonNull detector: StandardScaleGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "SCALE START"))
-        if (focalPointLatLng != null) {
-          gestureAlertsAdapter.addAlert(
-            GestureAlert(
-              GestureAlert.TYPE_OTHER,
-              "INCREASING MOVE THRESHOLD"
-            )
-          )
-          gesturesManager.moveGestureDetector.moveThreshold = 175 * resources.displayMetrics.density
-
-          gestureAlertsAdapter.addAlert(
-            GestureAlert(
-              GestureAlert.TYPE_OTHER,
-              "MANUALLY INTERRUPTING MOVE"
-            )
-          )
-          gesturesManager.moveGestureDetector.interrupt()
-        }
-        recalculateFocalPoint()
-      }
-
-      override fun onScale(@NonNull detector: StandardScaleGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "SCALE PROGRESS"))
-      }
-
-      override fun onScaleEnd(@NonNull detector: StandardScaleGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "SCALE END"))
-
-        if (focalPointLatLng != null) {
-          gestureAlertsAdapter.addAlert(
-            GestureAlert(
-              GestureAlert.TYPE_OTHER,
-              "REVERTING MOVE THRESHOLD"
-            )
-          )
-          gesturesManager.moveGestureDetector.moveThreshold = 0f
-        }
-      }
-    }
     gesturesPlugin.addOnScaleListener(scaleListener)
-
-    shoveListener = object : OnShoveListener {
-      override fun onShoveBegin(@NonNull detector: ShoveGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "SHOVE START"))
-      }
-
-      override fun onShove(@NonNull detector: ShoveGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_PROGRESS, "SHOVE PROGRESS"))
-      }
-
-      override fun onShoveEnd(@NonNull detector: ShoveGestureDetector) {
-        gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "SHOVE END"))
-      }
-    }
     gesturesPlugin.addOnShoveListener(shoveListener)
   }
 

--- a/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/examples/GesturesActivity.kt
@@ -25,6 +25,7 @@ import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.gestures.*
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.maps.testapp.R
 import com.mapbox.maps.testapp.databinding.ActivityGesturesBinding
 import java.util.*
@@ -41,6 +42,10 @@ class GesturesActivity : AppCompatActivity() {
   private var focalPointLatLng: Point? = null
   private var pointAnnotationManager: PointAnnotationManager? = null
   private lateinit var binding: ActivityGesturesBinding
+  private lateinit var rotateListener: OnRotateListener
+  private lateinit var moveListener: OnMoveListener
+  private lateinit var scaleListener: OnScaleListener
+  private lateinit var shoveListener: OnShoveListener
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -71,6 +76,14 @@ class GesturesActivity : AppCompatActivity() {
     gestureAlertsAdapter.cancelUpdates()
   }
 
+  override fun onDestroy() {
+    super.onDestroy()
+    gesturesPlugin.removeOnMoveListener(moveListener)
+    gesturesPlugin.removeOnRotateListener(rotateListener)
+    gesturesPlugin.removeOnScaleListener(scaleListener)
+    gesturesPlugin.removeOnShoveListener(shoveListener)
+  }
+
   private fun initializeMap() {
     gesturesPlugin = binding.mapView.gestures
     gesturesManager = gesturesPlugin.getGesturesManager()
@@ -86,7 +99,7 @@ class GesturesActivity : AppCompatActivity() {
   }
 
   private fun attachListeners() {
-    gesturesPlugin.addOnMoveListener(object : OnMoveListener {
+    moveListener = object : OnMoveListener {
       override fun onMoveBegin(@NonNull detector: MoveGestureDetector) {
         gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "MOVE START"))
       }
@@ -100,9 +113,11 @@ class GesturesActivity : AppCompatActivity() {
         gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "MOVE END"))
         recalculateFocalPoint()
       }
-    })
+    }
+    gesturesPlugin.addOnMoveListener(moveListener)
 
-    gesturesPlugin.addOnRotateListener(object : OnRotateListener {
+
+    rotateListener = object : OnRotateListener {
       override fun onRotateBegin(@NonNull detector: RotateGestureDetector) {
         gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "ROTATE START"))
       }
@@ -115,9 +130,10 @@ class GesturesActivity : AppCompatActivity() {
       override fun onRotateEnd(@NonNull detector: RotateGestureDetector) {
         gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "ROTATE END"))
       }
-    })
+    }
+    gesturesPlugin.addOnRotateListener(rotateListener)
 
-    gesturesPlugin.addOnScaleListener(object : OnScaleListener {
+    scaleListener = object : OnScaleListener {
       override fun onScaleBegin(@NonNull detector: StandardScaleGestureDetector) {
         gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "SCALE START"))
         if (focalPointLatLng != null) {
@@ -157,9 +173,10 @@ class GesturesActivity : AppCompatActivity() {
           gesturesManager.moveGestureDetector.moveThreshold = 0f
         }
       }
-    })
+    }
+    gesturesPlugin.addOnScaleListener(scaleListener)
 
-    gesturesPlugin.addOnShoveListener(object : OnShoveListener {
+    shoveListener = object : OnShoveListener {
       override fun onShoveBegin(@NonNull detector: ShoveGestureDetector) {
         gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_START, "SHOVE START"))
       }
@@ -171,7 +188,8 @@ class GesturesActivity : AppCompatActivity() {
       override fun onShoveEnd(@NonNull detector: ShoveGestureDetector) {
         gestureAlertsAdapter.addAlert(GestureAlert(GestureAlert.TYPE_END, "SHOVE END"))
       }
-    })
+    }
+    gesturesPlugin.addOnShoveListener(shoveListener)
   }
 
   override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
This PR updates the GesturesActivity example to match our documentation on [listening to gesture events](https://docs.mapbox.com/android/maps/guides/user-interaction/#listen-for-gesture-events). Now, gestures are added from the gesturesPlugin and removed within `onDestroy`. This will prevent any confusion for developers when manipulating/detecting gestures within the map view. 

Fixes https://github.com/mapbox/mapbox-maps-android/issues/1641


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
