### PR TITLE
[ci] avoid running revapi when merged to main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,10 +543,15 @@ jobs:
     steps:
       - when:
           condition:
-            not:
-              matches:
-                pattern: << pipeline.parameters.changelog_branch >>
-                value: << pipeline.git.branch >>
+            and:
+              - not:
+                  matches:
+                    pattern: << pipeline.parameters.changelog_branch >>
+                    value: << pipeline.git.branch >>
+              - not:
+                  matches:
+                    pattern: "tvn-revapi-main"
+                    value: $CIRCLE_BRANCH
           steps:
             - checkout
             - restore-gradle-cache
@@ -557,9 +562,7 @@ jobs:
                 command: |
                   make build
                   echo "$(./mbx-ci github reader token)" > gh_token.txt
-                  if [[ $CIRCLE_BRANCH == "tvn-revapi-main" ]]; then
-                    echo "Running on main branch, skipping revapi"
-                  elif [[ $CIRCLE_TAG =~ << pipeline.parameters.git_release_tag >> ]]; then
+                  if [[ $CIRCLE_TAG =~ << pipeline.parameters.git_release_tag >> ]]; then
                     ./scripts/java-api-check-all.sh "${CIRCLE_TAG}"
                   else
                     ./scripts/java-api-check-all.sh ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,7 +557,9 @@ jobs:
                 command: |
                   make build
                   echo "$(./mbx-ci github reader token)" > gh_token.txt
-                  if [[ $CIRCLE_TAG =~ << pipeline.parameters.git_release_tag >> ]]; then
+                  if [[ $CIRCLE_BRANCH == "tvn-revapi-main" ]]; then
+                    echo "Running on main branch, skipping revapi"
+                  elif [[ $CIRCLE_TAG =~ << pipeline.parameters.git_release_tag >> ]]; then
                     ./scripts/java-api-check-all.sh "${CIRCLE_TAG}"
                   else
                     ./scripts/java-api-check-all.sh ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -549,9 +549,7 @@ jobs:
                     pattern: << pipeline.parameters.changelog_branch >>
                     value: << pipeline.git.branch >>
               - not:
-                  matches:
-                    pattern: "tvn-revapi-main"
-                    value: $CIRCLE_BRANCH
+                  equal: [ "tvn-revapi-main", << pipeline.git.branch >> ]
           steps:
             - checkout
             - restore-gradle-cache


### PR DESCRIPTION
PR optimizes the revapi job to skip when running on main branch (draft state to test setup).