### PR TITLE
MAPSAND-684 Run onAppUserTurnstileEvent in thread to speed up MapView initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
+* Improvement for MapView initialization time. ([1936](https://github.com/mapbox/mapbox-maps-android/pull/1936))
 
 # 10.11.0-beta.1 January 11, 2023
 ## Features ✨ and improvements 🏁

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
   api(project(":plugin-viewport"))
   compileOnly(Dependencies.asyncInflater)
   implementation(Dependencies.kotlin)
+  implementation(Dependencies.coroutines)
   implementation(Dependencies.androidxCoreKtx)
   implementation(Dependencies.androidxAnnotations)
   testImplementation(Dependencies.junit)

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -73,7 +73,6 @@ dependencies {
   api(project(":plugin-viewport"))
   compileOnly(Dependencies.asyncInflater)
   implementation(Dependencies.kotlin)
-  implementation(Dependencies.coroutines)
   implementation(Dependencies.androidxCoreKtx)
   implementation(Dependencies.androidxAnnotations)
   testImplementation(Dependencies.junit)

--- a/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
@@ -11,6 +11,8 @@ import com.mapbox.maps.base.BuildConfig
 import com.mapbox.maps.module.MapTelemetry
 import com.mapbox.maps.plugin.MapDelegateProviderImpl
 import com.mapbox.maps.plugin.MapPluginRegistry
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 internal object MapProvider {
 
@@ -50,7 +52,9 @@ internal object MapProvider {
         paramsProvider(context, accessToken, MapboxModuleType.MapTelemetry)
       }
     }
-    mapTelemetry.onAppUserTurnstileEvent()
+    GlobalScope.launch {
+      mapTelemetry.onAppUserTurnstileEvent()
+    }
     return mapTelemetry
   }
 

--- a/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
+++ b/sdk/src/main/java/com/mapbox/maps/MapProvider.kt
@@ -11,8 +11,8 @@ import com.mapbox.maps.base.BuildConfig
 import com.mapbox.maps.module.MapTelemetry
 import com.mapbox.maps.plugin.MapDelegateProviderImpl
 import com.mapbox.maps.plugin.MapPluginRegistry
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import kotlin.concurrent.thread
+
 
 internal object MapProvider {
 
@@ -52,7 +52,8 @@ internal object MapProvider {
         paramsProvider(context, accessToken, MapboxModuleType.MapTelemetry)
       }
     }
-    GlobalScope.launch {
+    // Report turnstile event in background thread.
+    thread {
       mapTelemetry.onAppUserTurnstileEvent()
     }
     return mapTelemetry


### PR DESCRIPTION
### Summary of changes

Measurement of map initialization seems to show calls to onAppUserTurnstileEvent during map construction taking around 20 milliseconds on average on the main thread.

Putting the call to onAppUserTurnstileEvent in a thread shortens this to around ~1 millisecond, so any delays that might occur during the event sending (e.g. initial report said the startup took over 100 ms) will not affect the main thread. The event is not critical to use of the MapView, it simply enqueues the turnstile event to be sent to the backend.

There were no apparent side effects of sending this event from a coroutine, so should be safe to take into use.

User impact (optional)
Should result is slightly faster MapView initialization.

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
