### PR TITLE
fix: hide compass when setting enabled to false

### DIFF
--- a/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
+++ b/plugin-compass/src/main/java/com/mapbox/maps/plugin/compass/CompassViewPlugin.kt
@@ -71,8 +71,15 @@ open class CompassViewPlugin(
         compassImage = drawable
       }
       compassRotation = internalSettings.rotation
+      val wasCompassEnabled = isCompassEnabled
       isCompassEnabled = internalSettings.enabled
-      setCompassAlpha(internalSettings.opacity)
+      if (wasCompassEnabled != isCompassEnabled) {
+        if (!isCompassEnabled) {
+          setCompassAlpha(0f)
+        } else {
+          setCompassAlpha(internalSettings.opacity)
+        }
+      }
       setCompassMargins(
         internalSettings.marginLeft.toInt(),
         internalSettings.marginTop.toInt(),


### PR DESCRIPTION
### Summary of changes

Set alpha of compass to 0 in case enabled changed from true to false

### User impact (optional)

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: #1856 

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
