### PR TITLE
[compose] get annotationManager from PointAnnotationGroup

### DIFF
--- a/extension-compose/src/main/java/com/mapbox/maps/extension/compose/annotation/generated/PointAnnotationGroup.kt
+++ b/extension-compose/src/main/java/com/mapbox/maps/extension/compose/annotation/generated/PointAnnotationGroup.kt
@@ -13,6 +13,7 @@ import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 
@@ -54,6 +55,7 @@ import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
  * @param iconTranslateAnchor Controls the frame of reference for {@link PropertyFactory#iconTranslate}.
  * @param textTranslate Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up. The unit of textTranslate is in density-independent pixels.
  * @param textTranslateAnchor Controls the frame of reference for {@link PropertyFactory#textTranslate}.
+ * @param onAnnotationManagerCreated get pointAnnotationManager for use of annotation id
  * @param onClick Callback to be invoked when one of the [PointAnnotation] in the cluster is clicked. The clicked [PointAnnotation] will be passed as parameter.
  */
 @Composable
@@ -90,6 +92,7 @@ public fun PointAnnotationGroup(
   iconTranslateAnchor: IconTranslateAnchor? = null,
   textTranslate: List<Double>? = null,
   textTranslateAnchor: TextTranslateAnchor? = null,
+  onAnnotationManagerCreated: (PointAnnotationManager) -> Unit = {},
   onClick: (PointAnnotation) -> Boolean = { false },
 ) {
 
@@ -100,6 +103,7 @@ public fun PointAnnotationGroup(
     factory = {
       val annotationManager =
         mapApplier.mapView.annotations.createPointAnnotationManager(annotationConfig)
+      onAnnotationManagerCreated(annotationManager)
       PointAnnotationManagerNode(annotationManager, onClick)
     },
     update = {


### PR DESCRIPTION
 for get featureId to use ViewAnnotation

<!--
Thanks for submitting a pull request!
Please fill out the sections below to complete your submission.
We appreciate your contributions!
-->

### Summary of changes

It doesn't work when using the combination of PointAnnotationGroup clustering and ViewAnotation.

When creating ViewAnnotationOptions, you can specify the featureId in annotatedLayerFeature to associate it with PointAnnotation. At this time, featureId is obtained from the Annotation as the return value when calling PointAnnotation.create().

However, when using the Copmose Extension, the PointAnnotationManager is hidden, so the annotation ID cannot be obtained.

As a workaround, you can remember PointAnnotationManager and access annotations property of PointAnnotationManager to get the annotation ID when needed.

Currently, annotation IDs are randomly generated, but another method is to specify an ID and create an annotation. However, I think this method requires a large scale of change.

Please consider the contents.

<!--
• If this is a new feature, include a short summary on how to use it.
• If this is a bug fix, explain how your contribution resolves the problem.
• Include a screenshot or gif if applicable
-->

### User impact (optional)

<!--
If this PR introduces user-facing changes, please note them here.
-->


## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
    <!--
        | Before | After |
        | ----- | ----- |
        | <img src="" width = 250/> | <img src="" width = 250/> |
        or
        | <video src="" width = 250/> | <video src="" width = 250/> |
    -->
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc).
 - [ ] Add example if relevant.
 - [ ] Document any changes to public APIs.
 - [ ] Run `make update-api` to update generated api files, if there's public API changes, otherwise the `verify-api-*` CI steps might fail.
 - [ ] Update [CHANGELOG.md](../CHANGELOG.md) or use the label 'skip changelog', otherwise `check changelog` CI step will fail.
 - [ ] If this PR is a `v10.[version]` release branch fix / enhancement, merge it to `main` firstly and then port to `v10.[version]` release branch.

Fixes: #2344

PRs must be submitted under the terms of our Contributor License Agreement [CLA](https://github.com/mapbox/mapbox-maps-android/blob/main/CONTRIBUTING.md#contributor-license-agreement).
