### PR TITLE
[MAPSAND-710] deprecate layer transition apis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 # main
 ## Bug fixes 🐞
 * Fix a bug where `flyTo` animation request invalid tiles from map engine. ([1949](https://github.com/mapbox/mapbox-maps-android/pull/1949))
+* Deprecate `pattern` and `dash` transition properties for layer (e.g. `BackgroundLayer.backgroundPatternTransition`, `FillExtrusionLayer.fillExtrusionPatternTransition`, `FillLayer.fillPatternTransition`, `LineLayer.lineDasharrayTransition`, `LineLayer.linePatternTransition`, ...).  ([1941](https://github.com/mapbox/mapbox-maps-android/pull/1941))
 
 # 10.11.0-beta.1 January 11, 2023
 ## Features ✨ and improvements 🏁

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/BackgroundLayerTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/BackgroundLayerTest.kt
@@ -173,37 +173,6 @@ class BackgroundLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun backgroundPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = backgroundLayer("id") {
-      backgroundPatternTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.backgroundPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun backgroundPatternTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = backgroundLayer("id") {
-      backgroundPatternTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.backgroundPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun visibilityTest() {
     val layer = backgroundLayer("id") {
       visibility(Visibility.NONE)
@@ -229,7 +198,6 @@ class BackgroundLayerTest : BaseStyleTest() {
     assertNotNull("defaultBackgroundOpacityTransition should not be null", BackgroundLayer.defaultBackgroundOpacityTransition)
     assertNotNull("defaultBackgroundPattern should not be null", BackgroundLayer.defaultBackgroundPattern)
     assertNotNull("defaultBackgroundPatternAsExpression should not be null", BackgroundLayer.defaultBackgroundPatternAsExpression)
-    assertNotNull("defaultBackgroundPatternTransition should not be null", BackgroundLayer.defaultBackgroundPatternTransition)
   }
 
   @Test

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/FillExtrusionLayerTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/FillExtrusionLayerTest.kt
@@ -452,37 +452,6 @@ class FillExtrusionLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun fillExtrusionPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = fillExtrusionLayer("id", "source") {
-      fillExtrusionPatternTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.fillExtrusionPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun fillExtrusionPatternTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = fillExtrusionLayer("id", "source") {
-      fillExtrusionPatternTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.fillExtrusionPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun fillExtrusionTranslateTest() {
     val testValue = listOf(0.0, 1.0)
     val layer = fillExtrusionLayer("id", "source") {
@@ -622,7 +591,6 @@ class FillExtrusionLayerTest : BaseStyleTest() {
     assertNotNull("defaultFillExtrusionOpacityTransition should not be null", FillExtrusionLayer.defaultFillExtrusionOpacityTransition)
     assertNotNull("defaultFillExtrusionPattern should not be null", FillExtrusionLayer.defaultFillExtrusionPattern)
     assertNotNull("defaultFillExtrusionPatternAsExpression should not be null", FillExtrusionLayer.defaultFillExtrusionPatternAsExpression)
-    assertNotNull("defaultFillExtrusionPatternTransition should not be null", FillExtrusionLayer.defaultFillExtrusionPatternTransition)
     assertNotNull("defaultFillExtrusionTranslate should not be null", FillExtrusionLayer.defaultFillExtrusionTranslate)
     assertNotNull("defaultFillExtrusionTranslateAsExpression should not be null", FillExtrusionLayer.defaultFillExtrusionTranslateAsExpression)
     assertNotNull("defaultFillExtrusionTranslateTransition should not be null", FillExtrusionLayer.defaultFillExtrusionTranslateTransition)

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/FillLayerTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/FillLayerTest.kt
@@ -349,37 +349,6 @@ class FillLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun fillPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = fillLayer("id", "source") {
-      fillPatternTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.fillPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun fillPatternTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = fillLayer("id", "source") {
-      fillPatternTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.fillPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun fillTranslateTest() {
     val testValue = listOf(0.0, 1.0)
     val layer = fillLayer("id", "source") {
@@ -491,7 +460,6 @@ class FillLayerTest : BaseStyleTest() {
     assertNotNull("defaultFillOutlineColorTransition should not be null", FillLayer.defaultFillOutlineColorTransition)
     assertNotNull("defaultFillPattern should not be null", FillLayer.defaultFillPattern)
     assertNotNull("defaultFillPatternAsExpression should not be null", FillLayer.defaultFillPatternAsExpression)
-    assertNotNull("defaultFillPatternTransition should not be null", FillLayer.defaultFillPatternTransition)
     assertNotNull("defaultFillTranslate should not be null", FillLayer.defaultFillTranslate)
     assertNotNull("defaultFillTranslateAsExpression should not be null", FillLayer.defaultFillTranslateAsExpression)
     assertNotNull("defaultFillTranslateTransition should not be null", FillLayer.defaultFillTranslateTransition)

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/LineLayerTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/LineLayerTest.kt
@@ -348,37 +348,6 @@ class LineLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun lineDasharrayTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = lineLayer("id", "source") {
-      lineDasharrayTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.lineDasharrayTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun lineDasharrayTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = lineLayer("id", "source") {
-      lineDasharrayTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.lineDasharrayTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun lineGapWidthTest() {
     val testValue = 1.0
     val layer = lineLayer("id", "source") {
@@ -618,37 +587,6 @@ class LineLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun linePatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = lineLayer("id", "source") {
-      linePatternTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.linePatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun linePatternTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = lineLayer("id", "source") {
-      linePatternTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.linePatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun lineTranslateTest() {
     val testValue = listOf(0.0, 1.0)
     val layer = lineLayer("id", "source") {
@@ -845,7 +783,6 @@ class LineLayerTest : BaseStyleTest() {
     assertNotNull("defaultLineColorTransition should not be null", LineLayer.defaultLineColorTransition)
     assertNotNull("defaultLineDasharray should not be null", LineLayer.defaultLineDasharray)
     assertNotNull("defaultLineDasharrayAsExpression should not be null", LineLayer.defaultLineDasharrayAsExpression)
-    assertNotNull("defaultLineDasharrayTransition should not be null", LineLayer.defaultLineDasharrayTransition)
     assertNotNull("defaultLineGapWidth should not be null", LineLayer.defaultLineGapWidth)
     assertNotNull("defaultLineGapWidthAsExpression should not be null", LineLayer.defaultLineGapWidthAsExpression)
     assertNotNull("defaultLineGapWidthTransition should not be null", LineLayer.defaultLineGapWidthTransition)
@@ -857,7 +794,6 @@ class LineLayerTest : BaseStyleTest() {
     assertNotNull("defaultLineOpacityTransition should not be null", LineLayer.defaultLineOpacityTransition)
     assertNotNull("defaultLinePattern should not be null", LineLayer.defaultLinePattern)
     assertNotNull("defaultLinePatternAsExpression should not be null", LineLayer.defaultLinePatternAsExpression)
-    assertNotNull("defaultLinePatternTransition should not be null", LineLayer.defaultLinePatternTransition)
     assertNotNull("defaultLineTranslate should not be null", LineLayer.defaultLineTranslate)
     assertNotNull("defaultLineTranslateAsExpression should not be null", LineLayer.defaultLineTranslateAsExpression)
     assertNotNull("defaultLineTranslateTransition should not be null", LineLayer.defaultLineTranslateTransition)

--- a/extension-style/api/metalava.txt
+++ b/extension-style/api/metalava.txt
@@ -1005,8 +1005,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundOpacityTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPattern(String backgroundPattern);
     method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPattern(com.mapbox.maps.extension.style.expressions.generated.Expression backgroundPattern);
-    method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public String? getBackgroundColor();
     method @ColorInt public Integer? getBackgroundColorAsColorInt();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getBackgroundColorAsExpression();
@@ -1016,7 +1016,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getBackgroundOpacityTransition();
     method public String? getBackgroundPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getBackgroundPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getBackgroundPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getBackgroundPatternTransition();
     method public String getLayerId();
     method public Double? getMaxZoom();
     method public Double? getMinZoom();
@@ -1034,7 +1034,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? backgroundOpacityTransition;
     property public final String? backgroundPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? backgroundPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? backgroundPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? backgroundPatternTransition;
     property public String layerId;
     property public Double? maxZoom;
     property public Double? minZoom;
@@ -1052,7 +1052,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultBackgroundOpacityTransition();
     method public String? getDefaultBackgroundPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultBackgroundPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultBackgroundPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultBackgroundPatternTransition();
     method public Double? getDefaultMaxZoom();
     method public Double? getDefaultMinZoom();
     method public com.mapbox.maps.extension.style.layers.properties.generated.Visibility? getDefaultVisibility();
@@ -1065,7 +1065,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultBackgroundOpacityTransition;
     property public final String? defaultBackgroundPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultBackgroundPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultBackgroundPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultBackgroundPatternTransition;
     property public final Double? defaultMaxZoom;
     property public final Double? defaultMinZoom;
     property public final com.mapbox.maps.extension.style.layers.properties.generated.Visibility? defaultVisibility;
@@ -1389,8 +1389,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionOpacityTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPattern(String fillExtrusionPattern);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPattern(com.mapbox.maps.extension.style.expressions.generated.Expression fillExtrusionPattern);
-    method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionTranslate(java.util.List<java.lang.Double> fillExtrusionTranslate);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionTranslate(com.mapbox.maps.extension.style.expressions.generated.Expression fillExtrusionTranslate);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionTranslateAnchor(com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor fillExtrusionTranslateAnchor);
@@ -1421,7 +1421,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getFillExtrusionOpacityTransition();
     method public String? getFillExtrusionPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getFillExtrusionPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getFillExtrusionPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getFillExtrusionPatternTransition();
     method public java.util.List<java.lang.Double>? getFillExtrusionTranslate();
     method public com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor? getFillExtrusionTranslateAnchor();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getFillExtrusionTranslateAnchorAsExpression();
@@ -1462,7 +1462,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? fillExtrusionOpacityTransition;
     property public final String? fillExtrusionPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? fillExtrusionPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? fillExtrusionPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? fillExtrusionPatternTransition;
     property public final java.util.List<java.lang.Double>? fillExtrusionTranslate;
     property public final com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor? fillExtrusionTranslateAnchor;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? fillExtrusionTranslateAnchorAsExpression;
@@ -1502,7 +1502,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillExtrusionOpacityTransition();
     method public String? getDefaultFillExtrusionPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultFillExtrusionPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillExtrusionPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillExtrusionPatternTransition();
     method public java.util.List<java.lang.Double>? getDefaultFillExtrusionTranslate();
     method public com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor? getDefaultFillExtrusionTranslateAnchor();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultFillExtrusionTranslateAnchorAsExpression();
@@ -1534,7 +1534,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillExtrusionOpacityTransition;
     property public final String? defaultFillExtrusionPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultFillExtrusionPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillExtrusionPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillExtrusionPatternTransition;
     property public final java.util.List<java.lang.Double>? defaultFillExtrusionTranslate;
     property public final com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor? defaultFillExtrusionTranslateAnchor;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultFillExtrusionTranslateAnchorAsExpression;
@@ -1616,8 +1616,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillOutlineColorTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPattern(String fillPattern);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPattern(com.mapbox.maps.extension.style.expressions.generated.Expression fillPattern);
-    method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillSortKey(double fillSortKey);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillSortKey(com.mapbox.maps.extension.style.expressions.generated.Expression fillSortKey);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillTranslate(java.util.List<java.lang.Double> fillTranslate);
@@ -1642,7 +1642,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getFillOutlineColorTransition();
     method public String? getFillPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getFillPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getFillPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getFillPatternTransition();
     method public Double? getFillSortKey();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getFillSortKeyAsExpression();
     method public java.util.List<java.lang.Double>? getFillTranslate();
@@ -1677,7 +1677,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? fillOutlineColorTransition;
     property public final String? fillPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? fillPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? fillPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? fillPatternTransition;
     property public final Double? fillSortKey;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? fillSortKeyAsExpression;
     property public final java.util.List<java.lang.Double>? fillTranslate;
@@ -1711,7 +1711,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillOutlineColorTransition();
     method public String? getDefaultFillPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultFillPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillPatternTransition();
     method public Double? getDefaultFillSortKey();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultFillSortKeyAsExpression();
     method public java.util.List<java.lang.Double>? getDefaultFillTranslate();
@@ -1737,7 +1737,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillOutlineColorTransition;
     property public final String? defaultFillPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultFillPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillPatternTransition;
     property public final Double? defaultFillSortKey;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultFillSortKeyAsExpression;
     property public final java.util.List<java.lang.Double>? defaultFillTranslate;
@@ -2094,7 +2094,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getLineColorTransition();
     method public java.util.List<java.lang.Double>? getLineDasharray();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getLineDasharrayAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getLineDasharrayTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getLineDasharrayTransition();
     method public Double? getLineGapWidth();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getLineGapWidthAsExpression();
     method public com.mapbox.maps.extension.style.types.StyleTransition? getLineGapWidthTransition();
@@ -2111,7 +2111,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getLineOpacityTransition();
     method public String? getLinePattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getLinePatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getLinePatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getLinePatternTransition();
     method public Double? getLineRoundLimit();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getLineRoundLimitAsExpression();
     method public Double? getLineSortKey();
@@ -2145,8 +2145,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineColorTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharray(java.util.List<java.lang.Double> lineDasharray);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharray(com.mapbox.maps.extension.style.expressions.generated.Expression lineDasharray);
-    method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharrayTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharrayTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharrayTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharrayTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineGapWidth(double lineGapWidth);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineGapWidth(com.mapbox.maps.extension.style.expressions.generated.Expression lineGapWidth);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineGapWidthTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
@@ -2166,8 +2166,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineOpacityTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer linePattern(String linePattern);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer linePattern(com.mapbox.maps.extension.style.expressions.generated.Expression linePattern);
-    method public com.mapbox.maps.extension.style.layers.generated.LineLayer linePatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.LineLayer linePatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.LineLayer linePatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.LineLayer linePatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineRoundLimit(double lineRoundLimit);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineRoundLimit(com.mapbox.maps.extension.style.expressions.generated.Expression lineRoundLimit);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineSortKey(double lineSortKey);
@@ -2201,7 +2201,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? lineColorTransition;
     property public final java.util.List<java.lang.Double>? lineDasharray;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? lineDasharrayAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? lineDasharrayTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? lineDasharrayTransition;
     property public final Double? lineGapWidth;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? lineGapWidthAsExpression;
     property public final com.mapbox.maps.extension.style.types.StyleTransition? lineGapWidthTransition;
@@ -2218,7 +2218,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? lineOpacityTransition;
     property public final String? linePattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? linePatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? linePatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? linePatternTransition;
     property public final Double? lineRoundLimit;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? lineRoundLimitAsExpression;
     property public final Double? lineSortKey;
@@ -2253,7 +2253,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineColorTransition();
     method public java.util.List<java.lang.Double>? getDefaultLineDasharray();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultLineDasharrayAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineDasharrayTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineDasharrayTransition();
     method public Double? getDefaultLineGapWidth();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultLineGapWidthAsExpression();
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineGapWidthTransition();
@@ -2269,7 +2269,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineOpacityTransition();
     method public String? getDefaultLinePattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultLinePatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLinePatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLinePatternTransition();
     method public Double? getDefaultLineRoundLimit();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultLineRoundLimitAsExpression();
     method public Double? getDefaultLineSortKey();
@@ -2298,7 +2298,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineColorTransition;
     property public final java.util.List<java.lang.Double>? defaultLineDasharray;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultLineDasharrayAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineDasharrayTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineDasharrayTransition;
     property public final Double? defaultLineGapWidth;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultLineGapWidthAsExpression;
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineGapWidthTransition;
@@ -2314,7 +2314,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineOpacityTransition;
     property public final String? defaultLinePattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultLinePatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLinePatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLinePatternTransition;
     property public final Double? defaultLineRoundLimit;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultLineRoundLimitAsExpression;
     property public final Double? defaultLineSortKey;

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
@@ -14,6 +14,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils.colorIntToRgbaExpression
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorInt
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorString
 import com.mapbox.maps.extension.style.utils.silentUnwrap
+import com.mapbox.maps.logE
 import java.util.*
 
 /**
@@ -436,6 +437,7 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
      * @return transition options for String
      */
     get() {
+      logE("BackgroundLayer", "This property has been deprecated and will return null.")
       return null
     }
 
@@ -680,7 +682,10 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
        *
        * @return transition options for String
        */
-      get() = null
+      get() {
+        logE("BackgroundLayer", "This property has been deprecated and will return null.")
+        return null
+      }
   }
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
@@ -424,6 +424,42 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
   }
 
   /**
+   * Transition options for BackgroundPattern.
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  val backgroundPatternTransition: StyleTransition?
+    /**
+     * Get the BackgroundPattern property transition options
+     *
+     * Use static method [BackgroundLayer.defaultBackgroundPatternTransition] to get the default property.
+     *
+     * @return transition options for String
+     */
+    get() {
+      return null
+    }
+
+  /**
+   * Set the BackgroundPattern property transition options
+   *
+   * Use static method [BackgroundLayer.defaultBackgroundPatternTransition] to set the default property.
+   *
+   * @param options transition options for String
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun backgroundPatternTransition(options: StyleTransition) = apply {
+    // no-op
+  }
+
+  /**
+   * DSL for [backgroundPatternTransition].
+   */
+    @Deprecated("This property has been deprecated and will do no operations")
+    override fun backgroundPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+      // no-op
+    }
+
+  /**
    * Get the type of this layer
    *
    * @return Type of the layer as [String]
@@ -633,6 +669,18 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
         }
         return null
       }
+
+    /**
+    * Transition options for BackgroundPattern.
+    */
+      @Deprecated("This property has been deprecated and will do no operations")
+    val defaultBackgroundPatternTransition: StyleTransition?
+      /**
+        * Get the BackgroundPattern property transition options
+        *
+        * @return transition options for String
+        */
+      get() = null
   }
 }
 
@@ -756,6 +804,22 @@ interface BackgroundLayerDsl {
    * @param backgroundPattern value of backgroundPattern as Expression
    */
   fun backgroundPattern(backgroundPattern: Expression): BackgroundLayer
+
+  /**
+   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * Set the BackgroundPattern property transition options
+   *
+   * @param options transition options for String
+   */
+  fun backgroundPatternTransition(options: StyleTransition): BackgroundLayer
+
+  /**
+   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * DSL for [backgroundPatternTransition].
+   */
+  fun backgroundPatternTransition(block: StyleTransition.Builder.() -> Unit): BackgroundLayer
 }
 
 /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
@@ -454,10 +454,10 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
   /**
    * DSL for [backgroundPatternTransition].
    */
-    @Deprecated("This property has been deprecated and will do no operations")
-    override fun backgroundPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-      // no-op
-    }
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun backgroundPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+    // no-op
+  }
 
   /**
    * Get the type of this layer
@@ -671,15 +671,15 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
       }
 
     /**
-    * Transition options for BackgroundPattern.
-    */
-      @Deprecated("This property has been deprecated and will do no operations")
+     * Transition options for BackgroundPattern.
+     */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultBackgroundPatternTransition: StyleTransition?
       /**
-        * Get the BackgroundPattern property transition options
-        *
-        * @return transition options for String
-        */
+       * Get the BackgroundPattern property transition options
+       *
+       * @return transition options for String
+       */
       get() = null
   }
 }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
@@ -424,40 +424,6 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
   }
 
   /**
-   * Transition options for BackgroundPattern.
-   */
-  val backgroundPatternTransition: StyleTransition?
-    /**
-     * Get the BackgroundPattern property transition options
-     *
-     * Use static method [BackgroundLayer.defaultBackgroundPatternTransition] to get the default property.
-     *
-     * @return transition options for String
-     */
-    get() {
-      return getPropertyValue("background-pattern-transition")
-    }
-
-  /**
-   * Set the BackgroundPattern property transition options
-   *
-   * Use static method [BackgroundLayer.defaultBackgroundPatternTransition] to set the default property.
-   *
-   * @param options transition options for String
-   */
-  override fun backgroundPatternTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("background-pattern-transition", options)
-    setProperty(propertyValue)
-  }
-
-  /**
-   * DSL for [backgroundPatternTransition].
-   */
-  override fun backgroundPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    backgroundPatternTransition(StyleTransition.Builder().apply(block).build())
-  }
-
-  /**
    * Get the type of this layer
    *
    * @return Type of the layer as [String]
@@ -667,17 +633,6 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
         }
         return null
       }
-
-    /**
-     * Transition options for BackgroundPattern.
-     */
-    val defaultBackgroundPatternTransition: StyleTransition?
-      /**
-       * Get the BackgroundPattern property transition options
-       *
-       * @return transition options for String
-       */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("background", "background-pattern-transition").silentUnwrap()
   }
 }
 
@@ -801,22 +756,6 @@ interface BackgroundLayerDsl {
    * @param backgroundPattern value of backgroundPattern as Expression
    */
   fun backgroundPattern(backgroundPattern: Expression): BackgroundLayer
-
-  /**
-   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * Set the BackgroundPattern property transition options
-   *
-   * @param options transition options for String
-   */
-  fun backgroundPatternTransition(options: StyleTransition): BackgroundLayer
-
-  /**
-   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * DSL for [backgroundPatternTransition].
-   */
-  fun backgroundPatternTransition(block: StyleTransition.Builder.() -> Unit): BackgroundLayer
 }
 
 /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
@@ -882,40 +882,6 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
   }
 
   /**
-   * Transition options for FillExtrusionPattern.
-   */
-  val fillExtrusionPatternTransition: StyleTransition?
-    /**
-     * Get the FillExtrusionPattern property transition options
-     *
-     * Use static method [FillExtrusionLayer.defaultFillExtrusionPatternTransition] to get the default property.
-     *
-     * @return transition options for String
-     */
-    get() {
-      return getPropertyValue("fill-extrusion-pattern-transition")
-    }
-
-  /**
-   * Set the FillExtrusionPattern property transition options
-   *
-   * Use static method [FillExtrusionLayer.defaultFillExtrusionPatternTransition] to set the default property.
-   *
-   * @param options transition options for String
-   */
-  override fun fillExtrusionPatternTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("fill-extrusion-pattern-transition", options)
-    setProperty(propertyValue)
-  }
-
-  /**
-   * DSL for [fillExtrusionPatternTransition].
-   */
-  override fun fillExtrusionPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    fillExtrusionPatternTransition(StyleTransition.Builder().apply(block).build())
-  }
-
-  /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.
    */
   val fillExtrusionTranslate: List<Double>?
@@ -1551,17 +1517,6 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
       }
 
     /**
-     * Transition options for FillExtrusionPattern.
-     */
-    val defaultFillExtrusionPatternTransition: StyleTransition?
-      /**
-       * Get the FillExtrusionPattern property transition options
-       *
-       * @return transition options for String
-       */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("fill-extrusion", "fill-extrusion-pattern-transition").silentUnwrap()
-
-    /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.
      */
     val defaultFillExtrusionTranslate: List<Double>?
@@ -1948,22 +1903,6 @@ interface FillExtrusionLayerDsl {
    * @param fillExtrusionPattern value of fillExtrusionPattern as Expression
    */
   fun fillExtrusionPattern(fillExtrusionPattern: Expression): FillExtrusionLayer
-
-  /**
-   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * Set the FillExtrusionPattern property transition options
-   *
-   * @param options transition options for String
-   */
-  fun fillExtrusionPatternTransition(options: StyleTransition): FillExtrusionLayer
-
-  /**
-   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * DSL for [fillExtrusionPatternTransition].
-   */
-  fun fillExtrusionPatternTransition(block: StyleTransition.Builder.() -> Unit): FillExtrusionLayer
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
@@ -882,6 +882,42 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
   }
 
   /**
+   * Transition options for FillExtrusionPattern.
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  val fillExtrusionPatternTransition: StyleTransition?
+    /**
+     * Get the FillExtrusionPattern property transition options
+     *
+     * Use static method [FillExtrusionLayer.defaultFillExtrusionPatternTransition] to get the default property.
+     *
+     * @return transition options for String
+     */
+    get() {
+      return null
+    }
+
+  /**
+   * Set the FillExtrusionPattern property transition options
+   *
+   * Use static method [FillExtrusionLayer.defaultFillExtrusionPatternTransition] to set the default property.
+   *
+   * @param options transition options for String
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun fillExtrusionPatternTransition(options: StyleTransition) = apply {
+    // no-op
+  }
+
+  /**
+   * DSL for [fillExtrusionPatternTransition].
+   */
+    @Deprecated("This property has been deprecated and will do no operations")
+    override fun fillExtrusionPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+      // no-op
+    }
+
+  /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.
    */
   val fillExtrusionTranslate: List<Double>?
@@ -1517,6 +1553,18 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
       }
 
     /**
+    * Transition options for FillExtrusionPattern.
+    */
+      @Deprecated("This property has been deprecated and will do no operations")
+    val defaultFillExtrusionPatternTransition: StyleTransition?
+      /**
+        * Get the FillExtrusionPattern property transition options
+        *
+        * @return transition options for String
+        */
+      get() = null
+
+    /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.
      */
     val defaultFillExtrusionTranslate: List<Double>?
@@ -1903,6 +1951,22 @@ interface FillExtrusionLayerDsl {
    * @param fillExtrusionPattern value of fillExtrusionPattern as Expression
    */
   fun fillExtrusionPattern(fillExtrusionPattern: Expression): FillExtrusionLayer
+
+  /**
+   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * Set the FillExtrusionPattern property transition options
+   *
+   * @param options transition options for String
+   */
+  fun fillExtrusionPatternTransition(options: StyleTransition): FillExtrusionLayer
+
+  /**
+   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * DSL for [fillExtrusionPatternTransition].
+   */
+  fun fillExtrusionPatternTransition(block: StyleTransition.Builder.() -> Unit): FillExtrusionLayer
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
@@ -14,6 +14,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils.colorIntToRgbaExpression
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorInt
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorString
 import com.mapbox.maps.extension.style.utils.silentUnwrap
+import com.mapbox.maps.logE
 import java.util.*
 
 /**
@@ -894,6 +895,7 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
      * @return transition options for String
      */
     get() {
+      logE("FillExtrusionLayer", "This property has been deprecated and will return null.")
       return null
     }
 
@@ -1562,7 +1564,10 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
        *
        * @return transition options for String
        */
-      get() = null
+      get() {
+        logE("FillExtrusionLayer", "This property has been deprecated and will return null.")
+        return null
+      }
 
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
@@ -912,10 +912,10 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
   /**
    * DSL for [fillExtrusionPatternTransition].
    */
-    @Deprecated("This property has been deprecated and will do no operations")
-    override fun fillExtrusionPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-      // no-op
-    }
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun fillExtrusionPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+    // no-op
+  }
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.
@@ -1553,15 +1553,15 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
       }
 
     /**
-    * Transition options for FillExtrusionPattern.
-    */
-      @Deprecated("This property has been deprecated and will do no operations")
+     * Transition options for FillExtrusionPattern.
+     */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultFillExtrusionPatternTransition: StyleTransition?
       /**
-        * Get the FillExtrusionPattern property transition options
-        *
-        * @return transition options for String
-        */
+       * Get the FillExtrusionPattern property transition options
+       *
+       * @return transition options for String
+       */
       get() = null
 
     /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
@@ -776,10 +776,10 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
   /**
    * DSL for [fillPatternTransition].
    */
-    @Deprecated("This property has been deprecated and will do no operations")
-    override fun fillPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-      // no-op
-    }
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun fillPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+    // no-op
+  }
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
@@ -1301,15 +1301,15 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
       }
 
     /**
-    * Transition options for FillPattern.
-    */
-      @Deprecated("This property has been deprecated and will do no operations")
+     * Transition options for FillPattern.
+     */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultFillPatternTransition: StyleTransition?
       /**
-        * Get the FillPattern property transition options
-        *
-        * @return transition options for String
-        */
+       * Get the FillPattern property transition options
+       *
+       * @return transition options for String
+       */
       get() = null
 
     /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
@@ -746,40 +746,6 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
   }
 
   /**
-   * Transition options for FillPattern.
-   */
-  val fillPatternTransition: StyleTransition?
-    /**
-     * Get the FillPattern property transition options
-     *
-     * Use static method [FillLayer.defaultFillPatternTransition] to get the default property.
-     *
-     * @return transition options for String
-     */
-    get() {
-      return getPropertyValue("fill-pattern-transition")
-    }
-
-  /**
-   * Set the FillPattern property transition options
-   *
-   * Use static method [FillLayer.defaultFillPatternTransition] to set the default property.
-   *
-   * @param options transition options for String
-   */
-  override fun fillPatternTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("fill-pattern-transition", options)
-    setProperty(propertyValue)
-  }
-
-  /**
-   * DSL for [fillPatternTransition].
-   */
-  override fun fillPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    fillPatternTransition(StyleTransition.Builder().apply(block).build())
-  }
-
-  /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
    */
   val fillTranslate: List<Double>?
@@ -1299,17 +1265,6 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
       }
 
     /**
-     * Transition options for FillPattern.
-     */
-    val defaultFillPatternTransition: StyleTransition?
-      /**
-       * Get the FillPattern property transition options
-       *
-       * @return transition options for String
-       */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-pattern-transition").silentUnwrap()
-
-    /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
      */
     val defaultFillTranslate: List<Double>?
@@ -1604,22 +1559,6 @@ interface FillLayerDsl {
    * @param fillPattern value of fillPattern as Expression
    */
   fun fillPattern(fillPattern: Expression): FillLayer
-
-  /**
-   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * Set the FillPattern property transition options
-   *
-   * @param options transition options for String
-   */
-  fun fillPatternTransition(options: StyleTransition): FillLayer
-
-  /**
-   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * DSL for [fillPatternTransition].
-   */
-  fun fillPatternTransition(block: StyleTransition.Builder.() -> Unit): FillLayer
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
@@ -14,6 +14,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils.colorIntToRgbaExpression
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorInt
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorString
 import com.mapbox.maps.extension.style.utils.silentUnwrap
+import com.mapbox.maps.logE
 import java.util.*
 
 /**
@@ -758,6 +759,7 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
      * @return transition options for String
      */
     get() {
+      logE("FillLayer", "This property has been deprecated and will return null.")
       return null
     }
 
@@ -1310,7 +1312,10 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
        *
        * @return transition options for String
        */
-      get() = null
+      get() {
+        logE("FillLayer", "This property has been deprecated and will return null.")
+        return null
+      }
 
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
@@ -746,6 +746,42 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
   }
 
   /**
+   * Transition options for FillPattern.
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  val fillPatternTransition: StyleTransition?
+    /**
+     * Get the FillPattern property transition options
+     *
+     * Use static method [FillLayer.defaultFillPatternTransition] to get the default property.
+     *
+     * @return transition options for String
+     */
+    get() {
+      return null
+    }
+
+  /**
+   * Set the FillPattern property transition options
+   *
+   * Use static method [FillLayer.defaultFillPatternTransition] to set the default property.
+   *
+   * @param options transition options for String
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun fillPatternTransition(options: StyleTransition) = apply {
+    // no-op
+  }
+
+  /**
+   * DSL for [fillPatternTransition].
+   */
+    @Deprecated("This property has been deprecated and will do no operations")
+    override fun fillPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+      // no-op
+    }
+
+  /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
    */
   val fillTranslate: List<Double>?
@@ -1265,6 +1301,18 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
       }
 
     /**
+    * Transition options for FillPattern.
+    */
+      @Deprecated("This property has been deprecated and will do no operations")
+    val defaultFillPatternTransition: StyleTransition?
+      /**
+        * Get the FillPattern property transition options
+        *
+        * @return transition options for String
+        */
+      get() = null
+
+    /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
      */
     val defaultFillTranslate: List<Double>?
@@ -1559,6 +1607,22 @@ interface FillLayerDsl {
    * @param fillPattern value of fillPattern as Expression
    */
   fun fillPattern(fillPattern: Expression): FillLayer
+
+  /**
+   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * Set the FillPattern property transition options
+   *
+   * @param options transition options for String
+   */
+  fun fillPatternTransition(options: StyleTransition): FillLayer
+
+  /**
+   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * DSL for [fillPatternTransition].
+   */
+  fun fillPatternTransition(block: StyleTransition.Builder.() -> Unit): FillLayer
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
@@ -14,6 +14,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils.colorIntToRgbaExpression
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorInt
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorString
 import com.mapbox.maps.extension.style.utils.silentUnwrap
+import com.mapbox.maps.logE
 import java.util.*
 
 /**
@@ -829,6 +830,7 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
      * @return transition options for List<Double>
      */
     get() {
+      logE("LineLayer", "This property has been deprecated and will return null.")
       return null
     }
 
@@ -1254,6 +1256,7 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
      * @return transition options for String
      */
     get() {
+      logE("LineLayer", "This property has been deprecated and will return null.")
       return null
     }
 
@@ -2020,7 +2023,10 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
        *
        * @return transition options for List<Double>
        */
-      get() = null
+      get() {
+        logE("LineLayer", "This property has been deprecated and will return null.")
+        return null
+      }
 
     /**
      * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
@@ -2213,7 +2219,10 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
        *
        * @return transition options for String
        */
-      get() = null
+      get() {
+        logE("LineLayer", "This property has been deprecated and will return null.")
+        return null
+      }
 
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
@@ -847,10 +847,10 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
   /**
    * DSL for [lineDasharrayTransition].
    */
-    @Deprecated("This property has been deprecated and will do no operations")
-    override fun lineDasharrayTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-      // no-op
-    }
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun lineDasharrayTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+    // no-op
+  }
 
   /**
    * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
@@ -1272,10 +1272,10 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
   /**
    * DSL for [linePatternTransition].
    */
-    @Deprecated("This property has been deprecated and will do no operations")
-    override fun linePatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-      // no-op
-    }
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun linePatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+    // no-op
+  }
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
@@ -2011,15 +2011,15 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
       }
 
     /**
-    * Transition options for LineDasharray.
-    */
-      @Deprecated("This property has been deprecated and will do no operations")
+     * Transition options for LineDasharray.
+     */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultLineDasharrayTransition: StyleTransition?
       /**
-        * Get the LineDasharray property transition options
-        *
-        * @return transition options for List<Double>
-        */
+       * Get the LineDasharray property transition options
+       *
+       * @return transition options for List<Double>
+       */
       get() = null
 
     /**
@@ -2204,15 +2204,15 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
       }
 
     /**
-    * Transition options for LinePattern.
-    */
-      @Deprecated("This property has been deprecated and will do no operations")
+     * Transition options for LinePattern.
+     */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultLinePatternTransition: StyleTransition?
       /**
-        * Get the LinePattern property transition options
-        *
-        * @return transition options for String
-        */
+       * Get the LinePattern property transition options
+       *
+       * @return transition options for String
+       */
       get() = null
 
     /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
@@ -817,40 +817,6 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
   }
 
   /**
-   * Transition options for LineDasharray.
-   */
-  val lineDasharrayTransition: StyleTransition?
-    /**
-     * Get the LineDasharray property transition options
-     *
-     * Use static method [LineLayer.defaultLineDasharrayTransition] to get the default property.
-     *
-     * @return transition options for List<Double>
-     */
-    get() {
-      return getPropertyValue("line-dasharray-transition")
-    }
-
-  /**
-   * Set the LineDasharray property transition options
-   *
-   * Use static method [LineLayer.defaultLineDasharrayTransition] to set the default property.
-   *
-   * @param options transition options for List<Double>
-   */
-  override fun lineDasharrayTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("line-dasharray-transition", options)
-    setProperty(propertyValue)
-  }
-
-  /**
-   * DSL for [lineDasharrayTransition].
-   */
-  override fun lineDasharrayTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    lineDasharrayTransition(StyleTransition.Builder().apply(block).build())
-  }
-
-  /**
    * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
    */
   val lineGapWidth: Double?
@@ -1237,40 +1203,6 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
   override fun linePattern(linePattern: Expression) = apply {
     val propertyValue = PropertyValue("line-pattern", linePattern)
     setProperty(propertyValue)
-  }
-
-  /**
-   * Transition options for LinePattern.
-   */
-  val linePatternTransition: StyleTransition?
-    /**
-     * Get the LinePattern property transition options
-     *
-     * Use static method [LineLayer.defaultLinePatternTransition] to get the default property.
-     *
-     * @return transition options for String
-     */
-    get() {
-      return getPropertyValue("line-pattern-transition")
-    }
-
-  /**
-   * Set the LinePattern property transition options
-   *
-   * Use static method [LineLayer.defaultLinePatternTransition] to set the default property.
-   *
-   * @param options transition options for String
-   */
-  override fun linePatternTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("line-pattern-transition", options)
-    setProperty(propertyValue)
-  }
-
-  /**
-   * DSL for [linePatternTransition].
-   */
-  override fun linePatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    linePatternTransition(StyleTransition.Builder().apply(block).build())
   }
 
   /**
@@ -2007,17 +1939,6 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
       }
 
     /**
-     * Transition options for LineDasharray.
-     */
-    val defaultLineDasharrayTransition: StyleTransition?
-      /**
-       * Get the LineDasharray property transition options
-       *
-       * @return transition options for List<Double>
-       */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("line", "line-dasharray-transition").silentUnwrap()
-
-    /**
      * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
      */
     val defaultLineGapWidth: Double?
@@ -2197,17 +2118,6 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
         }
         return null
       }
-
-    /**
-     * Transition options for LinePattern.
-     */
-    val defaultLinePatternTransition: StyleTransition?
-      /**
-       * Get the LinePattern property transition options
-       *
-       * @return transition options for String
-       */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("line", "line-pattern-transition").silentUnwrap()
 
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
@@ -2596,22 +2506,6 @@ interface LineLayerDsl {
   fun lineDasharray(lineDasharray: Expression): LineLayer
 
   /**
-   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * Set the LineDasharray property transition options
-   *
-   * @param options transition options for List<Double>
-   */
-  fun lineDasharrayTransition(options: StyleTransition): LineLayer
-
-  /**
-   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * DSL for [lineDasharrayTransition].
-   */
-  fun lineDasharrayTransition(block: StyleTransition.Builder.() -> Unit): LineLayer
-
-  /**
    * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
    *
    * @param lineGapWidth value of lineGapWidth
@@ -2721,22 +2615,6 @@ interface LineLayerDsl {
    * @param linePattern value of linePattern as Expression
    */
   fun linePattern(linePattern: Expression): LineLayer
-
-  /**
-   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * Set the LinePattern property transition options
-   *
-   * @param options transition options for String
-   */
-  fun linePatternTransition(options: StyleTransition): LineLayer
-
-  /**
-   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-   *
-   * DSL for [linePatternTransition].
-   */
-  fun linePatternTransition(block: StyleTransition.Builder.() -> Unit): LineLayer
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
@@ -817,6 +817,42 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
   }
 
   /**
+   * Transition options for LineDasharray.
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  val lineDasharrayTransition: StyleTransition?
+    /**
+     * Get the LineDasharray property transition options
+     *
+     * Use static method [LineLayer.defaultLineDasharrayTransition] to get the default property.
+     *
+     * @return transition options for List<Double>
+     */
+    get() {
+      return null
+    }
+
+  /**
+   * Set the LineDasharray property transition options
+   *
+   * Use static method [LineLayer.defaultLineDasharrayTransition] to set the default property.
+   *
+   * @param options transition options for List<Double>
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun lineDasharrayTransition(options: StyleTransition) = apply {
+    // no-op
+  }
+
+  /**
+   * DSL for [lineDasharrayTransition].
+   */
+    @Deprecated("This property has been deprecated and will do no operations")
+    override fun lineDasharrayTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+      // no-op
+    }
+
+  /**
    * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
    */
   val lineGapWidth: Double?
@@ -1204,6 +1240,42 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
     val propertyValue = PropertyValue("line-pattern", linePattern)
     setProperty(propertyValue)
   }
+
+  /**
+   * Transition options for LinePattern.
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  val linePatternTransition: StyleTransition?
+    /**
+     * Get the LinePattern property transition options
+     *
+     * Use static method [LineLayer.defaultLinePatternTransition] to get the default property.
+     *
+     * @return transition options for String
+     */
+    get() {
+      return null
+    }
+
+  /**
+   * Set the LinePattern property transition options
+   *
+   * Use static method [LineLayer.defaultLinePatternTransition] to set the default property.
+   *
+   * @param options transition options for String
+   */
+  @Deprecated("This property has been deprecated and will do no operations")
+  override fun linePatternTransition(options: StyleTransition) = apply {
+    // no-op
+  }
+
+  /**
+   * DSL for [linePatternTransition].
+   */
+    @Deprecated("This property has been deprecated and will do no operations")
+    override fun linePatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
+      // no-op
+    }
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
@@ -1939,6 +2011,18 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
       }
 
     /**
+    * Transition options for LineDasharray.
+    */
+      @Deprecated("This property has been deprecated and will do no operations")
+    val defaultLineDasharrayTransition: StyleTransition?
+      /**
+        * Get the LineDasharray property transition options
+        *
+        * @return transition options for List<Double>
+        */
+      get() = null
+
+    /**
      * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
      */
     val defaultLineGapWidth: Double?
@@ -2118,6 +2202,18 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
         }
         return null
       }
+
+    /**
+    * Transition options for LinePattern.
+    */
+      @Deprecated("This property has been deprecated and will do no operations")
+    val defaultLinePatternTransition: StyleTransition?
+      /**
+        * Get the LinePattern property transition options
+        *
+        * @return transition options for String
+        */
+      get() = null
 
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
@@ -2506,6 +2602,22 @@ interface LineLayerDsl {
   fun lineDasharray(lineDasharray: Expression): LineLayer
 
   /**
+   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * Set the LineDasharray property transition options
+   *
+   * @param options transition options for List<Double>
+   */
+  fun lineDasharrayTransition(options: StyleTransition): LineLayer
+
+  /**
+   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * DSL for [lineDasharrayTransition].
+   */
+  fun lineDasharrayTransition(block: StyleTransition.Builder.() -> Unit): LineLayer
+
+  /**
    * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
    *
    * @param lineGapWidth value of lineGapWidth
@@ -2615,6 +2727,22 @@ interface LineLayerDsl {
    * @param linePattern value of linePattern as Expression
    */
   fun linePattern(linePattern: Expression): LineLayer
+
+  /**
+   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * Set the LinePattern property transition options
+   *
+   * @param options transition options for String
+   */
+  fun linePatternTransition(options: StyleTransition): LineLayer
+
+  /**
+   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
+   *
+   * DSL for [linePatternTransition].
+   */
+  fun linePatternTransition(block: StyleTransition.Builder.() -> Unit): LineLayer
 
   /**
    * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayerTest.kt
@@ -379,46 +379,6 @@ class BackgroundLayerTest {
   }
 
   @Test
-  fun backgroundPatternTransitionSet() {
-    val layer = backgroundLayer("id") {}
-    layer.bindTo(style)
-    layer.backgroundPatternTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "background-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun backgroundPatternTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = backgroundLayer("id") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.backgroundPatternTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "background-pattern-transition") }
-  }
-
-  @Test
-  fun backgroundPatternTransitionSetDsl() {
-    val layer = backgroundLayer("id") {}
-    layer.bindTo(style)
-    layer.backgroundPatternTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "background-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
   fun visibilitySet() {
     val layer = backgroundLayer("id") {}
     layer.bindTo(style)
@@ -610,19 +570,6 @@ class BackgroundLayerTest {
     assertEquals("abc", BackgroundLayer.defaultBackgroundPatternAsExpression.toString())
     assertEquals("abc", BackgroundLayer.defaultBackgroundPattern)
     verify { StyleManager.getStyleLayerPropertyDefaultValue("background", "background-pattern") }
-  }
-
-  @Test
-  fun defaultBackgroundPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), BackgroundLayer.defaultBackgroundPatternTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("background", "background-pattern-transition") }
   }
 
   @Test

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayerTest.kt
@@ -908,46 +908,6 @@ class FillExtrusionLayerTest {
   }
 
   @Test
-  fun fillExtrusionPatternTransitionSet() {
-    val layer = fillExtrusionLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.fillExtrusionPatternTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "fill-extrusion-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun fillExtrusionPatternTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = fillExtrusionLayer("id", "source") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.fillExtrusionPatternTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "fill-extrusion-pattern-transition") }
-  }
-
-  @Test
-  fun fillExtrusionPatternTransitionSetDsl() {
-    val layer = fillExtrusionLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.fillExtrusionPatternTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "fill-extrusion-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
   fun fillExtrusionTranslateSet() {
     val layer = fillExtrusionLayer("id", "source") {}
     val testValue = listOf(0.0, 1.0)
@@ -1563,19 +1523,6 @@ class FillExtrusionLayerTest {
     assertEquals("abc", FillExtrusionLayer.defaultFillExtrusionPatternAsExpression.toString())
     assertEquals("abc", FillExtrusionLayer.defaultFillExtrusionPattern)
     verify { StyleManager.getStyleLayerPropertyDefaultValue("fill-extrusion", "fill-extrusion-pattern") }
-  }
-
-  @Test
-  fun defaultFillExtrusionPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), FillExtrusionLayer.defaultFillExtrusionPatternTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("fill-extrusion", "fill-extrusion-pattern-transition") }
   }
 
   @Test

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillLayerTest.kt
@@ -764,46 +764,6 @@ class FillLayerTest {
   }
 
   @Test
-  fun fillPatternTransitionSet() {
-    val layer = fillLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.fillPatternTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "fill-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun fillPatternTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = fillLayer("id", "source") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.fillPatternTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "fill-pattern-transition") }
-  }
-
-  @Test
-  fun fillPatternTransitionSetDsl() {
-    val layer = fillLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.fillPatternTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "fill-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
   fun fillTranslateSet() {
     val layer = fillLayer("id", "source") {}
     val testValue = listOf(0.0, 1.0)
@@ -1313,19 +1273,6 @@ class FillLayerTest {
     assertEquals("abc", FillLayer.defaultFillPatternAsExpression.toString())
     assertEquals("abc", FillLayer.defaultFillPattern)
     verify { StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-pattern") }
-  }
-
-  @Test
-  fun defaultFillPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), FillLayer.defaultFillPatternTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-pattern-transition") }
   }
 
   @Test

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LineLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LineLayerTest.kt
@@ -818,46 +818,6 @@ class LineLayerTest {
   }
 
   @Test
-  fun lineDasharrayTransitionSet() {
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.lineDasharrayTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "line-dasharray-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun lineDasharrayTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.lineDasharrayTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "line-dasharray-transition") }
-  }
-
-  @Test
-  fun lineDasharrayTransitionSetDsl() {
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.lineDasharrayTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "line-dasharray-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
   fun lineGapWidthSet() {
     val layer = lineLayer("id", "source") {}
     val testValue = 1.0
@@ -1328,46 +1288,6 @@ class LineLayerTest {
     assertEquals("abc", layer.linePatternAsExpression.toString())
     assertEquals("abc", layer.linePattern)
     verify { style.getStyleLayerProperty("id", "line-pattern") }
-  }
-
-  @Test
-  fun linePatternTransitionSet() {
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.linePatternTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "line-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun linePatternTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.linePatternTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "line-pattern-transition") }
-  }
-
-  @Test
-  fun linePatternTransitionSetDsl() {
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.linePatternTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "line-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
   }
 
   @Test
@@ -2077,19 +1997,6 @@ class LineLayerTest {
   }
 
   @Test
-  fun defaultLineDasharrayTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), LineLayer.defaultLineDasharrayTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("line", "line-dasharray-transition") }
-  }
-
-  @Test
   fun defaultLineGapWidthTest() {
     val testValue = 1.0
     every { styleProperty.value } returns TypeUtils.wrapToValue(testValue)
@@ -2252,19 +2159,6 @@ class LineLayerTest {
     assertEquals("abc", LineLayer.defaultLinePatternAsExpression.toString())
     assertEquals("abc", LineLayer.defaultLinePattern)
     verify { StyleManager.getStyleLayerPropertyDefaultValue("line", "line-pattern") }
-  }
-
-  @Test
-  fun defaultLinePatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), LineLayer.defaultLinePatternTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("line", "line-pattern-transition") }
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

SInce native has removed transition properties. syncing codegen for that.

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
