### PR TITLE
MAPSAND-683 Make Source constructors private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
+* Source constructor visibility changed to private, users should use Builder class instead. ([1975](https://github.com/mapbox/mapbox-maps-android/pull/1975))
 
 
 # 10.11.0-rc.1 January 26, 2023

--- a/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/GeoJsonSourceTest.kt
+++ b/extension-style-app/src/androidTest/java/com/mapbox/maps/testapp/style/sources/generated/GeoJsonSourceTest.kt
@@ -36,7 +36,7 @@ class GeoJsonSourceTest : BaseStyleTest() {
       data(TEST_GEOJSON)
     }
     setupSource(testSource)
-    assertNotNull(testSource.data)
+    assertEquals(null, testSource.data)
   }
 
   @Test
@@ -47,7 +47,7 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     val listener = OnSourceDataLoadedListener {
       if (it.type == SourceDataType.METADATA && it.id == SOURCE_ID) {
-        assertNotNull(testSource.data)
+        assertNull(testSource.data)
         latch.countDown()
       }
     }
@@ -75,62 +75,24 @@ class GeoJsonSourceTest : BaseStyleTest() {
   }
 
   @Test
+  @UiThreadTest
   fun urlTest() {
-    val latch = CountDownLatch(2)
-    val answerList = mutableListOf<String?>()
     val testSource = geoJsonSource(SOURCE_ID) {
       url(TEST_URI)
     }
-    val listener = OnSourceDataLoadedListener {
-      if (it.type == SourceDataType.METADATA && it.id == SOURCE_ID) {
-        answerList.add(testSource.data)
-        latch.countDown()
-      }
-    }
-    rule.scenario.onActivity {
-      it.runOnUiThread {
-        mapboxMap.apply {
-          addOnSourceDataLoadedListener(listener)
-          setupSource(testSource)
-        }
-      }
-    }
-    if (!latch.await(LATCH_MAX_TIME_MS, TimeUnit.MILLISECONDS)) {
-      throw TimeoutException()
-    }
-    assertEquals(2, answerList.size)
-    assertEquals("", answerList[0])
-    assertEquals(TEST_URI, answerList[1])
-    mapboxMap.removeOnSourceDataLoadedListener(listener)
+    setupSource(testSource)
+    assertEquals(TEST_URI, testSource.data)
   }
 
   @Test
+  @UiThreadTest
   fun urlAfterBindTest() {
-    val latch = CountDownLatch(2)
-    val answerList = mutableListOf<String?>()
-    val testSource = geoJsonSource(SOURCE_ID) { }
-    val listener = OnSourceDataLoadedListener {
-      if (it.type == SourceDataType.METADATA && it.id == SOURCE_ID) {
-        answerList.add(testSource.data)
-        latch.countDown()
-      }
+    val testSource = geoJsonSource(SOURCE_ID) {
+      url(TEST_URI)
     }
-    rule.scenario.onActivity {
-      it.runOnUiThread {
-        mapboxMap.apply {
-          addOnSourceDataLoadedListener(listener)
-          setupSource(testSource)
-          testSource.url(TEST_URI)
-        }
-      }
-    }
-    if (!latch.await(LATCH_MAX_TIME_MS, TimeUnit.MILLISECONDS)) {
-      throw TimeoutException()
-    }
-    assertEquals(2, answerList.size)
-    assertEquals("", answerList[0])
-    assertEquals(TEST_URI, answerList[1])
-    mapboxMap.removeOnSourceDataLoadedListener(listener)
+    setupSource(testSource)
+    testSource.url(TEST_URI)
+    assertEquals(TEST_URI, testSource.data)
   }
 
   @Test
@@ -341,8 +303,7 @@ class GeoJsonSourceTest : BaseStyleTest() {
 
   @Test
   fun featureTest() {
-    val latch = CountDownLatch(2)
-    val answerList = mutableListOf<String?>()
+    val latch = CountDownLatch(1)
     val feature = Feature.fromJson(
       """
         {
@@ -362,7 +323,8 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     val listener = OnSourceDataLoadedListener {
       if (it.type == SourceDataType.METADATA && it.id == SOURCE_ID) {
-        answerList.add(testSource.data)
+        // Plain json string data getter is not supported due to performance consideration.
+        assertNull(testSource.data)
         latch.countDown()
       }
     }
@@ -377,17 +339,12 @@ class GeoJsonSourceTest : BaseStyleTest() {
     if (!latch.await(LATCH_MAX_TIME_MS, TimeUnit.MILLISECONDS)) {
       throw TimeoutException()
     }
-    assertEquals(2, answerList.size)
-    assertEquals("", answerList[0])
-    // Plain json string data getter is not supported due to performance consideration.
-    assertNull(answerList[1])
     mapboxMap.removeOnSourceDataLoadedListener(listener)
   }
 
   @Test
   fun featureCollectionTest() {
-    val latch = CountDownLatch(2)
-    val answerList = mutableListOf<String?>()
+    val latch = CountDownLatch(1)
     val featureCollection = FeatureCollection.fromJson(
       """
         {
@@ -395,7 +352,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
           "features": [
             {
               "type": "Feature",
-              "properties": {},
               "geometry": {
                 "type": "Point",
                 "coordinates": [102.0, 0.5]
@@ -403,7 +359,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
             },
             {
               "type": "Feature",
-              "properties": {},
               "geometry": {
                 "type": "LineString",
                 "coordinates": [
@@ -420,7 +375,8 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     val listener = OnSourceDataLoadedListener {
       if (it.type == SourceDataType.METADATA && it.id == SOURCE_ID) {
-        answerList.add(testSource.data)
+        // Plain json string data getter is not supported due to performance consideration.
+        assertEquals(null, testSource.data)
         latch.countDown()
       }
     }
@@ -435,17 +391,12 @@ class GeoJsonSourceTest : BaseStyleTest() {
     if (!latch.await(LATCH_MAX_TIME_MS, TimeUnit.MILLISECONDS)) {
       throw TimeoutException()
     }
-    assertEquals(2, answerList.size)
-    assertEquals("", answerList[0])
-    // Plain json string data getter is not supported due to performance consideration.
-    assertNull(answerList[1])
     mapboxMap.removeOnSourceDataLoadedListener(listener)
   }
 
   @Test
   fun geometryTest() {
-    val latch = CountDownLatch(2)
-    val answerList = mutableListOf<String?>()
+    val latch = CountDownLatch(1)
     val feature = Feature.fromJson(
       """
         {
@@ -465,7 +416,8 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     val listener = OnSourceDataLoadedListener {
       if (it.type == SourceDataType.METADATA && it.id == SOURCE_ID) {
-        answerList.add(testSource.data)
+        // Plain json string data getter is not supported due to performance consideration.
+        assertEquals(null, testSource.data)
         latch.countDown()
       }
     }
@@ -480,17 +432,12 @@ class GeoJsonSourceTest : BaseStyleTest() {
     if (!latch.await(LATCH_MAX_TIME_MS, TimeUnit.MILLISECONDS)) {
       throw TimeoutException()
     }
-    assertEquals(2, answerList.size)
-    assertEquals("", answerList[0])
-    // Plain json string data getter is not supported due to performance consideration.
-    assertNull(answerList[1])
     mapboxMap.removeOnSourceDataLoadedListener(listener)
   }
 
   @Test
   fun featureAfterBindTest() {
-    val latch = CountDownLatch(2)
-    val answerList = mutableListOf<String?>()
+    val latch = CountDownLatch(1)
     val feature = Feature.fromJson(
       """
         {
@@ -510,7 +457,8 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     val listener = OnSourceDataLoadedListener {
       if (it.type == SourceDataType.METADATA && it.id == SOURCE_ID) {
-        answerList.add(testSource.data)
+        // Plain json string data getter is not supported due to performance consideration.
+        assertEquals(null, testSource.data)
         latch.countDown()
       }
     }
@@ -526,17 +474,12 @@ class GeoJsonSourceTest : BaseStyleTest() {
     if (!latch.await(LATCH_MAX_TIME_MS, TimeUnit.MILLISECONDS)) {
       throw TimeoutException()
     }
-    assertEquals(2, answerList.size)
-    assertEquals("", answerList[0])
-    // Plain json string data getter is not supported due to performance consideration.
-    assertNull(answerList[1])
     mapboxMap.removeOnSourceDataLoadedListener(listener)
   }
 
   @Test
   fun featureCollectionAfterBindTest() {
-    val latch = CountDownLatch(2)
-    val answerList = mutableListOf<String?>()
+    val latch = CountDownLatch(1)
     val featureCollection = FeatureCollection.fromJson(
       """
         {
@@ -544,7 +487,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
           "features": [
             {
               "type": "Feature",
-              "properties": {},
               "geometry": {
                 "type": "Point",
                 "coordinates": [102.0, 0.5]
@@ -552,7 +494,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
             },
             {
               "type": "Feature",
-              "properties": {},
               "geometry": {
                 "type": "LineString",
                 "coordinates": [
@@ -569,7 +510,8 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     val listener = OnSourceDataLoadedListener {
       if (it.type == SourceDataType.METADATA && it.id == SOURCE_ID) {
-        answerList.add(testSource.data)
+        // Plain json string data getter is not supported due to performance consideration.
+        assertEquals(null, testSource.data)
         latch.countDown()
       }
     }
@@ -585,17 +527,12 @@ class GeoJsonSourceTest : BaseStyleTest() {
     if (!latch.await(LATCH_MAX_TIME_MS, TimeUnit.MILLISECONDS)) {
       throw TimeoutException()
     }
-    assertEquals(2, answerList.size)
-    assertEquals("", answerList[0])
-    // Plain json string data getter is not supported due to performance consideration.
-    assertNull(answerList[1])
     mapboxMap.removeOnSourceDataLoadedListener(listener)
   }
 
   @Test
   fun geometryAfterBindTest() {
-    val latch = CountDownLatch(2)
-    val answerList = mutableListOf<String?>()
+    val latch = CountDownLatch(1)
     val feature = Feature.fromJson(
       """
         {
@@ -615,7 +552,8 @@ class GeoJsonSourceTest : BaseStyleTest() {
     }
     val listener = OnSourceDataLoadedListener {
       if (it.type == SourceDataType.METADATA && it.id == SOURCE_ID) {
-        answerList.add(testSource.data)
+        // Plain json string data getter is not supported due to performance consideration.
+        assertEquals(null, testSource.data)
         latch.countDown()
       }
     }
@@ -631,10 +569,6 @@ class GeoJsonSourceTest : BaseStyleTest() {
     if (!latch.await(LATCH_MAX_TIME_MS, TimeUnit.MILLISECONDS)) {
       throw TimeoutException()
     }
-    assertEquals(2, answerList.size)
-    assertEquals("", answerList[0])
-    // Plain json string data getter is not supported due to performance consideration.
-    assertNull(answerList[1])
     mapboxMap.removeOnSourceDataLoadedListener(listener)
   }
 
@@ -658,7 +592,7 @@ class GeoJsonSourceTest : BaseStyleTest() {
     const val TEST_URI = "https://raw.githubusercontent.com/mapbox/mapbox-gl-native-android/master/MapboxGLAndroidSDKTestApp/src/main/assets/earthquakes.geojson"
     const val SOURCE_ID = "testId"
     val TEST_GEOJSON = FeatureCollection.fromFeatures(listOf()).toJson()
-    const val LATCH_MAX_TIME_MS = 10_000L
+    const val LATCH_MAX_TIME_MS = 5_000L
   }
 }
 

--- a/extension-style/api/extension-style.api
+++ b/extension-style/api/extension-style.api
@@ -3666,8 +3666,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/Encoding : 
 
 public final class com/mapbox/maps/extension/style/sources/generated/GeoJsonSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;)V
-	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;Lcom/mapbox/geojson/GeoJson;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun bindTo (Lcom/mapbox/maps/extension/style/StyleInterface;)V
 	public final fun data (Ljava/lang/String;)Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource;
 	public final fun feature (Lcom/mapbox/geojson/Feature;)Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource;
@@ -3743,7 +3742,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/GeoJsonSour
 
 public final class com/mapbox/maps/extension/style/sources/generated/ImageSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/ImageSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/ImageSource$Builder;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/ImageSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun coordinates (Ljava/util/List;)Lcom/mapbox/maps/extension/style/sources/generated/ImageSource;
 	public final fun getCoordinates ()Ljava/util/List;
 	public final fun getPrefetchZoomDelta ()Ljava/lang/Long;
@@ -3773,7 +3772,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/ImageSource
 
 public final class com/mapbox/maps/extension/style/sources/generated/RasterDemSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/RasterDemSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterDemSource$Builder;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterDemSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAttribution ()Ljava/lang/String;
 	public final fun getBounds ()Ljava/util/List;
 	public final fun getEncoding ()Lcom/mapbox/maps/extension/style/sources/generated/Encoding;
@@ -3856,7 +3855,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/RasterDemSo
 
 public final class com/mapbox/maps/extension/style/sources/generated/RasterSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/RasterSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterSource$Builder;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAttribution ()Ljava/lang/String;
 	public final fun getBounds ()Ljava/util/List;
 	public final fun getMaxOverscaleFactorForParentTiles ()Ljava/lang/Long;
@@ -3947,7 +3946,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/Scheme : ja
 
 public final class com/mapbox/maps/extension/style/sources/generated/VectorSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/VectorSource$Companion;
-	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/VectorSource$Builder;)V
+	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/VectorSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAttribution ()Ljava/lang/String;
 	public final fun getBounds ()Ljava/util/List;
 	public final fun getMaxOverscaleFactorForParentTiles ()Ljava/lang/Long;

--- a/extension-style/api/extension-style.api
+++ b/extension-style/api/extension-style.api
@@ -3666,7 +3666,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/Encoding : 
 
 public final class com/mapbox/maps/extension/style/sources/generated/GeoJsonSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Companion;
-	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource$Builder;)V
 	public fun bindTo (Lcom/mapbox/maps/extension/style/StyleInterface;)V
 	public final fun data (Ljava/lang/String;)Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource;
 	public final fun feature (Lcom/mapbox/geojson/Feature;)Lcom/mapbox/maps/extension/style/sources/generated/GeoJsonSource;
@@ -3742,7 +3742,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/GeoJsonSour
 
 public final class com/mapbox/maps/extension/style/sources/generated/ImageSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/ImageSource$Companion;
-	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/ImageSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/ImageSource$Builder;)V
 	public final fun coordinates (Ljava/util/List;)Lcom/mapbox/maps/extension/style/sources/generated/ImageSource;
 	public final fun getCoordinates ()Ljava/util/List;
 	public final fun getPrefetchZoomDelta ()Ljava/lang/Long;
@@ -3772,7 +3772,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/ImageSource
 
 public final class com/mapbox/maps/extension/style/sources/generated/RasterDemSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/RasterDemSource$Companion;
-	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterDemSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterDemSource$Builder;)V
 	public final fun getAttribution ()Ljava/lang/String;
 	public final fun getBounds ()Ljava/util/List;
 	public final fun getEncoding ()Lcom/mapbox/maps/extension/style/sources/generated/Encoding;
@@ -3855,7 +3855,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/RasterDemSo
 
 public final class com/mapbox/maps/extension/style/sources/generated/RasterSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/RasterSource$Companion;
-	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/RasterSource$Builder;)V
 	public final fun getAttribution ()Ljava/lang/String;
 	public final fun getBounds ()Ljava/util/List;
 	public final fun getMaxOverscaleFactorForParentTiles ()Ljava/lang/Long;
@@ -3946,7 +3946,7 @@ public final class com/mapbox/maps/extension/style/sources/generated/Scheme : ja
 
 public final class com/mapbox/maps/extension/style/sources/generated/VectorSource : com/mapbox/maps/extension/style/sources/Source {
 	public static final field Companion Lcom/mapbox/maps/extension/style/sources/generated/VectorSource$Companion;
-	public synthetic fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/VectorSource$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/mapbox/maps/extension/style/sources/generated/VectorSource$Builder;)V
 	public final fun getAttribution ()Ljava/lang/String;
 	public final fun getBounds ()Ljava/util/List;
 	public final fun getMaxOverscaleFactorForParentTiles ()Ljava/lang/Long;

--- a/extension-style/api/metalava.txt
+++ b/extension-style/api/metalava.txt
@@ -4369,7 +4369,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class GeoJsonSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public GeoJsonSource(com.mapbox.maps.extension.style.sources.generated.GeoJsonSource.Builder builder);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource data(String value);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource feature(com.mapbox.geojson.Feature value);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource featureCollection(com.mapbox.geojson.FeatureCollection value);
@@ -4459,7 +4458,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class ImageSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public ImageSource(com.mapbox.maps.extension.style.sources.generated.ImageSource.Builder builder);
     method public com.mapbox.maps.extension.style.sources.generated.ImageSource coordinates(java.util.List<? extends java.util.List<java.lang.Double>> value);
     method public java.util.List<java.util.List<java.lang.Double>>? getCoordinates();
     method public Long? getPrefetchZoomDelta();
@@ -4493,7 +4491,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class RasterDemSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public RasterDemSource(com.mapbox.maps.extension.style.sources.generated.RasterDemSource.Builder builder);
     method public String? getAttribution();
     method public java.util.List<java.lang.Double>? getBounds();
     method public com.mapbox.maps.extension.style.sources.generated.Encoding? getEncoding();
@@ -4583,7 +4580,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class RasterSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public RasterSource(com.mapbox.maps.extension.style.sources.generated.RasterSource.Builder builder);
     method public String? getAttribution();
     method public java.util.List<java.lang.Double>? getBounds();
     method public Long? getMaxOverscaleFactorForParentTiles();
@@ -4680,7 +4676,6 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class VectorSource extends com.mapbox.maps.extension.style.sources.Source {
-    ctor public VectorSource(com.mapbox.maps.extension.style.sources.generated.VectorSource.Builder builder);
     method public String? getAttribution();
     method public java.util.List<java.lang.Double>? getBounds();
     method public Long? getMaxOverscaleFactorForParentTiles();

--- a/extension-style/api/metalava.txt
+++ b/extension-style/api/metalava.txt
@@ -4369,6 +4369,7 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class GeoJsonSource extends com.mapbox.maps.extension.style.sources.Source {
+    ctor @Deprecated public GeoJsonSource(com.mapbox.maps.extension.style.sources.generated.GeoJsonSource.Builder builder);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource data(String value);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource feature(com.mapbox.geojson.Feature value);
     method public com.mapbox.maps.extension.style.sources.generated.GeoJsonSource featureCollection(com.mapbox.geojson.FeatureCollection value);
@@ -4458,6 +4459,7 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class ImageSource extends com.mapbox.maps.extension.style.sources.Source {
+    ctor public ImageSource(com.mapbox.maps.extension.style.sources.generated.ImageSource.Builder builder);
     method public com.mapbox.maps.extension.style.sources.generated.ImageSource coordinates(java.util.List<? extends java.util.List<java.lang.Double>> value);
     method public java.util.List<java.util.List<java.lang.Double>>? getCoordinates();
     method public Long? getPrefetchZoomDelta();
@@ -4491,6 +4493,7 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class RasterDemSource extends com.mapbox.maps.extension.style.sources.Source {
+    ctor public RasterDemSource(com.mapbox.maps.extension.style.sources.generated.RasterDemSource.Builder builder);
     method public String? getAttribution();
     method public java.util.List<java.lang.Double>? getBounds();
     method public com.mapbox.maps.extension.style.sources.generated.Encoding? getEncoding();
@@ -4580,6 +4583,7 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class RasterSource extends com.mapbox.maps.extension.style.sources.Source {
+    ctor public RasterSource(com.mapbox.maps.extension.style.sources.generated.RasterSource.Builder builder);
     method public String? getAttribution();
     method public java.util.List<java.lang.Double>? getBounds();
     method public Long? getMaxOverscaleFactorForParentTiles();
@@ -4676,6 +4680,7 @@ package com.mapbox.maps.extension.style.sources.generated {
   }
 
   public final class VectorSource extends com.mapbox.maps.extension.style.sources.Source {
+    ctor public VectorSource(com.mapbox.maps.extension.style.sources.generated.VectorSource.Builder builder);
     method public String? getAttribution();
     method public java.util.List<java.lang.Double>? getBounds();
     method public Long? getMaxOverscaleFactorForParentTiles();

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -33,20 +33,13 @@ import com.mapbox.maps.logW
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#geojson)
  *
  */
-class GeoJsonSource : Source {
-  private constructor(builder: Builder) : super(builder.sourceId) {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
-    initGeoJson = builder.geoJson
-    initData = builder.data
-  }
+class GeoJsonSource private constructor(builder: Builder): Source(builder.sourceId) { 
+  private var initGeoJson: GeoJson? = builder.geoJson
+  private var initData: String? = builder.data
 
   private val workerHandler by lazy {
     Handler(workerThread.looper)
   }
-
-  private var initGeoJson: GeoJson? = null
-  private var initData: String? = null
 
   private fun setGeoJson(geoJson: GeoJson) {
     workerHandler.removeCallbacksAndMessages(null)
@@ -81,6 +74,11 @@ class GeoJsonSource : Source {
       setData(it)
       initData = null
     }
+  }
+
+  init {
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   /**
@@ -403,12 +401,6 @@ class GeoJsonSource : Source {
     // Properties that only settable after the source is added to the style.
     internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
-    init {
-      // set default data to allow empty data source.
-      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
-      properties[propertyValue.propertyName] = propertyValue
-    }
-
     /**
      * A URL to a GeoJSON file, or inline GeoJSON.
      */
@@ -645,6 +637,9 @@ class GeoJsonSource : Source {
      * @return the GeoJsonSource
      */
     fun build(): GeoJsonSource {
+      // set default data to allow empty data source.
+      val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))
+      properties[propertyValue.propertyName] = propertyValue
       return GeoJsonSource(this)
     }
   }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -34,13 +34,14 @@ import com.mapbox.maps.logW
  *
  */
 class GeoJsonSource : Source {
-  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
+  @Deprecated("Use builder instead", level = DeprecationLevel.ERROR)
   constructor(builder: Builder) : super(builder.sourceId) {
-      sourceProperties.putAll(builder.properties)
-      volatileSourceProperties.putAll(builder.volatileProperties)
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
     initGeoJson = builder.geoJson
     initData = builder.data
   }
+
   private var initGeoJson: GeoJson?
   private var initData: String?
 
@@ -638,7 +639,7 @@ class GeoJsonSource : Source {
      *
      * @return the GeoJsonSource
      */
-    @SuppressWarnings("deprecation")
+    @Suppress("DEPRECATION_ERROR")
     fun build(): GeoJsonSource {
       // set default data to allow empty data source.
       val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -33,9 +33,16 @@ import com.mapbox.maps.logW
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#geojson)
  *
  */
-class GeoJsonSource private constructor(builder: Builder) : Source(builder.sourceId) {
-  private var initGeoJson: GeoJson? = builder.geoJson
-  private var initData: String? = builder.data
+class GeoJsonSource : Source {
+  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
+  constructor(builder: Builder) : super(builder.sourceId) {
+      sourceProperties.putAll(builder.properties)
+      volatileSourceProperties.putAll(builder.volatileProperties)
+    initGeoJson = builder.geoJson
+    initData = builder.data
+  }
+  private var initGeoJson: GeoJson?
+  private var initData: String?
 
   private val workerHandler by lazy {
     Handler(workerThread.looper)
@@ -74,11 +81,6 @@ class GeoJsonSource private constructor(builder: Builder) : Source(builder.sourc
       setData(it)
       initData = null
     }
-  }
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   /**
@@ -636,6 +638,7 @@ class GeoJsonSource private constructor(builder: Builder) : Source(builder.sourc
      *
      * @return the GeoJsonSource
      */
+    @SuppressWarnings("deprecation")
     fun build(): GeoJsonSource {
       // set default data to allow empty data source.
       val propertyValue = PropertyValue("data", TypeUtils.wrapToValue(""))

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/GeoJsonSource.kt
@@ -33,7 +33,7 @@ import com.mapbox.maps.logW
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#geojson)
  *
  */
-class GeoJsonSource private constructor(builder: Builder): Source(builder.sourceId) { 
+class GeoJsonSource private constructor(builder: Builder) : Source(builder.sourceId) {
   private var initGeoJson: GeoJson? = builder.geoJson
   private var initData: String? = builder.data
 

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -16,13 +16,7 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#image)
  *
  */
-class ImageSource : Source {
-  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
-  constructor(builder: Builder) : super(builder.sourceId) {
-      sourceProperties.putAll(builder.properties)
-      volatileSourceProperties.putAll(builder.volatileProperties)
-  }
-
+class ImageSource(builder: Builder) : Source(builder.sourceId) {
   /**
    * Get the type of the current source as a String.
    */
@@ -103,7 +97,7 @@ class ImageSource : Source {
   class Builder(val sourceId: String) {
     internal val properties = HashMap<String, PropertyValue<*>>()
     // Properties that only settable after the source is added to the style.
-    internal val volatileProperties = HashMap<String, PropertyValue<*>>()
+    private val volatileProperties = HashMap<String, PropertyValue<*>>()
 
     /**
      * URL that points to an image.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -16,11 +16,11 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#image)
  *
  */
-class ImageSource private constructor(builder: Builder) : Source(builder.sourceId) {
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
+class ImageSource : Source {
+  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
+  constructor(builder: Builder) : super(builder.sourceId) {
+      sourceProperties.putAll(builder.properties)
+      volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -17,6 +17,11 @@ import java.util.*
  *
  */
 class ImageSource(builder: Builder) : Source(builder.sourceId) {
+  init {
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
+  }
+
   /**
    * Get the type of the current source as a String.
    */
@@ -97,7 +102,7 @@ class ImageSource(builder: Builder) : Source(builder.sourceId) {
   class Builder(val sourceId: String) {
     internal val properties = HashMap<String, PropertyValue<*>>()
     // Properties that only settable after the source is added to the style.
-    private val volatileProperties = HashMap<String, PropertyValue<*>>()
+    internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
     /**
      * URL that points to an image.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -16,9 +16,8 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#image)
  *
  */
-class ImageSource(builder: Builder) : Source(builder.sourceId) {
-
-  init {
+class ImageSource : Source {
+  private constructor(builder: Builder) : super(builder.sourceId) {
     sourceProperties.putAll(builder.properties)
     volatileSourceProperties.putAll(builder.volatileProperties)
   }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -16,7 +16,7 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#image)
  *
  */
-class ImageSource private constructor(builder: Builder): Source(builder.sourceId) { 
+class ImageSource private constructor(builder: Builder) : Source(builder.sourceId) {
 
   init {
     sourceProperties.putAll(builder.properties)

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/ImageSource.kt
@@ -16,8 +16,9 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#image)
  *
  */
-class ImageSource : Source {
-  private constructor(builder: Builder) : super(builder.sourceId) {
+class ImageSource private constructor(builder: Builder): Source(builder.sourceId) { 
+
+  init {
     sourceProperties.putAll(builder.properties)
     volatileSourceProperties.putAll(builder.volatileProperties)
   }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -17,11 +17,11 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster_dem)
  *
  */
-class RasterDemSource private constructor(builder: Builder) : Source(builder.sourceId) {
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
+class RasterDemSource : Source {
+  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
+  constructor(builder: Builder) : super(builder.sourceId) {
+      sourceProperties.putAll(builder.properties)
+      volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -17,13 +17,7 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster_dem)
  *
  */
-class RasterDemSource : Source {
-  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
-  constructor(builder: Builder) : super(builder.sourceId) {
-      sourceProperties.putAll(builder.properties)
-      volatileSourceProperties.putAll(builder.volatileProperties)
-  }
-
+class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
   /**
    * Get the type of the current source as a String.
    */
@@ -317,7 +311,7 @@ class RasterDemSource : Source {
   class Builder(val sourceId: String) {
     internal val properties = HashMap<String, PropertyValue<*>>()
     // Properties that only settable after the source is added to the style.
-    internal val volatileProperties = HashMap<String, PropertyValue<*>>()
+    private val volatileProperties = HashMap<String, PropertyValue<*>>()
 
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -17,8 +17,9 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster_dem)
  *
  */
-class RasterDemSource : Source {
-  private constructor(builder: Builder) : super(builder.sourceId) {
+class RasterDemSource private constructor(builder: Builder): Source(builder.sourceId) { 
+
+  init {
     sourceProperties.putAll(builder.properties)
     volatileSourceProperties.putAll(builder.volatileProperties)
   }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -17,7 +17,7 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster_dem)
  *
  */
-class RasterDemSource private constructor(builder: Builder): Source(builder.sourceId) { 
+class RasterDemSource private constructor(builder: Builder) : Source(builder.sourceId) {
 
   init {
     sourceProperties.putAll(builder.properties)

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -17,9 +17,8 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster_dem)
  *
  */
-class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
-
-  init {
+class RasterDemSource : Source {
+  private constructor(builder: Builder) : super(builder.sourceId) {
     sourceProperties.putAll(builder.properties)
     volatileSourceProperties.putAll(builder.volatileProperties)
   }
@@ -157,7 +156,7 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
      */
     get() {
       getPropertyValue<String?>("encoding")?.let {
-        return Encoding.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+        return Encoding.valueOf(it.uppercase(Locale.US).replace('-', '_'))
       }
       return null
     }
@@ -521,7 +520,7 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
        */
       get() {
         StyleManager.getStyleSourcePropertyDefaultValue("raster-dem", "encoding").silentUnwrap<String>()?.let {
-          return Encoding.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+          return Encoding.valueOf(it.uppercase(Locale.US).replace('-', '_'))
         }
         return null
       }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterDemSource.kt
@@ -18,6 +18,11 @@ import java.util.*
  *
  */
 class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
+  init {
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
+  }
+
   /**
    * Get the type of the current source as a String.
    */
@@ -311,7 +316,7 @@ class RasterDemSource(builder: Builder) : Source(builder.sourceId) {
   class Builder(val sourceId: String) {
     internal val properties = HashMap<String, PropertyValue<*>>()
     // Properties that only settable after the source is added to the style.
-    private val volatileProperties = HashMap<String, PropertyValue<*>>()
+    internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -18,6 +18,11 @@ import java.util.*
  *
  */
 class RasterSource(builder: Builder) : Source(builder.sourceId) {
+  init {
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
+  }
+
   /**
    * Get the type of the current source as a String.
    */
@@ -311,7 +316,7 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
   class Builder(val sourceId: String) {
     internal val properties = HashMap<String, PropertyValue<*>>()
     // Properties that only settable after the source is added to the style.
-    private val volatileProperties = HashMap<String, PropertyValue<*>>()
+    internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -17,9 +17,8 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster)
  *
  */
-class RasterSource(builder: Builder) : Source(builder.sourceId) {
-
-  init {
+class RasterSource : Source {
+  private constructor(builder: Builder) : super(builder.sourceId) {
     sourceProperties.putAll(builder.properties)
     volatileSourceProperties.putAll(builder.volatileProperties)
   }
@@ -146,7 +145,7 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
      */
     get() {
       getPropertyValue<String?>("scheme")?.let {
-        return Scheme.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+        return Scheme.valueOf(it.uppercase(Locale.US).replace('-', '_'))
       }
       return null
     }
@@ -521,7 +520,7 @@ class RasterSource(builder: Builder) : Source(builder.sourceId) {
        */
       get() {
         StyleManager.getStyleSourcePropertyDefaultValue("raster", "scheme").silentUnwrap<String>()?.let {
-          return Scheme.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+          return Scheme.valueOf(it.uppercase(Locale.US).replace('-', '_'))
         }
         return null
       }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -17,11 +17,11 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster)
  *
  */
-class RasterSource private constructor(builder: Builder) : Source(builder.sourceId) {
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
+class RasterSource : Source {
+  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
+  constructor(builder: Builder) : super(builder.sourceId) {
+      sourceProperties.putAll(builder.properties)
+      volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -17,13 +17,7 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster)
  *
  */
-class RasterSource : Source {
-  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
-  constructor(builder: Builder) : super(builder.sourceId) {
-      sourceProperties.putAll(builder.properties)
-      volatileSourceProperties.putAll(builder.volatileProperties)
-  }
-
+class RasterSource(builder: Builder) : Source(builder.sourceId) {
   /**
    * Get the type of the current source as a String.
    */
@@ -317,7 +311,7 @@ class RasterSource : Source {
   class Builder(val sourceId: String) {
     internal val properties = HashMap<String, PropertyValue<*>>()
     // Properties that only settable after the source is added to the style.
-    internal val volatileProperties = HashMap<String, PropertyValue<*>>()
+    private val volatileProperties = HashMap<String, PropertyValue<*>>()
 
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -17,7 +17,7 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster)
  *
  */
-class RasterSource private constructor(builder: Builder): Source(builder.sourceId) { 
+class RasterSource private constructor(builder: Builder) : Source(builder.sourceId) {
 
   init {
     sourceProperties.putAll(builder.properties)

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterSource.kt
@@ -17,8 +17,9 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster)
  *
  */
-class RasterSource : Source {
-  private constructor(builder: Builder) : super(builder.sourceId) {
+class RasterSource private constructor(builder: Builder): Source(builder.sourceId) { 
+
+  init {
     sourceProperties.putAll(builder.properties)
     volatileSourceProperties.putAll(builder.volatileProperties)
   }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -18,13 +18,7 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector)
  *
  */
-class VectorSource : Source {
-  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
-  constructor(builder: Builder) : super(builder.sourceId) {
-      sourceProperties.putAll(builder.properties)
-      volatileSourceProperties.putAll(builder.volatileProperties)
-  }
-
+class VectorSource(builder: Builder) : Source(builder.sourceId) {
   /**
    * Get the type of the current source as a String.
    */
@@ -327,7 +321,7 @@ class VectorSource : Source {
   class Builder(val sourceId: String) {
     internal val properties = HashMap<String, PropertyValue<*>>()
     // Properties that only settable after the source is added to the style.
-    internal val volatileProperties = HashMap<String, PropertyValue<*>>()
+    private val volatileProperties = HashMap<String, PropertyValue<*>>()
 
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -18,8 +18,9 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector)
  *
  */
-class VectorSource : Source {
-  private constructor(builder: Builder) : super(builder.sourceId) {
+class VectorSource private constructor(builder: Builder): Source(builder.sourceId) { 
+
+  init {
     sourceProperties.putAll(builder.properties)
     volatileSourceProperties.putAll(builder.volatileProperties)
   }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -19,6 +19,11 @@ import java.util.*
  *
  */
 class VectorSource(builder: Builder) : Source(builder.sourceId) {
+  init {
+    sourceProperties.putAll(builder.properties)
+    volatileSourceProperties.putAll(builder.volatileProperties)
+  }
+
   /**
    * Get the type of the current source as a String.
    */
@@ -321,7 +326,7 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
   class Builder(val sourceId: String) {
     internal val properties = HashMap<String, PropertyValue<*>>()
     // Properties that only settable after the source is added to the style.
-    private val volatileProperties = HashMap<String, PropertyValue<*>>()
+    internal val volatileProperties = HashMap<String, PropertyValue<*>>()
 
     /**
      * A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -18,11 +18,11 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector)
  *
  */
-class VectorSource private constructor(builder: Builder) : Source(builder.sourceId) {
-
-  init {
-    sourceProperties.putAll(builder.properties)
-    volatileSourceProperties.putAll(builder.volatileProperties)
+class VectorSource : Source {
+  @Deprecated("Use builder instead", level = DeprecationLevel.WARNING)
+  constructor(builder: Builder) : super(builder.sourceId) {
+      sourceProperties.putAll(builder.properties)
+      volatileSourceProperties.putAll(builder.volatileProperties)
   }
 
   /**

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -18,9 +18,8 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector)
  *
  */
-class VectorSource(builder: Builder) : Source(builder.sourceId) {
-
-  init {
+class VectorSource : Source {
+  private constructor(builder: Builder) : super(builder.sourceId) {
     sourceProperties.putAll(builder.properties)
     volatileSourceProperties.putAll(builder.volatileProperties)
   }
@@ -94,7 +93,7 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
      */
     get() {
       getPropertyValue<String?>("scheme")?.let {
-        return Scheme.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+        return Scheme.valueOf(it.uppercase(Locale.US).replace('-', '_'))
       }
       return null
     }
@@ -511,7 +510,7 @@ class VectorSource(builder: Builder) : Source(builder.sourceId) {
        */
       get() {
         StyleManager.getStyleSourcePropertyDefaultValue("vector", "scheme").silentUnwrap<String>()?.let {
-          return Scheme.valueOf(it.toUpperCase(Locale.US).replace('-', '_'))
+          return Scheme.valueOf(it.uppercase(Locale.US).replace('-', '_'))
         }
         return null
       }

--- a/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
+++ b/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/VectorSource.kt
@@ -18,7 +18,7 @@ import java.util.*
  * @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#vector)
  *
  */
-class VectorSource private constructor(builder: Builder): Source(builder.sourceId) { 
+class VectorSource private constructor(builder: Builder) : Source(builder.sourceId) {
 
   init {
     sourceProperties.putAll(builder.properties)


### PR DESCRIPTION
### Summary of changes

Source constructor visibility changed to private, users should use Builder class instead.

### User impact (optional)

Usage of e.g. GeoJsonSource(builder) should be changed to GeoJsonSource.Builder().build()

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
