### PR TITLE
MAPSAND-683 Make Source constructors private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
+* Source constructors made private, use Builder instead. ([1967](https://github.com/mapbox/mapbox-maps-android/pull/1967))
 
 # 10.11.0-beta.1 January 11, 2023
 ## Features ✨ and improvements 🏁

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/BackgroundLayerTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/BackgroundLayerTest.kt
@@ -173,37 +173,6 @@ class BackgroundLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun backgroundPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = backgroundLayer("id") {
-      backgroundPatternTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.backgroundPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun backgroundPatternTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = backgroundLayer("id") {
-      backgroundPatternTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.backgroundPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun visibilityTest() {
     val layer = backgroundLayer("id") {
       visibility(Visibility.NONE)
@@ -229,7 +198,6 @@ class BackgroundLayerTest : BaseStyleTest() {
     assertNotNull("defaultBackgroundOpacityTransition should not be null", BackgroundLayer.defaultBackgroundOpacityTransition)
     assertNotNull("defaultBackgroundPattern should not be null", BackgroundLayer.defaultBackgroundPattern)
     assertNotNull("defaultBackgroundPatternAsExpression should not be null", BackgroundLayer.defaultBackgroundPatternAsExpression)
-    assertNotNull("defaultBackgroundPatternTransition should not be null", BackgroundLayer.defaultBackgroundPatternTransition)
   }
 
   @Test

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/FillExtrusionLayerTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/FillExtrusionLayerTest.kt
@@ -452,37 +452,6 @@ class FillExtrusionLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun fillExtrusionPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = fillExtrusionLayer("id", "source") {
-      fillExtrusionPatternTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.fillExtrusionPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun fillExtrusionPatternTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = fillExtrusionLayer("id", "source") {
-      fillExtrusionPatternTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.fillExtrusionPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun fillExtrusionTranslateTest() {
     val testValue = listOf(0.0, 1.0)
     val layer = fillExtrusionLayer("id", "source") {
@@ -622,7 +591,6 @@ class FillExtrusionLayerTest : BaseStyleTest() {
     assertNotNull("defaultFillExtrusionOpacityTransition should not be null", FillExtrusionLayer.defaultFillExtrusionOpacityTransition)
     assertNotNull("defaultFillExtrusionPattern should not be null", FillExtrusionLayer.defaultFillExtrusionPattern)
     assertNotNull("defaultFillExtrusionPatternAsExpression should not be null", FillExtrusionLayer.defaultFillExtrusionPatternAsExpression)
-    assertNotNull("defaultFillExtrusionPatternTransition should not be null", FillExtrusionLayer.defaultFillExtrusionPatternTransition)
     assertNotNull("defaultFillExtrusionTranslate should not be null", FillExtrusionLayer.defaultFillExtrusionTranslate)
     assertNotNull("defaultFillExtrusionTranslateAsExpression should not be null", FillExtrusionLayer.defaultFillExtrusionTranslateAsExpression)
     assertNotNull("defaultFillExtrusionTranslateTransition should not be null", FillExtrusionLayer.defaultFillExtrusionTranslateTransition)

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/FillLayerTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/FillLayerTest.kt
@@ -349,37 +349,6 @@ class FillLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun fillPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = fillLayer("id", "source") {
-      fillPatternTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.fillPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun fillPatternTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = fillLayer("id", "source") {
-      fillPatternTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.fillPatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun fillTranslateTest() {
     val testValue = listOf(0.0, 1.0)
     val layer = fillLayer("id", "source") {
@@ -491,7 +460,6 @@ class FillLayerTest : BaseStyleTest() {
     assertNotNull("defaultFillOutlineColorTransition should not be null", FillLayer.defaultFillOutlineColorTransition)
     assertNotNull("defaultFillPattern should not be null", FillLayer.defaultFillPattern)
     assertNotNull("defaultFillPatternAsExpression should not be null", FillLayer.defaultFillPatternAsExpression)
-    assertNotNull("defaultFillPatternTransition should not be null", FillLayer.defaultFillPatternTransition)
     assertNotNull("defaultFillTranslate should not be null", FillLayer.defaultFillTranslate)
     assertNotNull("defaultFillTranslateAsExpression should not be null", FillLayer.defaultFillTranslateAsExpression)
     assertNotNull("defaultFillTranslateTransition should not be null", FillLayer.defaultFillTranslateTransition)

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/LineLayerTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/layers/generated/LineLayerTest.kt
@@ -348,37 +348,6 @@ class LineLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun lineDasharrayTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = lineLayer("id", "source") {
-      lineDasharrayTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.lineDasharrayTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun lineDasharrayTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = lineLayer("id", "source") {
-      lineDasharrayTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.lineDasharrayTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun lineGapWidthTest() {
     val testValue = 1.0
     val layer = lineLayer("id", "source") {
@@ -618,37 +587,6 @@ class LineLayerTest : BaseStyleTest() {
 
   @Test
   @UiThreadTest
-  fun linePatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = lineLayer("id", "source") {
-      linePatternTransition(transition)
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.linePatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
-  fun linePatternTransitionSetDslTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    val layer = lineLayer("id", "source") {
-      linePatternTransition {
-        duration(100)
-        delay(200)
-      }
-    }
-    setupLayer(layer)
-    assertEquals(transition, layer.linePatternTransition)
-  }
-
-  @Test
-  @UiThreadTest
   fun lineTranslateTest() {
     val testValue = listOf(0.0, 1.0)
     val layer = lineLayer("id", "source") {
@@ -845,7 +783,6 @@ class LineLayerTest : BaseStyleTest() {
     assertNotNull("defaultLineColorTransition should not be null", LineLayer.defaultLineColorTransition)
     assertNotNull("defaultLineDasharray should not be null", LineLayer.defaultLineDasharray)
     assertNotNull("defaultLineDasharrayAsExpression should not be null", LineLayer.defaultLineDasharrayAsExpression)
-    assertNotNull("defaultLineDasharrayTransition should not be null", LineLayer.defaultLineDasharrayTransition)
     assertNotNull("defaultLineGapWidth should not be null", LineLayer.defaultLineGapWidth)
     assertNotNull("defaultLineGapWidthAsExpression should not be null", LineLayer.defaultLineGapWidthAsExpression)
     assertNotNull("defaultLineGapWidthTransition should not be null", LineLayer.defaultLineGapWidthTransition)
@@ -857,7 +794,6 @@ class LineLayerTest : BaseStyleTest() {
     assertNotNull("defaultLineOpacityTransition should not be null", LineLayer.defaultLineOpacityTransition)
     assertNotNull("defaultLinePattern should not be null", LineLayer.defaultLinePattern)
     assertNotNull("defaultLinePatternAsExpression should not be null", LineLayer.defaultLinePatternAsExpression)
-    assertNotNull("defaultLinePatternTransition should not be null", LineLayer.defaultLinePatternTransition)
     assertNotNull("defaultLineTranslate should not be null", LineLayer.defaultLineTranslate)
     assertNotNull("defaultLineTranslateAsExpression should not be null", LineLayer.defaultLineTranslateAsExpression)
     assertNotNull("defaultLineTranslateTransition should not be null", LineLayer.defaultLineTranslateTransition)

--- a/extension-style/api/extension-style.api
+++ b/extension-style/api/extension-style.api
@@ -3666,8 +3666,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/Encoding : 
 
 public final class com/mapbox/maps/extension/style/sources/generated/GeoJsonSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;)V
-	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;Lcom/mapbox/geojson/GeoJson;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun bindTo (Lcom/mapbox/maps/extension/style/StyleInterface;)V
 	public final fun data (Ljava/lang/String;)Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource;
 	public final fun feature (Lcom/mapbox/geojson/Feature;)Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource;
@@ -3743,7 +3742,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/GeoJsonSour
 
 public final class com/mapbox/maps/extension/style/sources/generated/ImageSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/ImageSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/ImageSource$Builder;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/ImageSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun coordinates (Ljava/util/List;)Lcom/mapbox/maps/extension/style/sources/generated/ImageSource;
 	public final fun getCoordinates ()Ljava/util/List;
 	public final fun getPrefetchZoomDelta ()Ljava/lang/Long;
@@ -3773,7 +3772,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/ImageSource
 
 public final class com/mapbox/maps/extension/style/sources/generated/RasterDemSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/RasterDemSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterDemSource$Builder;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterDemSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAttribution ()Ljava/lang/String;
 	public final fun getBounds ()Ljava/util/List;
 	public final fun getEncoding ()Lcom/mapbox/maps/extension/style/sources/generated/Encoding;
@@ -3856,7 +3855,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/RasterDemSo
 
 public final class com/mapbox/maps/extension/style/sources/generated/RasterSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/RasterSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterSource$Builder;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAttribution ()Ljava/lang/String;
 	public final fun getBounds ()Ljava/util/List;
 	public final fun getMaxOverscaleFactorForParentTiles ()Ljava/lang/Long;
@@ -3947,7 +3946,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/Scheme : ja
 
 public final class com/mapbox/maps/extension/style/sources/generated/VectorSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/VectorSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/VectorSource$Builder;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/VectorSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAttribution ()Ljava/lang/String;
 	public final fun getBounds ()Ljava/util/List;
 	public final fun getMaxOverscaleFactorForParentTiles ()Ljava/lang/Long;

--- a/extension-style/api/metalava.txt
+++ b/extension-style/api/metalava.txt
@@ -1005,8 +1005,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundOpacityTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPattern(String backgroundPattern);
     method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPattern(com.mapbox.maps.extension.style.expressions.generated.Expression backgroundPattern);
-    method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.BackgroundLayer backgroundPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public String? getBackgroundColor();
     method @ColorInt public Integer? getBackgroundColorAsColorInt();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getBackgroundColorAsExpression();
@@ -1016,7 +1016,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getBackgroundOpacityTransition();
     method public String? getBackgroundPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getBackgroundPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getBackgroundPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getBackgroundPatternTransition();
     method public String getLayerId();
     method public Double? getMaxZoom();
     method public Double? getMinZoom();
@@ -1034,7 +1034,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? backgroundOpacityTransition;
     property public final String? backgroundPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? backgroundPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? backgroundPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? backgroundPatternTransition;
     property public String layerId;
     property public Double? maxZoom;
     property public Double? minZoom;
@@ -1052,7 +1052,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultBackgroundOpacityTransition();
     method public String? getDefaultBackgroundPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultBackgroundPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultBackgroundPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultBackgroundPatternTransition();
     method public Double? getDefaultMaxZoom();
     method public Double? getDefaultMinZoom();
     method public com.mapbox.maps.extension.style.layers.properties.generated.Visibility? getDefaultVisibility();
@@ -1065,7 +1065,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultBackgroundOpacityTransition;
     property public final String? defaultBackgroundPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultBackgroundPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultBackgroundPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultBackgroundPatternTransition;
     property public final Double? defaultMaxZoom;
     property public final Double? defaultMinZoom;
     property public final com.mapbox.maps.extension.style.layers.properties.generated.Visibility? defaultVisibility;
@@ -1389,8 +1389,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionOpacityTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPattern(String fillExtrusionPattern);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPattern(com.mapbox.maps.extension.style.expressions.generated.Expression fillExtrusionPattern);
-    method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionTranslate(java.util.List<java.lang.Double> fillExtrusionTranslate);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionTranslate(com.mapbox.maps.extension.style.expressions.generated.Expression fillExtrusionTranslate);
     method public com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer fillExtrusionTranslateAnchor(com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor fillExtrusionTranslateAnchor);
@@ -1421,7 +1421,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getFillExtrusionOpacityTransition();
     method public String? getFillExtrusionPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getFillExtrusionPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getFillExtrusionPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getFillExtrusionPatternTransition();
     method public java.util.List<java.lang.Double>? getFillExtrusionTranslate();
     method public com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor? getFillExtrusionTranslateAnchor();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getFillExtrusionTranslateAnchorAsExpression();
@@ -1462,7 +1462,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? fillExtrusionOpacityTransition;
     property public final String? fillExtrusionPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? fillExtrusionPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? fillExtrusionPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? fillExtrusionPatternTransition;
     property public final java.util.List<java.lang.Double>? fillExtrusionTranslate;
     property public final com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor? fillExtrusionTranslateAnchor;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? fillExtrusionTranslateAnchorAsExpression;
@@ -1502,7 +1502,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillExtrusionOpacityTransition();
     method public String? getDefaultFillExtrusionPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultFillExtrusionPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillExtrusionPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillExtrusionPatternTransition();
     method public java.util.List<java.lang.Double>? getDefaultFillExtrusionTranslate();
     method public com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor? getDefaultFillExtrusionTranslateAnchor();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultFillExtrusionTranslateAnchorAsExpression();
@@ -1534,7 +1534,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillExtrusionOpacityTransition;
     property public final String? defaultFillExtrusionPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultFillExtrusionPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillExtrusionPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillExtrusionPatternTransition;
     property public final java.util.List<java.lang.Double>? defaultFillExtrusionTranslate;
     property public final com.mapbox.maps.extension.style.layers.properties.generated.FillExtrusionTranslateAnchor? defaultFillExtrusionTranslateAnchor;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultFillExtrusionTranslateAnchorAsExpression;
@@ -1616,8 +1616,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillOutlineColorTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPattern(String fillPattern);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPattern(com.mapbox.maps.extension.style.expressions.generated.Expression fillPattern);
-    method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.FillLayer fillPatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillSortKey(double fillSortKey);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillSortKey(com.mapbox.maps.extension.style.expressions.generated.Expression fillSortKey);
     method public com.mapbox.maps.extension.style.layers.generated.FillLayer fillTranslate(java.util.List<java.lang.Double> fillTranslate);
@@ -1642,7 +1642,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getFillOutlineColorTransition();
     method public String? getFillPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getFillPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getFillPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getFillPatternTransition();
     method public Double? getFillSortKey();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getFillSortKeyAsExpression();
     method public java.util.List<java.lang.Double>? getFillTranslate();
@@ -1677,7 +1677,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? fillOutlineColorTransition;
     property public final String? fillPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? fillPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? fillPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? fillPatternTransition;
     property public final Double? fillSortKey;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? fillSortKeyAsExpression;
     property public final java.util.List<java.lang.Double>? fillTranslate;
@@ -1711,7 +1711,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillOutlineColorTransition();
     method public String? getDefaultFillPattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultFillPatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillPatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultFillPatternTransition();
     method public Double? getDefaultFillSortKey();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultFillSortKeyAsExpression();
     method public java.util.List<java.lang.Double>? getDefaultFillTranslate();
@@ -1737,7 +1737,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillOutlineColorTransition;
     property public final String? defaultFillPattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultFillPatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillPatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultFillPatternTransition;
     property public final Double? defaultFillSortKey;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultFillSortKeyAsExpression;
     property public final java.util.List<java.lang.Double>? defaultFillTranslate;
@@ -2094,7 +2094,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getLineColorTransition();
     method public java.util.List<java.lang.Double>? getLineDasharray();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getLineDasharrayAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getLineDasharrayTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getLineDasharrayTransition();
     method public Double? getLineGapWidth();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getLineGapWidthAsExpression();
     method public com.mapbox.maps.extension.style.types.StyleTransition? getLineGapWidthTransition();
@@ -2111,7 +2111,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getLineOpacityTransition();
     method public String? getLinePattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getLinePatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getLinePatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getLinePatternTransition();
     method public Double? getLineRoundLimit();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getLineRoundLimitAsExpression();
     method public Double? getLineSortKey();
@@ -2145,8 +2145,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineColorTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharray(java.util.List<java.lang.Double> lineDasharray);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharray(com.mapbox.maps.extension.style.expressions.generated.Expression lineDasharray);
-    method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharrayTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharrayTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharrayTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.LineLayer lineDasharrayTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineGapWidth(double lineGapWidth);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineGapWidth(com.mapbox.maps.extension.style.expressions.generated.Expression lineGapWidth);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineGapWidthTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
@@ -2166,8 +2166,8 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineOpacityTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer linePattern(String linePattern);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer linePattern(com.mapbox.maps.extension.style.expressions.generated.Expression linePattern);
-    method public com.mapbox.maps.extension.style.layers.generated.LineLayer linePatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
-    method public com.mapbox.maps.extension.style.layers.generated.LineLayer linePatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.LineLayer linePatternTransition(com.mapbox.maps.extension.style.types.StyleTransition options);
+    method @Deprecated public com.mapbox.maps.extension.style.layers.generated.LineLayer linePatternTransition(kotlin.jvm.functions.Function1<? super com.mapbox.maps.extension.style.types.StyleTransition.Builder,kotlin.Unit> block);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineRoundLimit(double lineRoundLimit);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineRoundLimit(com.mapbox.maps.extension.style.expressions.generated.Expression lineRoundLimit);
     method public com.mapbox.maps.extension.style.layers.generated.LineLayer lineSortKey(double lineSortKey);
@@ -2201,7 +2201,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? lineColorTransition;
     property public final java.util.List<java.lang.Double>? lineDasharray;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? lineDasharrayAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? lineDasharrayTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? lineDasharrayTransition;
     property public final Double? lineGapWidth;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? lineGapWidthAsExpression;
     property public final com.mapbox.maps.extension.style.types.StyleTransition? lineGapWidthTransition;
@@ -2218,7 +2218,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? lineOpacityTransition;
     property public final String? linePattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? linePatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? linePatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? linePatternTransition;
     property public final Double? lineRoundLimit;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? lineRoundLimitAsExpression;
     property public final Double? lineSortKey;
@@ -2253,7 +2253,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineColorTransition();
     method public java.util.List<java.lang.Double>? getDefaultLineDasharray();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultLineDasharrayAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineDasharrayTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineDasharrayTransition();
     method public Double? getDefaultLineGapWidth();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultLineGapWidthAsExpression();
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineGapWidthTransition();
@@ -2269,7 +2269,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLineOpacityTransition();
     method public String? getDefaultLinePattern();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultLinePatternAsExpression();
-    method public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLinePatternTransition();
+    method @Deprecated public com.mapbox.maps.extension.style.types.StyleTransition? getDefaultLinePatternTransition();
     method public Double? getDefaultLineRoundLimit();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression? getDefaultLineRoundLimitAsExpression();
     method public Double? getDefaultLineSortKey();
@@ -2298,7 +2298,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineColorTransition;
     property public final java.util.List<java.lang.Double>? defaultLineDasharray;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultLineDasharrayAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineDasharrayTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineDasharrayTransition;
     property public final Double? defaultLineGapWidth;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultLineGapWidthAsExpression;
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineGapWidthTransition;
@@ -2314,7 +2314,7 @@ package com.mapbox.maps.extension.style.layers.generated {
     property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLineOpacityTransition;
     property public final String? defaultLinePattern;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultLinePatternAsExpression;
-    property public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLinePatternTransition;
+    property @Deprecated public final com.mapbox.maps.extension.style.types.StyleTransition? defaultLinePatternTransition;
     property public final Double? defaultLineRoundLimit;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression? defaultLineRoundLimitAsExpression;
     property public final Double? defaultLineSortKey;

--- a/extension-style/api/metalava.txt
+++ b/extension-style/api/metalava.txt
@@ -4369,7 +4369,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class GeoJsonSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public GeoJsonSource(com.mapbox.maps.extension.style.sources.generated.GeoJsonSource.Builder builder);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource data(String value);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource feature(com.mapbox.geojson.Feature value);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource featureCollection(com.mapbox.geojson.FeatureCollection value);
@@ -4459,7 +4458,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class ImageSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public ImageSource(com.mapbox.maps.extension.style.sources.generated.ImageSource.Builder builder);
     method public com.mapbox.maps.extension.style.sources.generated.ImageSource coordinates(java.util.List<? extends java.util.List<java.lang.Double>> value);
     method public java.util.List<java.util.List<java.lang.Double>>? getCoordinates();
     method public Long? getPrefetchZoomDelta();
@@ -4493,7 +4491,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class RasterDemSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public RasterDemSource(com.mapbox.maps.extension.style.sources.generated.RasterDemSource.Builder builder);
     method public String? getAttribution();
     method public java.util.List<java.lang.Double>? getBounds();
     method public com.mapbox.maps.extension.style.sources.generated.Encoding? getEncoding();
@@ -4583,7 +4580,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class RasterSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public RasterSource(com.mapbox.maps.extension.style.sources.generated.RasterSource.Builder builder);
     method public String? getAttribution();
     method public java.util.List<java.lang.Double>? getBounds();
     method public Long? getMaxOverscaleFactorForParentTiles();
@@ -4680,7 +4676,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class VectorSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public VectorSource(com.mapbox.maps.extension.style.sources.generated.VectorSource.Builder builder);
     method public String? getAttribution();
     method public java.util.List<java.lang.Double>? getBounds();
     method public Long? getMaxOverscaleFactorForParentTiles();

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayer.kt
@@ -14,6 +14,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils.colorIntToRgbaExpression
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorInt
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorString
 import com.mapbox.maps.extension.style.utils.silentUnwrap
+import com.mapbox.maps.logE
 import java.util.*
 
 /**
@@ -426,6 +427,7 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
   /**
    * Transition options for BackgroundPattern.
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   val backgroundPatternTransition: StyleTransition?
     /**
      * Get the BackgroundPattern property transition options
@@ -435,7 +437,8 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
      * @return transition options for String
      */
     get() {
-      return getPropertyValue("background-pattern-transition")
+      logE("BackgroundLayer", "This property has been deprecated and will return null.")
+      return null
     }
 
   /**
@@ -445,16 +448,17 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
    *
    * @param options transition options for String
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun backgroundPatternTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("background-pattern-transition", options)
-    setProperty(propertyValue)
+    // no-op
   }
 
   /**
    * DSL for [backgroundPatternTransition].
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun backgroundPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    backgroundPatternTransition(StyleTransition.Builder().apply(block).build())
+    // no-op
   }
 
   /**
@@ -671,13 +675,17 @@ class BackgroundLayer(override val layerId: String) : BackgroundLayerDsl, Layer(
     /**
      * Transition options for BackgroundPattern.
      */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultBackgroundPatternTransition: StyleTransition?
       /**
        * Get the BackgroundPattern property transition options
        *
        * @return transition options for String
        */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("background", "background-pattern-transition").silentUnwrap()
+      get() {
+        logE("BackgroundLayer", "This property has been deprecated and will return null.")
+        return null
+      }
   }
 }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayer.kt
@@ -14,6 +14,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils.colorIntToRgbaExpression
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorInt
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorString
 import com.mapbox.maps.extension.style.utils.silentUnwrap
+import com.mapbox.maps.logE
 import java.util.*
 
 /**
@@ -884,6 +885,7 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
   /**
    * Transition options for FillExtrusionPattern.
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   val fillExtrusionPatternTransition: StyleTransition?
     /**
      * Get the FillExtrusionPattern property transition options
@@ -893,7 +895,8 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
      * @return transition options for String
      */
     get() {
-      return getPropertyValue("fill-extrusion-pattern-transition")
+      logE("FillExtrusionLayer", "This property has been deprecated and will return null.")
+      return null
     }
 
   /**
@@ -903,16 +906,17 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
    *
    * @param options transition options for String
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun fillExtrusionPatternTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("fill-extrusion-pattern-transition", options)
-    setProperty(propertyValue)
+    // no-op
   }
 
   /**
    * DSL for [fillExtrusionPatternTransition].
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun fillExtrusionPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    fillExtrusionPatternTransition(StyleTransition.Builder().apply(block).build())
+    // no-op
   }
 
   /**
@@ -1553,13 +1557,17 @@ class FillExtrusionLayer(override val layerId: String, val sourceId: String) : F
     /**
      * Transition options for FillExtrusionPattern.
      */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultFillExtrusionPatternTransition: StyleTransition?
       /**
        * Get the FillExtrusionPattern property transition options
        *
        * @return transition options for String
        */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("fill-extrusion", "fill-extrusion-pattern-transition").silentUnwrap()
+      get() {
+        logE("FillExtrusionLayer", "This property has been deprecated and will return null.")
+        return null
+      }
 
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up (on the flat plane), respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/FillLayer.kt
@@ -14,6 +14,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils.colorIntToRgbaExpression
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorInt
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorString
 import com.mapbox.maps.extension.style.utils.silentUnwrap
+import com.mapbox.maps.logE
 import java.util.*
 
 /**
@@ -748,6 +749,7 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
   /**
    * Transition options for FillPattern.
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   val fillPatternTransition: StyleTransition?
     /**
      * Get the FillPattern property transition options
@@ -757,7 +759,8 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
      * @return transition options for String
      */
     get() {
-      return getPropertyValue("fill-pattern-transition")
+      logE("FillLayer", "This property has been deprecated and will return null.")
+      return null
     }
 
   /**
@@ -767,16 +770,17 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
    *
    * @param options transition options for String
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun fillPatternTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("fill-pattern-transition", options)
-    setProperty(propertyValue)
+    // no-op
   }
 
   /**
    * DSL for [fillPatternTransition].
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun fillPatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    fillPatternTransition(StyleTransition.Builder().apply(block).build())
+    // no-op
   }
 
   /**
@@ -1301,13 +1305,17 @@ class FillLayer(override val layerId: String, val sourceId: String) : FillLayerD
     /**
      * Transition options for FillPattern.
      */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultFillPatternTransition: StyleTransition?
       /**
        * Get the FillPattern property transition options
        *
        * @return transition options for String
        */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-pattern-transition").silentUnwrap()
+      get() {
+        logE("FillLayer", "This property has been deprecated and will return null.")
+        return null
+      }
 
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/layers/generated/LineLayer.kt
@@ -14,6 +14,7 @@ import com.mapbox.maps.extension.style.utils.ColorUtils.colorIntToRgbaExpression
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorInt
 import com.mapbox.maps.extension.style.utils.ColorUtils.rgbaExpressionToColorString
 import com.mapbox.maps.extension.style.utils.silentUnwrap
+import com.mapbox.maps.logE
 import java.util.*
 
 /**
@@ -819,6 +820,7 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
   /**
    * Transition options for LineDasharray.
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   val lineDasharrayTransition: StyleTransition?
     /**
      * Get the LineDasharray property transition options
@@ -828,7 +830,8 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
      * @return transition options for List<Double>
      */
     get() {
-      return getPropertyValue("line-dasharray-transition")
+      logE("LineLayer", "This property has been deprecated and will return null.")
+      return null
     }
 
   /**
@@ -838,16 +841,17 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
    *
    * @param options transition options for List<Double>
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun lineDasharrayTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("line-dasharray-transition", options)
-    setProperty(propertyValue)
+    // no-op
   }
 
   /**
    * DSL for [lineDasharrayTransition].
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun lineDasharrayTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    lineDasharrayTransition(StyleTransition.Builder().apply(block).build())
+    // no-op
   }
 
   /**
@@ -1242,6 +1246,7 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
   /**
    * Transition options for LinePattern.
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   val linePatternTransition: StyleTransition?
     /**
      * Get the LinePattern property transition options
@@ -1251,7 +1256,8 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
      * @return transition options for String
      */
     get() {
-      return getPropertyValue("line-pattern-transition")
+      logE("LineLayer", "This property has been deprecated and will return null.")
+      return null
     }
 
   /**
@@ -1261,16 +1267,17 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
    *
    * @param options transition options for String
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun linePatternTransition(options: StyleTransition) = apply {
-    val propertyValue = PropertyValue("line-pattern-transition", options)
-    setProperty(propertyValue)
+    // no-op
   }
 
   /**
    * DSL for [linePatternTransition].
    */
+  @Deprecated("This property has been deprecated and will do no operations")
   override fun linePatternTransition(block: StyleTransition.Builder.() -> Unit) = apply {
-    linePatternTransition(StyleTransition.Builder().apply(block).build())
+    // no-op
   }
 
   /**
@@ -2009,13 +2016,17 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
     /**
      * Transition options for LineDasharray.
      */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultLineDasharrayTransition: StyleTransition?
       /**
        * Get the LineDasharray property transition options
        *
        * @return transition options for List<Double>
        */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("line", "line-dasharray-transition").silentUnwrap()
+      get() {
+        logE("LineLayer", "This property has been deprecated and will return null.")
+        return null
+      }
 
     /**
      * Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
@@ -2201,13 +2212,17 @@ class LineLayer(override val layerId: String, val sourceId: String) : LineLayerD
     /**
      * Transition options for LinePattern.
      */
+    @Deprecated("This property has been deprecated and will do no operations")
     val defaultLinePatternTransition: StyleTransition?
       /**
        * Get the LinePattern property transition options
        *
        * @return transition options for String
        */
-      get() = StyleManager.getStyleLayerPropertyDefaultValue("line", "line-pattern-transition").silentUnwrap()
+      get() {
+        logE("LineLayer", "This property has been deprecated and will return null.")
+        return null
+      }
 
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -4,7 +4,6 @@ package com.mapbox.maps.extension.style.sources.generated
 
 import android.os.Handler
 import android.os.HandlerThread
-import android.os.Looper
 import android.os.Process.THREAD_PRIORITY_DEFAULT
 import androidx.annotation.VisibleForTesting
 import com.mapbox.bindgen.Value
@@ -410,6 +409,7 @@ class GeoJsonSource : Source {
       properties[propertyValue.propertyName] = propertyValue
     }
 
+
     /**
      * A URL to a GeoJSON file, or inline GeoJSON.
      */
@@ -661,8 +661,6 @@ class GeoJsonSource : Source {
     internal val workerThread = HandlerThread("GEOJSON_PARSER", THREAD_PRIORITY_DEFAULT).apply {
       start()
     }
-
-    private val mainHandler = Handler(Looper.getMainLooper())
 
     internal fun toGeoJsonData(geoJson: GeoJson): GeoJSONSourceData {
       return when (geoJson) {

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -34,22 +34,20 @@ import com.mapbox.maps.logW
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#geojson)
  *
  */
-class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
+class GeoJsonSource : Source {
+  private constructor(builder: Builder) : super(builder.sourceId) {
+    initGeoJson = builder.geoJson
+    initData = builder.data
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
+  }
+
   private val workerHandler by lazy {
     Handler(workerThread.looper)
   }
 
   private var initGeoJson: GeoJson? = null
   private var initData: String? = null
-
-  private constructor(
-    builder: Builder,
-    geoJson: GeoJson?,
-    data: String?,
-  ) : this(builder) {
-    this.initGeoJson = geoJson
-    this.initData = data
-  }
 
   private fun setGeoJson(geoJson: GeoJson) {
     workerHandler.removeCallbacksAndMessages(null)
@@ -84,11 +82,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       setData(it)
       initData = null
     }
-  }
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   /**
@@ -407,12 +400,17 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
   class Builder(
     val sourceId: String
   ) {
-
-    private var geoJson: GeoJson? = null
-    private var data: String? = null
+    internal var geoJson: GeoJson? = null
+    internal var data: String? = null
     internal val properties = HashMap<String, PropertyValue<*>>()
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
+
+    init {
+      // set default data to allow empty data source.
+      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
+      properties[propertyValue.propertyName] = propertyValue
+    }
 
     /**
      * A URL to a GeoJSON file, or inline GeoJSON.
@@ -428,7 +426,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
     fun url(value: String) = apply {
       data(value)
     }
-
     /**
      * Maximum zoom level at which to create vector tiles (higher means greater detail at high zoom
      * levels).
@@ -437,7 +434,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("maxzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
@@ -445,7 +441,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("attribution", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Size of the tile buffer on each side. A value of 0 produces no buffer. A
      * value of 512 produces a buffer as wide as the tile itself. Larger values produce fewer
@@ -455,7 +450,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("buffer", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Douglas-Peucker simplification tolerance (higher means simpler geometries and faster performance).
      */
@@ -463,7 +457,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("tolerance", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * If the data is a collection of point features, setting this to true clusters the points
      * by radius into groups. Cluster groups become new `Point` features in the source with additional properties:
@@ -477,7 +470,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("cluster", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Radius of each cluster if clustering is enabled. A value of 512 indicates a radius equal
      * to the width of a tile.
@@ -486,7 +478,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("clusterRadius", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less
      * than maxzoom (so that last zoom features are not clustered). Clusters are re-evaluated at integer zoom
@@ -496,7 +487,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("clusterMaxZoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * An object defining custom properties on the generated clusters if clustering is enabled, aggregating values from
      * clustered points. Has the form `{"property_name": [operator, map_expression]}`. `operator` is any expression function that accepts at
@@ -573,7 +563,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
         val propertyValue = PropertyValue("clusterProperties", TypeUtils.wrapToValue(options))
         properties[propertyValue.propertyName] = propertyValue
       }
-
     /**
      * Whether to calculate line distance metrics. This is required for line layers that specify `line-gradient` values.
      */
@@ -581,7 +570,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("lineMetrics", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
      * assigned based on its index in the `features` array, over-writing any previous values.
@@ -590,7 +578,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("generateId", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * A property to use as a feature id (for feature state). Either a property name, or
      * an object of the form `{<sourceLayer>: <propertyName>}`.
@@ -599,7 +586,6 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("promoteId", value.toValue())
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that
@@ -650,10 +636,7 @@ class GeoJsonSource(builder: Builder) : Source(builder.sourceId) {
      * @return the GeoJsonSource
      */
     fun build(): GeoJsonSource {
-      // set default data to allow empty data source.
-      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
-      properties[propertyValue.propertyName] = propertyValue
-      return GeoJsonSource(this, geoJson, data)
+      return GeoJsonSource(this)
     }
   }
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -409,7 +409,6 @@ class GeoJsonSource : Source {
       properties[propertyValue.propertyName] = propertyValue
     }
 
-
     /**
      * A URL to a GeoJSON file, or inline GeoJSON.
      */

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -36,10 +36,10 @@ import com.mapbox.maps.logW
  */
 class GeoJsonSource : Source {
   private constructor(builder: Builder) : super(builder.sourceId) {
-    initGeoJson = builder.geoJson
-    initData = builder.data
     sourceProperties.putAll(builder.properties)
     volatileSourceProperties.putAll(builder.volatileProperties)
+    initGeoJson = builder.geoJson
+    initData = builder.data
   }
 
   private val workerHandler by lazy {
@@ -397,9 +397,7 @@ class GeoJsonSource : Source {
    * @param sourceId the ID of the source
    */
   @SourceDsl
-  class Builder(
-    val sourceId: String
-  ) {
+  class Builder(val sourceId: String) {
     internal var geoJson: GeoJson? = null
     internal var data: String? = null
     internal val properties = HashMap<String, PropertyValue<*>>()

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -424,6 +424,7 @@ class GeoJsonSource : Source {
     fun url(value: String) = apply {
       data(value)
     }
+
     /**
      * Maximum zoom level at which to create vector tiles (higher means greater detail at high zoom
      * levels).
@@ -432,6 +433,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("maxzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
@@ -439,6 +441,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("attribution", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Size of the tile buffer on each side. A value of 0 produces no buffer. A
      * value of 512 produces a buffer as wide as the tile itself. Larger values produce fewer
@@ -448,6 +451,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("buffer", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Douglas-Peucker simplification tolerance (higher means simpler geometries and faster performance).
      */
@@ -455,6 +459,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("tolerance", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * If the data is a collection of point features, setting this to true clusters the points
      * by radius into groups. Cluster groups become new `Point` features in the source with additional properties:
@@ -468,6 +473,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("cluster", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Radius of each cluster if clustering is enabled. A value of 512 indicates a radius equal
      * to the width of a tile.
@@ -476,6 +482,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("clusterRadius", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less
      * than maxzoom (so that last zoom features are not clustered). Clusters are re-evaluated at integer zoom
@@ -485,6 +492,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("clusterMaxZoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * An object defining custom properties on the generated clusters if clustering is enabled, aggregating values from
      * clustered points. Has the form `{"property_name": [operator, map_expression]}`. `operator` is any expression function that accepts at
@@ -561,6 +569,7 @@ class GeoJsonSource : Source {
         val propertyValue = PropertyValue("clusterProperties", TypeUtils.wrapToValue(options))
         properties[propertyValue.propertyName] = propertyValue
       }
+
     /**
      * Whether to calculate line distance metrics. This is required for line layers that specify `line-gradient` values.
      */
@@ -568,6 +577,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("lineMetrics", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Whether to generate ids for the geojson features. When enabled, the `feature.id` property will be auto
      * assigned based on its index in the `features` array, over-writing any previous values.
@@ -576,6 +586,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("generateId", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * A property to use as a feature id (for feature state). Either a property name, or
      * an object of the form `{<sourceLayer>: <propertyName>}`.
@@ -584,6 +595,7 @@ class GeoJsonSource : Source {
       val propertyValue = PropertyValue("promoteId", value.toValue())
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -16,12 +16,8 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#image)
  *
  */
-class ImageSource(builder: Builder) : Source(builder.sourceId) {
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
-  }
+class ImageSource : Source {
+  private constructor(builder: Builder) : super(builder.sourceId)
 
   /**
    * Get the type of the current source as a String.
@@ -105,6 +101,12 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
+    init {
+      // set default data to allow empty data source.
+      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
+      properties[propertyValue.propertyName] = propertyValue
+    }
+
     /**
      * URL that points to an image.
      */
@@ -112,7 +114,6 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("url", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Corners of image specified in longitude, latitude pairs.
      */
@@ -120,7 +121,6 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("coordinates", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -104,8 +104,6 @@ class ImageSource : Source {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
-
-
     /**
      * URL that points to an image.
      */

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -117,6 +117,7 @@ class ImageSource : Source {
       val propertyValue = PropertyValue("url", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Corners of image specified in longitude, latitude pairs.
      */
@@ -124,6 +125,7 @@ class ImageSource : Source {
       val propertyValue = PropertyValue("coordinates", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -104,11 +104,7 @@ class ImageSource : Source {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
-    init {
-      // set default data to allow empty data source.
-      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
-      properties[propertyValue.propertyName] = propertyValue
-    }
+
 
     /**
      * URL that points to an image.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -17,7 +17,10 @@ import java.util.*
  *
  */
 class ImageSource : Source {
-  private constructor(builder: Builder) : super(builder.sourceId)
+  private constructor(builder: Builder) : super(builder.sourceId) {
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
+  }
 
   /**
    * Get the type of the current source as a String.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -17,12 +17,8 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster_dem)
  *
  */
-class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
-  }
+class RasterDemSource : Source {
+  private constructor(builder: Builder) : super(builder.sourceId)
 
   /**
    * Get the type of the current source as a String.
@@ -319,6 +315,12 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
+    init {
+      // set default data to allow empty data source.
+      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
+      properties[propertyValue.propertyName] = propertyValue
+    }
+
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
      */
@@ -326,7 +328,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("url", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * An array of one or more tile source URLs, as in the TileJSON spec.
      */
@@ -334,7 +335,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("tiles", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * An array containing the longitude and latitude of the southwest and northeast corners of the source's
      * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
@@ -344,7 +344,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("bounds", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
@@ -352,7 +351,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("minzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
      * at the maxzoom are used when displaying the map at higher zoom levels.
@@ -361,7 +359,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("maxzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
      */
@@ -369,7 +366,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("tileSize", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
@@ -377,7 +373,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("attribution", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * The encoding used by this source. Mapbox Terrain RGB is used by default
      */
@@ -385,7 +380,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("encoding", TypeUtils.wrapToValue(value.value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * A setting to determine whether a source's tiles are cached locally.
      */
@@ -393,7 +387,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("volatile", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that
@@ -405,7 +398,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Minimum tile update interval in seconds, which is used to throttle the tile update network requests.
      * If the given source supports loading tiles from a server, sets the minimum tile update interval.
@@ -415,7 +407,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * When a set of tiles for a current zoom level is being rendered and some of
      * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
@@ -426,7 +417,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * For the tiled sources, this property sets the tile requests delay. The given delay comes in
      * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
@@ -436,7 +426,6 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * For the tiled sources, this property sets the tile network requests delay. The given delay comes
      * in action only during an ongoing animation or gestures. It helps to avoid loading the transient

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -156,7 +156,7 @@ class RasterDemSource : Source {
      */
     get() {
       getPropertyValue<String?>("encoding")?.let {
-        return Encoding.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+        return Encoding.valueOf(it.uppercase(Locale.US).replace('-', '_'))
       }
       return null
     }
@@ -318,11 +318,7 @@ class RasterDemSource : Source {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
-    init {
-      // set default data to allow empty data source.
-      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
-      properties[propertyValue.propertyName] = propertyValue
-    }
+
 
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
@@ -526,7 +522,7 @@ class RasterDemSource : Source {
        */
       get() {
         StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "encoding").silentUnwrap<String>()?.let {
-          return Encoding.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+          return Encoding.valueOf(it.uppercase(Locale.US).replace('-', '_'))
         }
         return null
       }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -18,7 +18,10 @@ import java.util.*
  *
  */
 class RasterDemSource : Source {
-  private constructor(builder: Builder) : super(builder.sourceId)
+  private constructor(builder: Builder) : super(builder.sourceId) {
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
+  }
 
   /**
    * Get the type of the current source as a String.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -331,6 +331,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("url", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * An array of one or more tile source URLs, as in the TileJSON spec.
      */
@@ -338,6 +339,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("tiles", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * An array containing the longitude and latitude of the southwest and northeast corners of the source's
      * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
@@ -347,6 +349,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("bounds", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
@@ -354,6 +357,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("minzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
      * at the maxzoom are used when displaying the map at higher zoom levels.
@@ -362,6 +366,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("maxzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
      */
@@ -369,6 +374,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("tileSize", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
@@ -376,6 +382,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("attribution", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * The encoding used by this source. Mapbox Terrain RGB is used by default
      */
@@ -383,6 +390,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("encoding", TypeUtils.wrapToValue(value.value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * A setting to determine whether a source's tiles are cached locally.
      */
@@ -390,6 +398,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("volatile", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that
@@ -401,6 +410,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Minimum tile update interval in seconds, which is used to throttle the tile update network requests.
      * If the given source supports loading tiles from a server, sets the minimum tile update interval.
@@ -410,6 +420,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * When a set of tiles for a current zoom level is being rendered and some of
      * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
@@ -420,6 +431,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * For the tiled sources, this property sets the tile requests delay. The given delay comes in
      * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
@@ -429,6 +441,7 @@ class RasterDemSource : Source {
       val propertyValue = PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * For the tiled sources, this property sets the tile network requests delay. The given delay comes
      * in action only during an ongoing animation or gestures. It helps to avoid loading the transient

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -318,8 +318,6 @@ class RasterDemSource : Source {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
-
-
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
      */

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -17,12 +17,8 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster)
  *
  */
-class RasterSource(builder: Builder) : Source(builder.sourceId) {
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
-  }
+class RasterSource : Source {
+  private constructor(builder: Builder) : super(builder.sourceId)
 
   /**
    * Get the type of the current source as a String.
@@ -319,6 +315,12 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
+    init {
+      // set default data to allow empty data source.
+      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
+      properties[propertyValue.propertyName] = propertyValue
+    }
+
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
      */
@@ -326,7 +328,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("url", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * An array of one or more tile source URLs, as in the TileJSON spec.
      */
@@ -334,7 +335,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("tiles", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * An array containing the longitude and latitude of the southwest and northeast corners of the source's
      * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
@@ -344,7 +344,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("bounds", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
@@ -352,7 +351,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("minzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
      * at the maxzoom are used when displaying the map at higher zoom levels.
@@ -361,7 +359,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("maxzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
      */
@@ -369,7 +366,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("tileSize", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
      */
@@ -377,7 +373,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("scheme", TypeUtils.wrapToValue(value.value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
@@ -385,7 +380,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("attribution", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * A setting to determine whether a source's tiles are cached locally.
      */
@@ -393,7 +387,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("volatile", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that
@@ -405,7 +398,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Minimum tile update interval in seconds, which is used to throttle the tile update network requests.
      * If the given source supports loading tiles from a server, sets the minimum tile update interval.
@@ -415,7 +407,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * When a set of tiles for a current zoom level is being rendered and some of
      * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
@@ -426,7 +417,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * For the tiled sources, this property sets the tile requests delay. The given delay comes in
      * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
@@ -436,7 +426,6 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * For the tiled sources, this property sets the tile network requests delay. The given delay comes
      * in action only during an ongoing animation or gestures. It helps to avoid loading the transient

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -331,6 +331,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("url", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * An array of one or more tile source URLs, as in the TileJSON spec.
      */
@@ -338,6 +339,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("tiles", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * An array containing the longitude and latitude of the southwest and northeast corners of the source's
      * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
@@ -347,6 +349,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("bounds", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
@@ -354,6 +357,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("minzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
      * at the maxzoom are used when displaying the map at higher zoom levels.
@@ -362,6 +366,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("maxzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * The minimum visual size to display tiles for this layer. Only configurable for raster layers.
      */
@@ -369,6 +374,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("tileSize", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
      */
@@ -376,6 +382,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("scheme", TypeUtils.wrapToValue(value.value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
@@ -383,6 +390,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("attribution", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * A setting to determine whether a source's tiles are cached locally.
      */
@@ -390,6 +398,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("volatile", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that
@@ -401,6 +410,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Minimum tile update interval in seconds, which is used to throttle the tile update network requests.
      * If the given source supports loading tiles from a server, sets the minimum tile update interval.
@@ -410,6 +420,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * When a set of tiles for a current zoom level is being rendered and some of
      * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
@@ -420,6 +431,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * For the tiled sources, this property sets the tile requests delay. The given delay comes in
      * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
@@ -429,6 +441,7 @@ class RasterSource : Source {
       val propertyValue = PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * For the tiled sources, this property sets the tile network requests delay. The given delay comes
      * in action only during an ongoing animation or gestures. It helps to avoid loading the transient

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -318,8 +318,6 @@ class RasterSource : Source {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
-
-
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
      */

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -145,7 +145,7 @@ class RasterSource : Source {
      */
     get() {
       getPropertyValue<String?>("scheme")?.let {
-        return Scheme.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+        return Scheme.valueOf(it.uppercase(Locale.US).replace('-', '_'))
       }
       return null
     }
@@ -318,11 +318,7 @@ class RasterSource : Source {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
-    init {
-      // set default data to allow empty data source.
-      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
-      properties[propertyValue.propertyName] = propertyValue
-    }
+
 
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
@@ -526,7 +522,7 @@ class RasterSource : Source {
        */
       get() {
         StyleManager.getStyleSourcePropertyDefaultValue("raster", "scheme").silentUnwrap<String>()?.let {
-          return Scheme.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+          return Scheme.valueOf(it.uppercase(Locale.US).replace('-', '_'))
         }
         return null
       }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -18,7 +18,10 @@ import java.util.*
  *
  */
 class RasterSource : Source {
-  private constructor(builder: Builder) : super(builder.sourceId)
+  private constructor(builder: Builder) : super(builder.sourceId) {
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
+  }
 
   /**
    * Get the type of the current source as a String.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -93,7 +93,7 @@ class VectorSource : Source {
      */
     get() {
       getPropertyValue<String?>("scheme")?.let {
-        return Scheme.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+        return Scheme.valueOf(it.uppercase(Locale.US).replace('-', '_'))
       }
       return null
     }
@@ -328,11 +328,7 @@ class VectorSource : Source {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
-    init {
-      // set default data to allow empty data source.
-      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
-      properties[propertyValue.propertyName] = propertyValue
-    }
+
 
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
@@ -516,7 +512,7 @@ class VectorSource : Source {
        */
       get() {
         StyleManager.getStyleSourcePropertyDefaultValue("vector", "scheme").silentUnwrap<String>()?.let {
-          return Scheme.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+          return Scheme.valueOf(it.uppercase(Locale.US).replace('-', '_'))
         }
         return null
       }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -19,7 +19,10 @@ import java.util.*
  *
  */
 class VectorSource : Source {
-  private constructor(builder: Builder) : super(builder.sourceId)
+  private constructor(builder: Builder) : super(builder.sourceId) {
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
+  }
 
   /**
    * Get the type of the current source as a String.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -328,8 +328,6 @@ class VectorSource : Source {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
-
-
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
      */

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -18,12 +18,8 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector)
  *
  */
-class VectorSource(builder: Builder) : Source(builder.sourceId) {
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
-  }
+class VectorSource : Source {
+  private constructor(builder: Builder) : super(builder.sourceId)
 
   /**
    * Get the type of the current source as a String.
@@ -329,6 +325,12 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
+    init {
+      // set default data to allow empty data source.
+      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
+      properties[propertyValue.propertyName] = propertyValue
+    }
+
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
      */
@@ -336,7 +338,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("url", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * An array of one or more tile source URLs, as in the TileJSON spec.
      */
@@ -344,7 +345,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("tiles", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * An array containing the longitude and latitude of the southwest and northeast corners of the source's
      * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
@@ -354,7 +354,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("bounds", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
      */
@@ -362,7 +361,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("scheme", TypeUtils.wrapToValue(value.value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
@@ -370,7 +368,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("minzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
      * at the maxzoom are used when displaying the map at higher zoom levels.
@@ -379,7 +376,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("maxzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
@@ -387,7 +383,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("attribution", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * A property to use as a feature id (for feature state). Either a property name, or
      * an object of the form `{<sourceLayer>: <propertyName>}`. If specified as a string for a vector tile
@@ -398,7 +393,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("promoteId", value.toValue())
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * A setting to determine whether a source's tiles are cached locally.
      */
@@ -406,7 +400,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("volatile", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that
@@ -418,7 +411,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * Minimum tile update interval in seconds, which is used to throttle the tile update network requests.
      * If the given source supports loading tiles from a server, sets the minimum tile update interval.
@@ -428,7 +420,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * When a set of tiles for a current zoom level is being rendered and some of
      * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
@@ -439,7 +430,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * For the tiled sources, this property sets the tile requests delay. The given delay comes in
      * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
@@ -449,7 +439,6 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
       val propertyValue = PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
-
     /**
      * For the tiled sources, this property sets the tile network requests delay. The given delay comes
      * in action only during an ongoing animation or gestures. It helps to avoid loading the transient

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -341,6 +341,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("url", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * An array of one or more tile source URLs, as in the TileJSON spec.
      */
@@ -348,6 +349,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("tiles", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * An array containing the longitude and latitude of the southwest and northeast corners of the source's
      * bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in
@@ -357,6 +359,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("bounds", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
      */
@@ -364,6 +367,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("scheme", TypeUtils.wrapToValue(value.value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Minimum zoom level for which tiles are available, as in the TileJSON spec.
      */
@@ -371,6 +375,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("minzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles
      * at the maxzoom are used when displaying the map at higher zoom levels.
@@ -379,6 +384,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("maxzoom", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Contains an attribution to be displayed when the map is shown to a user.
      */
@@ -386,6 +392,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("attribution", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * A property to use as a feature id (for feature state). Either a property name, or
      * an object of the form `{<sourceLayer>: <propertyName>}`. If specified as a string for a vector tile
@@ -396,6 +403,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("promoteId", value.toValue())
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * A setting to determine whether a source's tiles are cached locally.
      */
@@ -403,6 +411,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("volatile", TypeUtils.wrapToValue(value))
       properties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * When loading a map, if PrefetchZoomDelta is set to any number greater than 0, the map
      * will first request a tile at zoom level lower than zoom - delta, but so that
@@ -414,6 +423,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("prefetch-zoom-delta", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * Minimum tile update interval in seconds, which is used to throttle the tile update network requests.
      * If the given source supports loading tiles from a server, sets the minimum tile update interval.
@@ -423,6 +433,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("minimum-tile-update-interval", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * When a set of tiles for a current zoom level is being rendered and some of
      * the ideal tiles that cover the screen are not yet loaded, parent tile could be used
@@ -433,6 +444,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("max-overscale-factor-for-parent-tiles", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * For the tiled sources, this property sets the tile requests delay. The given delay comes in
      * action only during an ongoing animation or gestures. It helps to avoid loading, parsing and rendering
@@ -442,6 +454,7 @@ class VectorSource : Source {
       val propertyValue = PropertyValue("tile-requests-delay", TypeUtils.wrapToValue(value))
       volatileProperties[propertyValue.propertyName] = propertyValue
     }
+
     /**
      * For the tiled sources, this property sets the tile network requests delay. The given delay comes
      * in action only during an ongoing animation or gestures. It helps to avoid loading the transient

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/BackgroundLayerTest.kt
@@ -379,46 +379,6 @@ class BackgroundLayerTest {
   }
 
   @Test
-  fun backgroundPatternTransitionSet() {
-    val layer = backgroundLayer("id") {}
-    layer.bindTo(style)
-    layer.backgroundPatternTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "background-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun backgroundPatternTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = backgroundLayer("id") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.backgroundPatternTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "background-pattern-transition") }
-  }
-
-  @Test
-  fun backgroundPatternTransitionSetDsl() {
-    val layer = backgroundLayer("id") {}
-    layer.bindTo(style)
-    layer.backgroundPatternTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "background-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
   fun visibilitySet() {
     val layer = backgroundLayer("id") {}
     layer.bindTo(style)
@@ -610,19 +570,6 @@ class BackgroundLayerTest {
     assertEquals("abc", BackgroundLayer.defaultBackgroundPatternAsExpression.toString())
     assertEquals("abc", BackgroundLayer.defaultBackgroundPattern)
     verify { StyleManager.getStyleLayerPropertyDefaultValue("background", "background-pattern") }
-  }
-
-  @Test
-  fun defaultBackgroundPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), BackgroundLayer.defaultBackgroundPatternTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("background", "background-pattern-transition") }
   }
 
   @Test

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillExtrusionLayerTest.kt
@@ -908,46 +908,6 @@ class FillExtrusionLayerTest {
   }
 
   @Test
-  fun fillExtrusionPatternTransitionSet() {
-    val layer = fillExtrusionLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.fillExtrusionPatternTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "fill-extrusion-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun fillExtrusionPatternTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = fillExtrusionLayer("id", "source") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.fillExtrusionPatternTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "fill-extrusion-pattern-transition") }
-  }
-
-  @Test
-  fun fillExtrusionPatternTransitionSetDsl() {
-    val layer = fillExtrusionLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.fillExtrusionPatternTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "fill-extrusion-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
   fun fillExtrusionTranslateSet() {
     val layer = fillExtrusionLayer("id", "source") {}
     val testValue = listOf(0.0, 1.0)
@@ -1563,19 +1523,6 @@ class FillExtrusionLayerTest {
     assertEquals("abc", FillExtrusionLayer.defaultFillExtrusionPatternAsExpression.toString())
     assertEquals("abc", FillExtrusionLayer.defaultFillExtrusionPattern)
     verify { StyleManager.getStyleLayerPropertyDefaultValue("fill-extrusion", "fill-extrusion-pattern") }
-  }
-
-  @Test
-  fun defaultFillExtrusionPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), FillExtrusionLayer.defaultFillExtrusionPatternTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("fill-extrusion", "fill-extrusion-pattern-transition") }
   }
 
   @Test

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/FillLayerTest.kt
@@ -764,46 +764,6 @@ class FillLayerTest {
   }
 
   @Test
-  fun fillPatternTransitionSet() {
-    val layer = fillLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.fillPatternTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "fill-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun fillPatternTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = fillLayer("id", "source") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.fillPatternTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "fill-pattern-transition") }
-  }
-
-  @Test
-  fun fillPatternTransitionSetDsl() {
-    val layer = fillLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.fillPatternTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "fill-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
   fun fillTranslateSet() {
     val layer = fillLayer("id", "source") {}
     val testValue = listOf(0.0, 1.0)
@@ -1313,19 +1273,6 @@ class FillLayerTest {
     assertEquals("abc", FillLayer.defaultFillPatternAsExpression.toString())
     assertEquals("abc", FillLayer.defaultFillPattern)
     verify { StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-pattern") }
-  }
-
-  @Test
-  fun defaultFillPatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), FillLayer.defaultFillPatternTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("fill", "fill-pattern-transition") }
   }
 
   @Test

--- a/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LineLayerTest.kt
+++ b/extension-style/src/test/java/com/mapbox/maps/extension/style/layers/generated/LineLayerTest.kt
@@ -818,46 +818,6 @@ class LineLayerTest {
   }
 
   @Test
-  fun lineDasharrayTransitionSet() {
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.lineDasharrayTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "line-dasharray-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun lineDasharrayTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.lineDasharrayTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "line-dasharray-transition") }
-  }
-
-  @Test
-  fun lineDasharrayTransitionSetDsl() {
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.lineDasharrayTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "line-dasharray-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
   fun lineGapWidthSet() {
     val layer = lineLayer("id", "source") {}
     val testValue = 1.0
@@ -1328,46 +1288,6 @@ class LineLayerTest {
     assertEquals("abc", layer.linePatternAsExpression.toString())
     assertEquals("abc", layer.linePattern)
     verify { style.getStyleLayerProperty("id", "line-pattern") }
-  }
-
-  @Test
-  fun linePatternTransitionSet() {
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.linePatternTransition(
-      transitionOptions {
-        duration(100)
-        delay(200)
-      }
-    )
-    verify { style.setStyleLayerProperty("id", "line-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
-  }
-
-  @Test
-  fun linePatternTransitionGet() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    assertEquals(transition.toValue().toString(), layer.linePatternTransition?.toValue().toString())
-    verify { style.getStyleLayerProperty("id", "line-pattern-transition") }
-  }
-
-  @Test
-  fun linePatternTransitionSetDsl() {
-    val layer = lineLayer("id", "source") {}
-    layer.bindTo(style)
-    layer.linePatternTransition {
-      duration(100)
-      delay(200)
-    }
-    verify { style.setStyleLayerProperty("id", "line-pattern-transition", capture(valueSlot)) }
-    assertEquals(valueSlot.captured.toString(), "{duration=100, delay=200}")
   }
 
   @Test
@@ -2077,19 +1997,6 @@ class LineLayerTest {
   }
 
   @Test
-  fun defaultLineDasharrayTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), LineLayer.defaultLineDasharrayTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("line", "line-dasharray-transition") }
-  }
-
-  @Test
   fun defaultLineGapWidthTest() {
     val testValue = 1.0
     every { styleProperty.value } returns TypeUtils.wrapToValue(testValue)
@@ -2252,19 +2159,6 @@ class LineLayerTest {
     assertEquals("abc", LineLayer.defaultLinePatternAsExpression.toString())
     assertEquals("abc", LineLayer.defaultLinePattern)
     verify { StyleManager.getStyleLayerPropertyDefaultValue("line", "line-pattern") }
-  }
-
-  @Test
-  fun defaultLinePatternTransitionTest() {
-    val transition = transitionOptions {
-      duration(100)
-      delay(200)
-    }
-    every { styleProperty.value } returns TypeUtils.wrapToValue(transition)
-    every { styleProperty.kind } returns StylePropertyValueKind.TRANSITION
-
-    assertEquals(transition.toValue().toString(), LineLayer.defaultLinePatternTransition?.toValue().toString())
-    verify { StyleManager.getStyleLayerPropertyDefaultValue("line", "line-pattern-transition") }
   }
 
   @Test


### PR DESCRIPTION
### Summary of changes

### User impact (optional)

Source constructors are made private, users should instead use Source.Builder.

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
