### PR TITLE
MAPSAND-709 Remember GesturesManager state during gesture handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
+
+## Bug fixes 🐞
 * Original gesture settings should be maintained after map operations (such as panning the map) complete. ([1989](https://github.com/mapbox/mapbox-maps-android/pull/1989))
 
 # 10.11.0-rc.1 January 26, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 # main
-
+* Original gesture settings should be maintained after map operations (such as panning the map) complete. ([1989](https://github.com/mapbox/mapbox-maps-android/pull/1989))
 
 # 10.11.0-rc.1 January 26, 2023
 ## Features ✨ and improvements 🏁

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GestureState.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GestureState.kt
@@ -10,47 +10,29 @@ internal class GestureState(private val gesturesManager: AndroidGesturesManager)
     Shove,
   }
 
-  private val rememberedGestureSettings = mutableMapOf<Type, Boolean>()
+  private val savedGestureEnabledMap = mutableMapOf<Type, Boolean>()
 
-  fun saveAndDisable(gesture: Type): Boolean {
-    return when (gesture) {
-      Type.DoubleTap -> {
-        gesturesManager.moveGestureDetector.isEnabled.also {
-          gesturesManager.moveGestureDetector.isEnabled = false
-        }
-      }
-      Type.Scale -> {
-        gesturesManager.rotateGestureDetector.isEnabled.also {
-          gesturesManager.rotateGestureDetector.isEnabled = false
-        }
-      }
-      Type.ScaleQuickZoom -> {
-        gesturesManager.moveGestureDetector.isEnabled.also {
-          gesturesManager.moveGestureDetector.isEnabled = false
-        }
-      }
-      Type.Shove -> {
-        gesturesManager.moveGestureDetector.isEnabled.also {
-          gesturesManager.moveGestureDetector.isEnabled = false
-        }
-      }
-    }.also {
-      rememberedGestureSettings[gesture] = it
+  fun saveAndDisable(gesture: Type): Boolean =
+    when (gesture) {
+      Type.Scale -> gesturesManager.rotateGestureDetector
+      else -> gesturesManager.moveGestureDetector
+    }.let { detector ->
+      val state = detector.isEnabled
+      savedGestureEnabledMap[gesture] = state
+      detector.isEnabled = false
+      state
     }
-  }
 
   fun restore(gesture: Type) {
-    rememberedGestureSettings.remove(gesture)?.let {
+    savedGestureEnabledMap.remove(gesture)?.let { state ->
       when (gesture) {
-        Type.DoubleTap -> gesturesManager.moveGestureDetector.isEnabled = it
-        Type.Scale -> gesturesManager.rotateGestureDetector.isEnabled = it
-        Type.ScaleQuickZoom -> gesturesManager.moveGestureDetector.isEnabled = it
-        Type.Shove -> gesturesManager.moveGestureDetector.isEnabled = it
-      }
+        Type.Scale -> gesturesManager.rotateGestureDetector
+        else -> gesturesManager.moveGestureDetector
+      }.isEnabled = state
     }
   }
 
   fun peek(gesture: Type): Boolean? {
-    return rememberedGestureSettings[gesture]
+    return savedGestureEnabledMap[gesture]
   }
 }

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GestureState.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GestureState.kt
@@ -1,0 +1,56 @@
+package com.mapbox.maps.plugin.gestures
+
+import com.mapbox.android.gestures.AndroidGesturesManager
+
+internal class GestureState(private val gesturesManager: AndroidGesturesManager) {
+  enum class Type {
+    DoubleTap,
+    Scale,
+    ScaleQuickZoom,
+    Shove,
+  }
+
+  private val rememberedGestureSettings = mutableMapOf<Type, Boolean>()
+
+  fun saveAndDisable(gesture: Type): Boolean {
+    return when (gesture) {
+      Type.DoubleTap -> {
+        gesturesManager.moveGestureDetector.isEnabled.also {
+          gesturesManager.moveGestureDetector.isEnabled = false
+        }
+      }
+      Type.Scale -> {
+        gesturesManager.rotateGestureDetector.isEnabled.also {
+          gesturesManager.rotateGestureDetector.isEnabled = false
+        }
+      }
+      Type.ScaleQuickZoom -> {
+        gesturesManager.moveGestureDetector.isEnabled.also {
+          gesturesManager.moveGestureDetector.isEnabled = false
+        }
+      }
+      Type.Shove -> {
+        gesturesManager.moveGestureDetector.isEnabled.also {
+          gesturesManager.moveGestureDetector.isEnabled = false
+        }
+      }
+    }.also {
+      rememberedGestureSettings[gesture] = it
+    }
+  }
+
+  fun restore(gesture: Type) {
+    rememberedGestureSettings.remove(gesture)?.let {
+      when (gesture) {
+        Type.DoubleTap -> gesturesManager.moveGestureDetector.isEnabled = it
+        Type.Scale -> gesturesManager.rotateGestureDetector.isEnabled = it
+        Type.ScaleQuickZoom -> gesturesManager.moveGestureDetector.isEnabled = it
+        Type.Shove -> gesturesManager.moveGestureDetector.isEnabled = it
+      }
+    }
+  }
+
+  fun peek(gesture: Type): Boolean? {
+    return rememberedGestureSettings[gesture]
+  }
+}

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -490,7 +490,6 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
 
   private fun doubleTapFinished() {
     if (doubleTapRegistered) {
-      // re-enable the move detector in case of double tap
       gestureState.restore(GestureState.Type.DoubleTap)
       doubleTapRegistered = false
     }
@@ -588,10 +587,7 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
     velocityX: Float,
     velocityY: Float
   ) {
-    if (quickZoom)
-      gestureState.restore(GestureState.Type.ScaleQuickZoom)
-    else
-      gestureState.restore(GestureState.Type.Scale)
+    gestureState.restore(if (quickZoom) GestureState.Type.ScaleQuickZoom else GestureState.Type.Scale)
 
     notifyOnScaleEndListeners(detector)
 
@@ -732,8 +728,6 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
             // do not scale in case we're preferring to start rotation
             return false
           }
-
-          // disable rotate gesture when scale is detected first
           gestureState.saveAndDisable(GestureState.Type.Scale)
         }
       } else {
@@ -1040,7 +1034,6 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
 
     cancelTransitionsIfRequired()
 
-    // disabling move gesture during shove
     gestureState.saveAndDisable(GestureState.Type.Shove)
 
     notifyOnShoveBeginListeners(detector)
@@ -1073,9 +1066,7 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
   internal fun handleShoveEnd(
     detector: ShoveGestureDetector
   ) {
-    // re-enabling move gesture
     gestureState.restore(GestureState.Type.Shove)
-
     notifyOnShoveEndListeners(detector)
   }
 

--- a/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
+++ b/plugin-gestures/src/main/java/com/mapbox/maps/plugin/gestures/GesturesPluginImpl.kt
@@ -1771,20 +1771,18 @@ class GesturesPluginImpl : GesturesPlugin, GesturesSettingsBase, MapStyleObserve
    */
   override fun bind(context: Context, attrs: AttributeSet?, pixelRatio: Float) {
     val gesturesManager = AndroidGesturesManager(context)
-    val gestureState = GestureState(gesturesManager)
-    bind(context, gesturesManager, gestureState, attrs, pixelRatio)
+    bind(context, gesturesManager, attrs, pixelRatio)
   }
 
   // For internal testing.
   internal fun bind(
     context: Context,
     gesturesManager: AndroidGesturesManager,
-    gestureState: GestureState,
     attrs: AttributeSet?,
     pixelRatio: Float
   ) {
     this.gesturesManager = gesturesManager
-    this.gestureState = gestureState
+    this.gestureState = GestureState(gesturesManager)
     this.pixelRatio = pixelRatio
     internalSettings = GesturesAttributeParser.parseGesturesSettings(context, attrs, pixelRatio)
   }

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GestureOptionsTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GestureOptionsTest.kt
@@ -71,6 +71,11 @@ class GestureOptionsTest {
     }
   }
 
+  private fun setupGesturePlugin() {
+    gesturePlugin.bind(context, gestureManager, GestureState(gestureManager), attrs, 1f)
+    gesturePlugin.initialize()
+  }
+
   @After
   fun cleanUp() {
     clearAllMocks()
@@ -78,8 +83,7 @@ class GestureOptionsTest {
 
   @Test
   fun getGestureSettingsPinchToZoomEnabled() {
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertTrue(gesturePlugin.getSettings().pinchToZoomEnabled)
   }
 
@@ -91,15 +95,13 @@ class GestureOptionsTest {
         true
       )
     } returns false
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertFalse(gesturePlugin.getSettings().pinchToZoomEnabled)
   }
 
   @Test
   fun getGestureSettingsRotateEnabled() {
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertTrue(gesturePlugin.getSettings().rotateEnabled)
   }
 
@@ -111,15 +113,13 @@ class GestureOptionsTest {
         true
       )
     } returns false
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertFalse(gesturePlugin.getSettings().rotateEnabled)
   }
 
   @Test
   fun getGestureSettingsPitchEnabled() {
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertTrue(gesturePlugin.getSettings().pitchEnabled)
   }
 
@@ -131,15 +131,13 @@ class GestureOptionsTest {
         true
       )
     } returns false
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertFalse(gesturePlugin.getSettings().pitchEnabled)
   }
 
   @Test
   fun getGestureSettingsScrollEnabled() {
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertTrue(gesturePlugin.getSettings().scrollEnabled)
   }
 
@@ -151,15 +149,13 @@ class GestureOptionsTest {
         true
       )
     } returns false
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertFalse(gesturePlugin.getSettings().scrollEnabled)
   }
 
   @Test
   fun getGestureSettingsQuickZoomEnabled() {
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertTrue(gesturePlugin.getSettings().quickZoomEnabled)
   }
 
@@ -171,15 +167,13 @@ class GestureOptionsTest {
         true
       )
     } returns false
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertFalse(gesturePlugin.getSettings().quickZoomEnabled)
   }
 
   @Test
   fun getGestureSettingsDoubleTapToZoomInEnabled() {
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertTrue(gesturePlugin.getSettings().doubleTapToZoomInEnabled)
   }
 
@@ -191,15 +185,13 @@ class GestureOptionsTest {
         true
       )
     } returns false
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertFalse(gesturePlugin.getSettings().doubleTapToZoomInEnabled)
   }
 
   @Test
   fun getGestureSettingsDoubleTouchToZoomOutEnabled() {
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertTrue(gesturePlugin.getSettings().doubleTouchToZoomOutEnabled)
   }
 
@@ -211,8 +203,7 @@ class GestureOptionsTest {
         true
       )
     } returns false
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertFalse(gesturePlugin.getSettings().doubleTouchToZoomOutEnabled)
   }
 
@@ -224,8 +215,7 @@ class GestureOptionsTest {
         any()
       )
     } returns ScrollMode.HORIZONTAL_AND_VERTICAL.ordinal
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertEquals(gesturePlugin.getSettings().scrollMode, ScrollMode.HORIZONTAL_AND_VERTICAL)
   }
 
@@ -237,8 +227,7 @@ class GestureOptionsTest {
         any()
       )
     } returns ScrollMode.HORIZONTAL.ordinal
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertEquals(gesturePlugin.getSettings().scrollMode, ScrollMode.HORIZONTAL)
   }
 
@@ -250,8 +239,7 @@ class GestureOptionsTest {
         any()
       )
     } returns ScrollMode.VERTICAL.ordinal
-    gesturePlugin.bind(context, gestureManager, attrs, 1f)
-    gesturePlugin.initialize()
+    setupGesturePlugin()
     assertEquals(gesturePlugin.getSettings().scrollMode, ScrollMode.VERTICAL)
   }
 }

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GestureOptionsTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GestureOptionsTest.kt
@@ -72,7 +72,7 @@ class GestureOptionsTest {
   }
 
   private fun setupGesturePlugin() {
-    gesturePlugin.bind(context, gestureManager, GestureState(gestureManager), attrs, 1f)
+    gesturePlugin.bind(context, gestureManager, attrs, 1f)
     gesturePlugin.initialize()
   }
 

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GestureStateTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GestureStateTest.kt
@@ -1,0 +1,101 @@
+package com.mapbox.maps.plugin.gestures
+
+import com.mapbox.android.gestures.AndroidGesturesManager
+import com.mapbox.android.gestures.MoveGestureDetector
+import com.mapbox.android.gestures.RotateGestureDetector
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class GestureStateTest(private val type: GestureState.Type) {
+  private lateinit var gestureState: GestureState
+  private lateinit var moveGestureDetector: MoveGestureDetector
+  private lateinit var rotateGestureDetector: RotateGestureDetector
+
+  @Before
+  fun setup() {
+    val gesturesManager = mockk<AndroidGesturesManager>()
+    moveGestureDetector = mockk()
+    rotateGestureDetector = mockk()
+    every { gesturesManager.moveGestureDetector } returns moveGestureDetector
+    every { gesturesManager.rotateGestureDetector } returns rotateGestureDetector
+    every { moveGestureDetector.isEnabled = any() } just runs
+    every { rotateGestureDetector.isEnabled = any() } just runs
+    gestureState = GestureState(gesturesManager)
+  }
+
+  @Test
+  fun checkPeekReturnsNull() {
+    assertNull(gestureState.peek(type))
+  }
+
+  private fun checkSaveAndDisableWithValue(value: Boolean) {
+    every { moveGestureDetector.isEnabled } returns value
+    every { rotateGestureDetector.isEnabled } returns value
+    gestureState.saveAndDisable(type)
+    assertEquals(value, gestureState.peek(type))
+    when (type) {
+      GestureState.Type.Scale -> verify { rotateGestureDetector.isEnabled = false }
+      else -> verify { moveGestureDetector.isEnabled = false }
+    }
+    assertNotNull(gestureState.peek(type))
+    // Ensure no other gestures were stored.
+    for (t in GestureState.Type.values()) {
+      if (t != type) {
+        assertNull(gestureState.peek(t))
+      }
+    }
+  }
+
+  @Test
+  fun checkSaveAndDisableWhenGestureIsDisabled() {
+    checkSaveAndDisableWithValue(false)
+  }
+
+  @Test
+  fun checkSaveAndDisableWhenGestureIsEnabled() {
+    checkSaveAndDisableWithValue(true)
+  }
+
+  private fun restoreWithValue(value: Boolean) {
+    every { moveGestureDetector.isEnabled } returns value
+    every { rotateGestureDetector.isEnabled } returns value
+    gestureState.saveAndDisable(type)
+    assertEquals(value, gestureState.peek(type))
+    gestureState.restore(type)
+    when (type) {
+      GestureState.Type.Scale -> verify { rotateGestureDetector.isEnabled = value }
+      else -> verify { moveGestureDetector.isEnabled = value }
+    }
+    // There should be no gestures stored of any type.
+    for (t in GestureState.Type.values()) {
+      assertNull(gestureState.peek(t))
+    }
+  }
+
+  @Test
+  fun checkRestoreWhenGestureIsDisabled() {
+    restoreWithValue(false)
+  }
+
+  @Test
+  fun checkRestoreWhenGestureIsEnabled() {
+    restoreWithValue(true)
+  }
+
+  internal companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "for gesture type {0}")
+    fun data() = GestureState.Type.values()
+  }
+}

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
@@ -67,7 +67,6 @@ class GesturesPluginTest {
   private val gestureListener = slot<StandardGestureDetector.StandardOnGestureListener>()
 
   private lateinit var presenter: GesturesPluginImpl
-  private lateinit var gestureState: GestureState
 
   @MapboxExperimental
   @Before
@@ -114,9 +113,8 @@ class GesturesPluginTest {
     every { motionEvent2.y } returns 0.0f
 
     presenter = GesturesPluginImpl(context, attrs, style)
-    gestureState = GestureState(gesturesManager)
 
-    presenter.bind(context, gesturesManager, gestureState, attrs, 1f)
+    presenter.bind(context, gesturesManager, attrs, 1f)
     presenter.onDelegateProvider(mapDelegateProvider)
     every {
       gesturesManager.setStandardGestureListener(capture(gestureListener))
@@ -888,7 +886,6 @@ class GesturesPluginTest {
     val result = presenter.handleShoveBegin(gestureDetector)
     assert(result)
     verify(exactly = 1) { shoveListener.onShoveBegin(any()) }
-    assertEquals(true, gestureState.peek(GestureState.Type.Shove))
     presenter.removeOnShoveListener(shoveListener)
     presenter.removeOnMoveListener(moveListener)
     presenter.handleShoveBegin(gestureDetector)
@@ -923,7 +920,6 @@ class GesturesPluginTest {
     val gestureDetector = mockk<ShoveGestureDetector>(relaxUnitFun = true)
     presenter.handleShoveEnd(gestureDetector)
     verify(exactly = 1) { listener.onShoveEnd(any()) }
-    assertNull(gestureState.peek(GestureState.Type.Shove))
   }
 
   @Test
@@ -1276,7 +1272,6 @@ class IsPointAboveHorizonTest(
     presenter.bind(
       context,
       gesturesManager,
-      GestureState(gesturesManager),
       attrs,
       1f
     )
@@ -1533,7 +1528,7 @@ class FlingGestureTest(
 
     presenter = GesturesPluginImpl(context, attrs, style)
 
-    presenter.bind(context, gesturesManager, GestureState(gesturesManager), attrs, 1f)
+    presenter.bind(context, gesturesManager, attrs, 1f)
     presenter.onDelegateProvider(mapDelegateProvider)
     presenter.initialize()
 

--- a/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
+++ b/plugin-gestures/src/test/java/com/mapbox/maps/plugin/gestures/GesturesPluginTest.kt
@@ -1229,7 +1229,7 @@ class GesturesPluginTest {
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @LooperMode(LooperMode.Mode.PAUSED)
 class IsPointAboveHorizonTest(
-  private val testProjectionStylePropertyValue: StylePropertyValue?,
+  private val testProjectionStylePropertyValue: StylePropertyValue,
   private val testScreenCoordinate: ScreenCoordinate,
   private val testMapSize: Size,
   private val testPixelForCoordinate: ScreenCoordinate,
@@ -1244,7 +1244,7 @@ class IsPointAboveHorizonTest(
   private val mapPluginProviderDelegate: MapPluginProviderDelegate = mockk(relaxUnitFun = true)
   private val mapProjectionDelegate: MapProjectionDelegate = mockk(relaxUnitFun = true)
   private val cameraAnimationsPlugin: CameraAnimationsPlugin = mockk(relaxed = true)
-  private val style: StyleInterface? = mockk()
+  private val style: StyleInterface = mockk()
 
   private lateinit var presenter: GesturesPluginImpl
 
@@ -1272,24 +1272,25 @@ class IsPointAboveHorizonTest(
     every { typedArray.getInt(any(), any()) } returns 2
     every { typedArray.hasValue(any()) } returns true
 
+    presenter = GesturesPluginImpl(context, attrs, style)
+    presenter.bind(
+      context,
+      gesturesManager,
+      GestureState(gesturesManager),
+      attrs,
+      1f
+    )
+
     every { mapDelegateProvider.mapCameraManagerDelegate } returns mapCameraManagerDelegate
     every { mapDelegateProvider.mapTransformDelegate } returns mapTransformDelegate
     every { mapDelegateProvider.mapProjectionDelegate } returns mapProjectionDelegate
     every { mapDelegateProvider.mapPluginProviderDelegate } returns mapPluginProviderDelegate
     every { mapPluginProviderDelegate.getPlugin<CameraAnimationsPlugin>(Plugin.MAPBOX_CAMERA_PLUGIN_ID) } returns cameraAnimationsPlugin
-    every { style?.getStyleProjectionProperty("name") } returns testProjectionStylePropertyValue
+    every { style.getStyleProjectionProperty("name") } returns testProjectionStylePropertyValue
     every { mapTransformDelegate.getSize() } returns testMapSize
     every { mapCameraManagerDelegate.coordinateForPixel(any()) } returns Point.fromLngLat(0.0, 0.0)
     every { mapCameraManagerDelegate.pixelForCoordinate(any()) } returns testPixelForCoordinate
 
-    presenter = GesturesPluginImpl(context, attrs, style!!)
-    presenter.bind(
-      context,
-      gesturesManager,
-      GestureState(presenter.getGesturesManager()),
-      attrs,
-      1f
-    )
     presenter.onDelegateProvider(mapDelegateProvider)
     presenter.initialize()
   }
@@ -1398,13 +1399,6 @@ class IsPointAboveHorizonTest(
         Size(100f, 100f),
         ScreenCoordinate(0.0, 0.0),
         true
-      ),
-      arrayOf(
-        null,
-        ScreenCoordinate(0.0, 0.0),
-        Size(100f, 100f),
-        ScreenCoordinate(0.0, 0.0),
-        false
       ),
       arrayOf(
         StylePropertyValue(


### PR DESCRIPTION
### Summary of changes

`GestureState` class added to save and restore state of gesture handlers during map operations, where gestures are temporarily disabled and later restored when the map operation (e.g. pan, shove, double-tap) complete.

### User impact (optional)

Original gesture settings should be maintained after map operations (such as panning the map) complete.

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [x] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
