### PR TITLE
Make GeoJsonSource constructor private so that GeoJsonSource.Builder should be used

### DIFF
--- a/extension-style/api/extension-style.api
+++ b/extension-style/api/extension-style.api
@@ -3666,8 +3666,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/Encoding : 
 
 public final class com/mapbox/maps/extension/style/sources/generated/GeoJsonSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;)V
-	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;Lcom/mapbox/geojson/GeoJson;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun bindTo (Lcom/mapbox/maps/extension/style/StyleInterface;)V
 	public final fun data (Ljava/lang/String;)Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource;
 	public final fun feature (Lcom/mapbox/geojson/Feature;)Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource;

--- a/extension-style/api/metalava.txt
+++ b/extension-style/api/metalava.txt
@@ -4369,7 +4369,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class GeoJsonSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public GeoJsonSource(com.mapbox.maps.extension.style.sources.generated.GeoJsonSource.Builder builder);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource data(String value);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource feature(com.mapbox.geojson.Feature value);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource featureCollection(com.mapbox.geojson.FeatureCollection value);

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -736,8 +736,7 @@ class GeoJsonSource : Source {
        *
        * @return Long
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterRadius")
-        .silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterRadius").silentUnwrap()
 
     /**
      * Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less
@@ -750,8 +749,7 @@ class GeoJsonSource : Source {
        *
        * @return Long
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterMaxZoom")
-        .silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterMaxZoom").silentUnwrap()
 
     /**
      * Whether to calculate line distance metrics. This is required for line layers that specify `line-gradient` values.
@@ -762,8 +760,7 @@ class GeoJsonSource : Source {
        *
        * @return Boolean
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "lineMetrics")
-        .silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "lineMetrics").silentUnwrap()
 
     /**
      * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
@@ -775,8 +772,7 @@ class GeoJsonSource : Source {
        *
        * @return Boolean
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId")
-        .silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId").silentUnwrap()
 
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
@@ -791,8 +787,7 @@ class GeoJsonSource : Source {
        *
        * @return Long
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "prefetch-zoom-delta")
-        .silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "prefetch-zoom-delta").silentUnwrap()
   }
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -41,11 +41,11 @@ class GeoJsonSource : Source {
   private var initGeoJson: GeoJson? = null
   private var initData: String? = null
 
-  private constructor(builder: Builder): super(builder.sourceId) {
-      initGeoJson = builder.geoJson
-      initData = builder.data
-      sourceProperties.putAll(builder.properties)
-      volatileSourceProperties.putAll(builder.volatileProperties)
+  private constructor(builder: Builder) : super(builder.sourceId) {
+    initGeoJson = builder.geoJson
+    initData = builder.data
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   private fun setGeoJson(geoJson: GeoJson) {

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -4,7 +4,6 @@ package com.mapbox.maps.extension.style.sources.generated
 
 import android.os.Handler
 import android.os.HandlerThread
-import android.os.Looper
 import android.os.Process.THREAD_PRIORITY_DEFAULT
 import androidx.annotation.VisibleForTesting
 import com.mapbox.bindgen.Value
@@ -34,7 +33,7 @@ import com.mapbox.maps.logW
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#geojson)
  *
  */
-class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
+class GeoJsonSource : Source {
   private val workerHandler by lazy {
     Handler(workerThread.looper)
   }
@@ -42,13 +41,11 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
   private var initGeoJson: GeoJson? = null
   private var initData: String? = null
 
-  private constructor(
-    builder: Builder,
-    geoJson: GeoJson?,
-    data: String?,
-  ) : this(builder) {
-    this.initGeoJson = geoJson
-    this.initData = data
+  private constructor(builder: Builder): super(builder.sourceId) {
+      initGeoJson = builder.geoJson
+      initData = builder.data
+      sourceProperties.putAll(builder.properties)
+      volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   private fun setGeoJson(geoJson: GeoJson) {
@@ -84,11 +81,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       setData(it)
       initData = null
     }
-  }
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   /**
@@ -407,12 +399,18 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
   class Builder(
     val sourceId: String
   ) {
-
-    private var geoJson: GeoJson? = null
-    private var data: String? = null
+    internal var geoJson: GeoJson? = null
+    internal var data: String? = null
     internal val properties = HashMap<String, PropertyValue<*>>()
+
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
+
+    init {
+      // set default data to allow empty data source.
+      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
+      properties[propertyValue.propertyName] = propertyValue
+    }
 
     /**
      * A URL to a GeoJSON file, or inline GeoJSON.
@@ -650,10 +648,7 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return the GeoJsonSource
      */
     fun build(): GeoJsonSource {
-      // set default data to allow empty data source.
-      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
-      properties[propertyValue.propertyName] = propertyValue
-      return GeoJsonSource(this, geoJson, data)
+      return GeoJsonSource(this)
     }
   }
 
@@ -668,8 +663,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     internal val workerThread = HandlerThread("GEOJSON_PARSER", THREAD_PRIORITY_DEFAULT).apply {
       start()
     }
-
-    private val mainHandler = Handler(Looper.getMainLooper())
 
     internal fun toGeoJsonData(geoJson: GeoJson): GeoJSONSourceData {
       return when (geoJson) {
@@ -743,7 +736,8 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        *
        * @return Long
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterRadius").silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterRadius")
+        .silentUnwrap()
 
     /**
      * Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less
@@ -756,7 +750,8 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        *
        * @return Long
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterMaxZoom").silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "clusterMaxZoom")
+        .silentUnwrap()
 
     /**
      * Whether to calculate line distance metrics. This is required for line layers that specify `line-gradient` values.
@@ -767,7 +762,8 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        *
        * @return Boolean
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "lineMetrics").silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "lineMetrics")
+        .silentUnwrap()
 
     /**
      * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
@@ -779,7 +775,8 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        *
        * @return Boolean
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId").silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "generateId")
+        .silentUnwrap()
 
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
@@ -794,7 +791,8 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
        *
        * @return Long
        */
-      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "prefetch-zoom-delta").silentUnwrap()
+      get() = StyleManager.getStyleSourcePropertyDefaultValue("geojson", "prefetch-zoom-delta")
+        .silentUnwrap()
   }
 }
 


### PR DESCRIPTION
### Summary of changes

Make GeoJsonSource's constructor private, user should only use `Builder.build()` to construct.

### User impact (optional)

Callers of GeoJsonSource's(Builder) should instead use GeoJsonSource.Builder().build().

## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
