### PR TITLE
MAPSAND-650 fix REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT typo

### DIFF
--- a/extension-androidauto/gradle.properties
+++ b/extension-androidauto/gradle.properties
@@ -3,5 +3,5 @@ POM_ARTIFACT_ID=maps-androidauto
 POM_ARTIFACT_TITLE=The android auto extension for the Mapbox Maps SDK for Android
 POM_DESCRIPTION=The android auto extension for the Mapbox Maps SDK for Android
 REGISTRY_SDK_NAME=mobile-maps-android-androidauto
-REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT=true
+REGISTRY_EXCLUDE_FROM_ROOT_PROJECT=true
 MODULE_VERSION_NAME=0.3.0

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -12,5 +12,5 @@ ext {
     mapboxArtifactLicenseUrl = 'https://opensource.org/licenses/BSD-2-Clause'
     versionName = project.hasProperty('MODULE_VERSION_NAME') ? project.property('MODULE_VERSION_NAME') : project.property('VERSION_NAME')
     mapboxRegistrySdkName = project.hasProperty('REGISTRY_SDK_NAME') ? project.property('REGISTRY_SDK_NAME') : System.getenv('REGISTRY_SDK_NAME')
-    mapboxRegistryExcludeFromRootProject = project.hasProperty('REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT') ? project.property('REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT').toBoolean() : false
+    mapboxRegistryExcludeFromRootProject = project.hasProperty('REGISTRY_EXCLUDE_FROM_ROOT_PROJECT') ? project.property('REGISTRY_EXCLUDE_FROM_ROOT_PROJECT').toBoolean() : false
 }


### PR DESCRIPTION
### Summary of changes

Fixes typo in "REGISTRY_EXCLUDE_FROM_ROOT_PROEJCT", must be intended to be "REGISTRY_EXCLUDE_FROM_ROOT_PROJECT"

### User impact (optional)

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >
