### PR TITLE
[viewport] Fix transition to FollowPuckViewportState when no new location update is available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Features ✨ and improvements 🏁
 * Skip redundant `MapboxMap.setCamera` updates in `CameraAnimationsPlugin`. ([1909](https://github.com/mapbox/mapbox-maps-android/pull/1909))
 * Improve performance by setting geojson data directly. ([1920](https://github.com/mapbox/mapbox-maps-android/pull/1920))
+* Fix viewport hang when transition to `FollowPuckViewportState` and no new location update is available. ([1929](https://github.com/mapbox/mapbox-maps-android/pull/1929))
 
 ## Bug fixes 🐞
 * Fix crash due to invalid distance when panning the map. ([1906](https://github.com/mapbox/mapbox-maps-android/pull/1906))

--- a/plugin-viewport/src/main/kotlin/com/mapbox/maps/plugin/viewport/state/FollowPuckViewportStateImpl.kt
+++ b/plugin-viewport/src/main/kotlin/com/mapbox/maps/plugin/viewport/state/FollowPuckViewportStateImpl.kt
@@ -95,6 +95,8 @@ internal class FollowPuckViewportStateImpl(
       locationComponent.addOnIndicatorPositionChangedListener(indicatorPositionChangedListener)
       locationComponent.addOnIndicatorBearingChangedListener(indicatorBearingChangedListener)
       isObservingLocationUpdates = true
+    } else {
+      notifyLatestViewportData()
     }
   }
 
@@ -103,6 +105,8 @@ internal class FollowPuckViewportStateImpl(
       locationComponent.removeOnIndicatorPositionChangedListener(indicatorPositionChangedListener)
       locationComponent.removeOnIndicatorBearingChangedListener(indicatorBearingChangedListener)
       isObservingLocationUpdates = false
+      lastBearing = null
+      lastLocation = null
     }
   }
 
@@ -124,8 +128,8 @@ internal class FollowPuckViewportStateImpl(
    */
   override fun observeDataSource(viewportStateDataObserver: ViewportStateDataObserver): Cancelable {
     checkLocationComponentEnablement()
-    addIndicatorListenerIfNeeded()
     dataSourceUpdateObservers.add(viewportStateDataObserver)
+    addIndicatorListenerIfNeeded()
     return Cancelable {
       dataSourceUpdateObservers.remove(viewportStateDataObserver)
       removeIndicatorListenerIfNeeded()

--- a/plugin-viewport/src/main/kotlin/com/mapbox/maps/plugin/viewport/state/FollowPuckViewportStateImpl.kt
+++ b/plugin-viewport/src/main/kotlin/com/mapbox/maps/plugin/viewport/state/FollowPuckViewportStateImpl.kt
@@ -113,6 +113,8 @@ internal class FollowPuckViewportStateImpl(
       locationComponent.removeOnIndicatorPositionChangedListener(indicatorPositionChangedListener)
       locationComponent.removeOnIndicatorBearingChangedListener(indicatorBearingChangedListener)
       isObservingLocationUpdates = false
+      // when unsubscribed from the location updates, we don't want to keep an outdated location, so
+      // when user transition to the FollowPuckViewportState, there wouldn't be any unintentional jump.
       lastBearing = null
       lastLocation = null
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

Fix transition to FollowPuckViewportState when no new location update is available.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
