### PR TITLE
port gl-native and common bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ Mapbox welcomes participation and contributions from everyone.
 * Fix wrong `onLongTouch` event detected on any map gesture after clicks on ViewAnnotation. ([1954](https://github.com/mapbox/mapbox-maps-android/pull/1954))
 
 
+# 10.11.0
+## Features ✨ and improvements 🏁
+* Skip redundant `MapboxMap.setCamera` updates in `CameraAnimationsPlugin`. ([1909](https://github.com/mapbox/mapbox-maps-android/pull/1909))
+* Improve performance by setting geojson data directly. ([1920](https://github.com/mapbox/mapbox-maps-android/pull/1920))
+* Fix viewport hang when transition to `FollowPuckViewportState` and no new location update is available. ([1929](https://github.com/mapbox/mapbox-maps-android/pull/1929))
+* Avoid unneeded tiles relayout on style change. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Enable the usage of expressions in array values during style parsing, where the member expressions in the array is evaluated to the same type. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Slightly improve quality and performance of the terrain. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Improve performance for style switch use cases by avoiding unneeded tiles re-layout. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+
+## Bug fixes 🐞
+* Fix a bug where `flyTo` animation request invalid tiles from map engine. ([1949](https://github.com/mapbox/mapbox-maps-android/pull/1949))
+* Deprecate `pattern` and `dash` transition properties for layer (e.g. `BackgroundLayer.backgroundPatternTransition`, `FillExtrusionLayer.fillExtrusionPatternTransition`, `FillLayer.fillPatternTransition`, `LineLayer.lineDasharrayTransition`, `LineLayer.linePatternTransition`, ...).  ([1941](https://github.com/mapbox/mapbox-maps-android/pull/1941))
+* Fix terrain tiles missing issue when running in the emulator and some android devices. ([1953](https://github.com/mapbox/mapbox-maps-android/pull/1953))
+* Fix wrong `onLongTouch` event detected on any map gesture after clicks on ViewAnnotation. ([1954](https://github.com/mapbox/mapbox-maps-android/pull/1954))
+* Fix a known issue where `NullPointerException` was thrown when last location was not available. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix flickering issues for the symbols that allow overlap (have text(icon)-allow-overlap: true) with skipping fade-in animation for them. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix data queueing issue when calling API 'setStyleGeoJSONSourceData'. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix flickering terrain on high pitched views. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Clamp inputs in DEMData::get() to prevent OOB Access. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix asset file source threading model - do not use legacy RunLoop, thus do not use ALooper and get rid of an extra thread. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix text visualization when in orthographic mode. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix terrain elevation when a padded dem source is used. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fixes visible tile borders when msaa enabled. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix distance-to-center filtering of symbols when terrain is enabled. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix color transitions in model ligthing. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix terrain placement for model layer when model scale is set to zero. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix geometry tile model layer paint property transition. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix camera bumpiness at the beginning of a drag operation when terrain is enabled. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix disappearing tiles when terrain with a high exaggeration is enabled. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix line-border-color when used with line-trim-offset. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fixes an issue when allow-overlap, ignore-placement , and map rotation-alignment of icon breaks the rendering of symbols on the globe. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Mitigate symbol flickering on source data change during camera animation. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Mitigate OOM caused by Snapshotter API usage. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fixes rare crashes during render feature queries, if the features are located close to each other. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix an issue where the camera would start flickering during subsequent calls to `Map::jumpTo` / `Map::easeTo` with terrain enabled.. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix redundant snapshot capturing that caused excessive memory usage. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Fix incorrect resource type being specified map loading error event data. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+* Original gesture settings should be maintained after map operations (such as panning the map) complete. ([1989](https://github.com/mapbox/mapbox-maps-android/pull/1989))
+
+## Dependencies
+* Update gl-native to v10.11.1, common to v23.3.1. ([1984](https://github.com/mapbox/mapbox-maps-android/pull/1984))
+
 # 10.11.0-rc.1 January 26, 2023
 ## Features ✨ and improvements 🏁
 * Improve performance for style switch use cases by avoiding unneeded tiles re-layout. ([1953](https://github.com/mapbox/mapbox-maps-android/pull/1953))

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -113,8 +113,8 @@ object Versions {
   const val mapboxGestures = "0.8.0"
   const val mapboxJavaServices = "5.4.1"
   const val mapboxBase = "0.8.0"
-  const val mapboxGlNative = "10.11.0-rc.1"
-  const val mapboxCommon = "23.3.0-rc.1"
+  const val mapboxGlNative = "10.11.1"
+  const val mapboxCommon = "23.3.1"
   const val androidxCore = "1.7.0" // last version compatible with kotlin 1.5.31
   const val androidxFragmentTesting = "1.5.0"
   const val androidxAnnotation = "1.1.0"


### PR DESCRIPTION
* bump common to v23.3.0

* update gl-native snapshot

* update gl-native and common

* update changelog

* test gl-native snapshot

* update gl-native to latest v10.11.1

<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: < Link to related issues that will be fixed by this pull request, if they exist >

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
