### PR TITLE
[gestures] Fix crash due to invalid distance when panning the map. - MAPSAND-627

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
-
+## Bug fixes 🐞
+* Fix crash due to invalid distance when panning the map. ([1906](https://github.com/mapbox/mapbox-maps-android/pull/1906))
 
 # 10.10.0 December 07, 2022
 ## Features ✨ and improvements 🏁

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -29,11 +29,7 @@ import com.mapbox.maps.plugin.animation.CameraAnimatorOptions.Companion.cameraAn
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.MapAnimationOptions.Companion.mapAnimationOptions
 import com.mapbox.maps.plugin.animation.MapAnimationOwnerRegistry
-import com.mapbox.maps.plugin.delegates.MapCameraManagerDelegate
-import com.mapbox.maps.plugin.delegates.MapDelegateProvider
-import com.mapbox.maps.plugin.delegates.MapPluginProviderDelegate
-import com.mapbox.maps.plugin.delegates.MapProjectionDelegate
-import com.mapbox.maps.plugin.delegates.MapTransformDelegate
+import com.mapbox.maps.plugin.delegates.*
 import com.mapbox.maps.plugin.gestures.generated.GesturesAttributeParser
 import com.mapbox.maps.plugin.gestures.generated.GesturesSettings
 import com.mapbox.maps.plugin.gestures.generated.GesturesSettingsBase
@@ -1470,6 +1466,12 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
       // Skip invalid focal points with non-finite values
       if (!focalPoint.x.isFinite() || !focalPoint.y.isFinite()) {
         logE(TAG, "Invalid focal point=$focalPoint to perform map panning!")
+        return false
+      }
+
+      // Skip invalid distance with non-finite values
+      if (!distanceX.isFinite() || !distanceY.isFinite()) {
+        logE(TAG, "Invalid distanceX=$distanceX or distanceY=$distanceY to perform map panning!")
         return false
       }
 

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
@@ -406,6 +406,24 @@ class GesturesPluginTest {
   }
 
   @Test
+  fun verifyHandleMoveExceptionFreeForInvalidDistance() {
+    mockkStatic("com.mapbox.maps.MapboxLogger")
+    every { logE(any(), any()) } just Runs
+    val moveGestureDetector = mockk<MoveGestureDetector>()
+    every { moveGestureDetector.pointersCount } returns 1
+    every {
+      moveGestureDetector.focalPoint
+    } returns PointF(0f, 0f)
+    var handled = presenter.handleMove(moveGestureDetector, 1f, Float.NaN)
+    assertFalse(handled)
+    verify(exactly = 1) { logE(any(), any()) }
+    handled = presenter.handleMove(moveGestureDetector, Float.NaN, 1f)
+    assertFalse(handled)
+    verify(exactly = 2) { logE(any(), any()) }
+    unmockkStatic("com.mapbox.maps.MapboxLogger")
+  }
+
+  @Test
   fun verifyMoveListenerPinchScrollDisabled() {
     presenter.pinchScrollEnabled = false
     val listener: OnMoveListener = mockk(relaxed = true)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Resolves https://github.com/mapbox/mapbox-maps-android/issues/1529

[gestures] Fix crash due to invalid distance when panning the map.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
