### PR TITLE
[port] wrap longitude to world bound for flyTo animation. (#1949)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
+## Bug fixes 🐞
+* Fix a bug where `flyTo` animation request invalid tiles from map engine. ([1949](https://github.com/mapbox/mapbox-maps-android/pull/1949))
 
 # 10.11.0-beta.1 January 11, 2023
 ## Features ✨ and improvements 🏁

--- a/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
+++ b/plugin-animation/src/main/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactory.kt
@@ -12,6 +12,7 @@ import com.mapbox.maps.plugin.animation.CameraTransform.deg2rad
 import com.mapbox.maps.plugin.animation.CameraTransform.offset
 import com.mapbox.maps.plugin.animation.CameraTransform.rad2deg
 import com.mapbox.maps.plugin.animation.CameraTransform.scaleZoom
+import com.mapbox.maps.plugin.animation.CameraTransform.wrapCoordinate
 import com.mapbox.maps.plugin.animation.CameraTransform.zoomScale
 import com.mapbox.maps.plugin.animation.animator.*
 import com.mapbox.maps.plugin.delegates.MapCameraManagerDelegate
@@ -255,7 +256,7 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
     val currentCameraState = mapCameraManagerDelegate.cameraState
 
     val endPadding = cameraOptions.padding ?: currentCameraState.padding
-    val endPointRaw = cameraOptions.center ?: currentCameraState.center
+    val endPointRaw = (cameraOptions.center ?: currentCameraState.center).wrapCoordinate()
     var endZoom = cameraOptions.zoom ?: currentCameraState.zoom
     val endBearing = cameraOptions.bearing ?: currentCameraState.bearing
     val endPitch = cameraOptions.pitch ?: currentCameraState.pitch
@@ -269,7 +270,7 @@ class CameraAnimatorsFactory internal constructor(mapDelegateProvider: MapDelega
     )
 
     // Determine endpoints
-    var startPointRaw = currentCameraState.center
+    var startPointRaw = currentCameraState.center.wrapCoordinate()
     startPointRaw = CameraTransform.unwrapForShortestPath(startPointRaw, endPointRaw)
 
     val startPoint = mapProjectionDelegate.project(startPointRaw, startScale)

--- a/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactoryTest.kt
+++ b/plugin-animation/src/test/java/com/mapbox/maps/plugin/animation/CameraAnimatorsFactoryTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowLog
@@ -217,5 +218,38 @@ class CameraAnimatorsFactoryTest {
         }
       }
     }
+  }
+}
+
+@RunWith(Parameterized::class)
+class WrapCoordinateTest(
+  private val actual: Triple<Double, Double, Double>,
+  private val expected: Double
+) {
+
+  private companion object {
+    @JvmStatic
+    @Parameterized.Parameters
+    fun data() = listOf(
+      arrayOf(Triple(-0.911, -LONGITUDE_MAX, LONGITUDE_MAX), -0.911),
+      arrayOf(Triple(LONGITUDE_MAX, -LONGITUDE_MAX, LONGITUDE_MAX), -LONGITUDE_MAX),
+      arrayOf(Triple(-LONGITUDE_MAX, -LONGITUDE_MAX, LONGITUDE_MAX), -LONGITUDE_MAX),
+      arrayOf(Triple(275.0, -LONGITUDE_MAX, LONGITUDE_MAX), -85.0),
+      arrayOf(Triple(-458.0, -LONGITUDE_MAX, LONGITUDE_MAX), -98.0),
+      arrayOf(Triple(385.0, -LONGITUDE_MAX, LONGITUDE_MAX), 25.0),
+      arrayOf(Triple(0.0, LONGITUDE_MAX, LONGITUDE_MAX), Double.NaN),
+    )
+
+    private const val DELTA = 0.0001
+    private const val LONGITUDE_MAX = 180.0
+  }
+
+  @Test
+  fun testLongitudeWrap() {
+    Assert.assertEquals(
+      expected,
+      CameraTransform.wrap(actual.first, actual.second, actual.third),
+      DELTA
+    )
   }
 }


### PR DESCRIPTION
* wrap longitude to world bounds for flyTo

* update changelog

* update tests and address review comments

<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
