### PR TITLE
[ci] continously verify if permission changes 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,6 +583,7 @@ jobs:
             - run:
                 name: verify-permissions
                 command: |
+                  apt install -y aapt
                   make check-permissions
       - run: exit 0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,11 +578,12 @@ jobs:
                 pattern: << pipeline.parameters.changelog_branch >>
                 value: << pipeline.git.branch >>
           steps:
+            - checkout
             - read-from-workspace
             - run:
                 name: verify-permissions
                 command: |
-                  make check-permissions          
+                  make check-permissions
       - run: exit 0
 
   verify-internal:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ workflows:
       - verify-api-revapi:
           requires:
             - verify-code
+      - verify-permissions:
+          requires:
+            - build-modules-and-instrumentation-tests
       - verify-internal:
             requires:
               - verify-code
@@ -561,6 +564,25 @@ jobs:
                   fi
             - store_artifacts:
                 path: api_compat_report
+      - run: exit 0
+
+  verify-permissions:
+    executor:
+      name: ubuntu
+      machine: small
+    steps:
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: << pipeline.parameters.changelog_branch >>
+                value: << pipeline.git.branch >>
+          steps:
+            - read-from-workspace
+            - run:
+                name: verify-permissions
+                command: |
+                  make check-permissions          
       - run: exit 0
 
   verify-internal:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build:
 	./gradlew module-telemetry:assembleRelease;
 	./gradlew plugin-animation:assembleRelease;
 	./gradlew plugin-annotation:assembleRelease;
-	./gradlew plugin-attribution:assembleRelease;	
+	./gradlew plugin-attribution:assembleRelease;
 	./gradlew plugin-compass:assembleRelease;
 	./gradlew plugin-gestures:assembleRelease;
 	./gradlew plugin-locationcomponent:assembleRelease;
@@ -135,3 +135,19 @@ update-metalava:
 start-android-auto-dhu:
 	adb forward tcp:5277 tcp:5277;
 	$(ANDROID_HOME)/extras/google/auto/desktop-head-unit;
+
+
+# Check permissions app module, requires app:assembleDebug first
+.PHONY: check-permissions
+check-permissions:
+	 python3 scripts/check-permissions.py \
+	 	--apk app/build/outputs/apk/debug/app-debug.apk \
+		--file app/permission.json
+
+# Update permissions app module, requires app:assembleDebug first
+.PHONY: update-permissions
+update-permissions:
+	 python3 scripts/check-permissions.py \
+	 	--apk app/build/outputs/apk/debug/app-debug.apk \
+		--file app/permission.json \
+		--update True

--- a/app/permission.json
+++ b/app/permission.json
@@ -1,0 +1,11 @@
+[
+    "android.permission.ACCESS_COARSE_LOCATION",
+    "android.permission.ACCESS_FINE_LOCATION",
+    "android.permission.ACCESS_NETWORK_STATE",
+    "android.permission.ACCESS_WIFI_STATE",
+    "android.permission.FOREGROUND_SERVICE",
+    "android.permission.INTERNET",
+    "android.permission.READ_EXTERNAL_STORAGE",
+    "android.permission.REORDER_TASKS",
+    "android.permission.WRITE_EXTERNAL_STORAGE"
+]

--- a/scripts/check-permissions.py
+++ b/scripts/check-permissions.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import json
+
+USER_PERMISSION = "uses-permission: name="
+
+def load_apk_permissions(args):
+    permissions = []
+    shell = subprocess.Popen(f"aapt d permissions {args.apk}", stdout=subprocess.PIPE, shell=True).stdout
+    for output in shell:
+        line = output.decode('utf-8')
+        if USER_PERMISSION in line:
+            permission = line.partition(USER_PERMISSION)[2].strip()[1:-1]
+            permissions.append(permission)
+    permissions.sort()
+    return permissions
+
+
+def load_file(args):
+    with open(args.file, "r") as read_file:
+        return json.load(read_file)
+
+
+def update_file(args, permissions):
+    with open(args.file, "w") as write_file:
+        json.dump(permissions, write_file, indent=4, sort_keys=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check permission change.")
+    parser.add_argument("--apk", required=True,
+            help="Provide the path to the APK to validate permissions.")
+    parser.add_argument("--file", default="app/permission.json",
+            help="File path to lookup/update stored permissions.")
+    parser.add_argument("--update", default=False,
+            help="Update the permission file")
+    args = parser.parse_args()
+
+    print("Utility to validate permissions of an application\n")
+    print(f"Loading apk permissions {args.apk}:\n")
+    permissions = load_apk_permissions(args)
+    print(f"{json.dumps(permissions, indent=4)}\n")
+
+    if args.update:
+        print(f"Updating permissions file: {args.file}")
+        update_file(args, permissions)
+    else:
+        print(f"Checking if permissions file({args.file}) matches\n")
+        expected = load_file(args)
+        assert expected == permissions
+        print("Success, exiting..")

--- a/scripts/check-permissions.py
+++ b/scripts/check-permissions.py
@@ -4,15 +4,16 @@ import argparse
 import subprocess
 import json
 
-USER_PERMISSION = "uses-permission: name="
+USES_PERMISSION = "uses-permission: name="
+
 
 def load_apk_permissions(args):
     permissions = []
     shell = subprocess.Popen(f"aapt d permissions {args.apk}", stdout=subprocess.PIPE, shell=True).stdout
     for output in shell:
         line = output.decode('utf-8')
-        if USER_PERMISSION in line:
-            permission = line.partition(USER_PERMISSION)[2].strip()[1:-1]
+        if USES_PERMISSION in line:
+            permission = line.partition(USES_PERMISSION)[2].strip()[1:-1]
             permissions.append(permission)
     permissions.sort()
     return permissions
@@ -50,5 +51,5 @@ if __name__ == "__main__":
     else:
         print(f"Checking if permissions file({args.file}) matches\n")
         expected = load_file(args)
-        assert expected == permissions
+        assert expected == permissions, "Permission check failed, the permission file is outdated and you need to rerun the script with the --update true to update the baseline file"
         print("Success, exiting..")


### PR DESCRIPTION

### Summary of changes
Continuously verify if permission changes with either ourselves, upstream Mapbox or external dependencies. This PR introduces continuous verification in CI env (`make check-permissions`) to get notified about permissions changes. If a change occurs and is permitted, we can update hte baseline file (`make update-permissions`)


```sh
make check-permissions 
    # is under the hood:
    python3 scripts/check-permissions.py 
	--apk app/build/outputs/apk/debug/app-debug.apk 
	--file app/permission.json 

make update-permissions 
    # is under the hood:
    python3 scripts/check-permissions.py 
 	--apk app/build/outputs/apk/debug/app-debug.apk 
	--file app/permission.json 
	--update True
```

#### Example output:

```
$ make check-permissions 
python3 scripts/check-permissions.py \
 	--apk app/build/outputs/apk/debug/app-debug.apk \
	--file app/permission.json
Utility to validate permissions of an application

Loading apk permissions app/build/outputs/apk/debug/app-debug.apk:

[
    "android.permission.ACCESS_COARSE_LOCATION",
    "android.permission.ACCESS_FINE_LOCATION",
    "android.permission.ACCESS_NETWORK_STATE",
    "android.permission.ACCESS_WIFI_STATE",
    "android.permission.FOREGROUND_SERVICE",
    "android.permission.INTERNET",
    "android.permission.READ_EXTERNAL_STORAGE",
    "android.permission.REORDER_TASKS",
    "android.permission.WRITE_EXTERNAL_STORAGE"
]

Checking if permissions file(app/permission.json) matches

Success, exiting..

```