### PR TITLE
Revert location engine packages.

### DIFF
--- a/app/src/main/java/com/mapbox/maps/testapp/utils/LocationPermissionHelper.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/utils/LocationPermissionHelper.kt
@@ -2,8 +2,8 @@ package com.mapbox.maps.testapp.utils
 
 import android.app.Activity
 import android.widget.Toast
-import com.mapbox.common.location.compat.permissions.PermissionsListener
-import com.mapbox.common.location.compat.permissions.PermissionsManager
+import com.mapbox.android.core.permissions.PermissionsListener
+import com.mapbox.android.core.permissions.PermissionsManager
 import java.lang.ref.WeakReference
 
 class LocationPermissionHelper(val activity: WeakReference<Activity>) {

--- a/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/DefaultLocationProvider.kt
+++ b/plugin-locationcomponent/src/main/java/com/mapbox/maps/plugin/locationcomponent/DefaultLocationProvider.kt
@@ -7,11 +7,11 @@ import android.os.Handler
 import android.os.Looper
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
-import com.mapbox.common.location.compat.LocationEngineCallback
-import com.mapbox.common.location.compat.LocationEngineProvider
-import com.mapbox.common.location.compat.LocationEngineRequest
-import com.mapbox.common.location.compat.LocationEngineResult
-import com.mapbox.common.location.compat.permissions.PermissionsManager
+import com.mapbox.android.core.location.LocationEngineCallback
+import com.mapbox.android.core.location.LocationEngineProvider
+import com.mapbox.android.core.location.LocationEngineRequest
+import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.geojson.Point
 import com.mapbox.maps.logE
 import com.mapbox.maps.logW

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/DefaultLocationProviderTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/DefaultLocationProviderTest.kt
@@ -2,8 +2,8 @@ package com.mapbox.maps.plugin.locationcomponent
 
 import android.content.Context
 import android.location.Location
-import com.mapbox.common.location.compat.*
-import com.mapbox.common.location.compat.permissions.PermissionsManager
+import com.mapbox.android.core.location.*
+import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.geojson.Point
 import com.mapbox.maps.logW
 import com.mapbox.maps.plugin.PuckBearingSource

--- a/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
+++ b/plugin-locationcomponent/src/test/java/com/mapbox/maps/plugin/locationcomponent/LocationComponentPluginImplTest.kt
@@ -8,9 +8,9 @@ import android.graphics.drawable.Drawable
 import android.hardware.SensorManager
 import android.util.AttributeSet
 import android.view.WindowManager
+import com.mapbox.android.core.location.LocationEngine
+import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.bindgen.ExpectedFactory
-import com.mapbox.common.location.compat.LocationEngine
-import com.mapbox.common.location.compat.LocationEngineProvider
 import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.style.StyleInterface
 import com.mapbox.maps.logW


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

As part of core telemetry migration in https://github.com/mapbox/mapbox-maps-android/pull/1672, we used compat packages to host the location engine, this PR reverts location engine packages back to `com.mapbox.android.core`, to validate the removal of MME dependency.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
