### PR TITLE
use android-core as GL Native snapshot artifact

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ japicmp = "0.4.1"
 # Dependencies
 
 # GlNative and Common are used by the convention plugin
-mapboxGlNative = "11.8.0-beta.1"
+mapboxGlNative = "11.8.0-beta.1" #change GlNative.snapshotArtifact if you use snapshots older than TODO, ref: https://github.com/mapbox/mapbox-maps-android/pull/2499
 mapboxCommon = "24.8.0-beta.1"
 
 mapboxBase = "0.11.0"

--- a/mapbox-convention-plugin/src/main/kotlin/com/mapbox/maps/gradle/plugins/internal/MapboxDependencies.kt
+++ b/mapbox-convention-plugin/src/main/kotlin/com/mapbox/maps/gradle/plugins/internal/MapboxDependencies.kt
@@ -14,7 +14,7 @@ internal object MapboxDependencies {
     artifact = "android-core",
     versionRef = "mapboxGlNative",
     sourceProject = ":maps-core",
-    snapshotArtifact = "android-core-internal",
+    snapshotArtifact = "android-core", // use "android-core-internal" for snapshots older than TODO, ref: https://github.com/mapbox/mapbox-maps-android/pull/2499
     supportsNdkVariant = true
   )
 }


### PR DESCRIPTION
Blocked by:
1. https://github.com/mapbox/mapbox-sdk/pull/553
2. Releasing the first snapshot with the new artifact ID.