### PR TITLE
Forward coding-agent id into test app for connectedAndroidTest verification

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,17 @@ android {
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    // Optional coding-agent identifier (e.g. `-Pmapbox.agent=claude-code`), forwarded at runtime
+    // to Common's MapboxAgentContext so outbound requests can be tagged for agent-driven traffic
+    // measurement. Defaults to an empty string, which is treated as "no agent" and is a no-op.
+    val mapboxAgentId = if (project.hasProperty("mapbox.agent")) {
+      (project.property("mapbox.agent") as String)
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+    } else {
+      ""
+    }
+    buildConfigField("String", "MAPBOX_AGENT", String.format("\"%s\"", mapboxAgentId))
     ndk {
       val abi: String =
         if (System.getenv("ANDROID_ABI") != null) System.getenv("ANDROID_ABI") else ""

--- a/app/src/main/java/com/mapbox/maps/testapp/AgentTelemetryForwarding.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/AgentTelemetryForwarding.kt
@@ -1,0 +1,24 @@
+package com.mapbox.maps.testapp
+
+/**
+ * Forwards [agentId] via [setAgentId] when it is non-empty.
+ *
+ * [agentId] is expected to come from [BuildConfig.MAPBOX_AGENT], which is populated at build
+ * time from the optional `-Pmapbox.agent=<id>` Gradle property (see `app/build.gradle.kts`).
+ * When that property is not supplied on the command line, [BuildConfig.MAPBOX_AGENT] defaults to
+ * an empty string and this function is a no-op, so normal (non-test) builds are unaffected.
+ *
+ * The forwarding logic itself is kept free of any Mapbox Common SDK dependency so that it can be
+ * unit tested in isolation; callers supply [setAgentId] to perform the actual forwarding, e.g.:
+ *
+ * ```
+ * forwardAgentIdIfPresent(BuildConfig.MAPBOX_AGENT) { agentId ->
+ *   MapboxAgentContextFactory.getInstance().setMapboxAgentId(agentId)
+ * }
+ * ```
+ */
+internal fun forwardAgentIdIfPresent(agentId: String, setAgentId: (String) -> Unit) {
+  if (agentId.isNotEmpty()) {
+    setAgentId(agentId)
+  }
+}

--- a/app/src/main/java/com/mapbox/maps/testapp/MapboxApplication.kt
+++ b/app/src/main/java/com/mapbox/maps/testapp/MapboxApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.os.StrictMode
 import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.annotation.MapboxExperimental
+import com.mapbox.common.MapboxAgentContextFactory
 import com.mapbox.common.MapboxTracing
 import com.mapbox.common.geofencing.GeofencingError
 import com.mapbox.common.geofencing.GeofencingEvent
@@ -66,8 +67,25 @@ class MapboxApplication : Application() {
     // Enable all traces. Useful when capturing Perfetto traces
     MapboxTracing.enableAll()
     initializeStrictMode()
+    forwardMapboxAgentId()
     if (ENABLE_BACKGROUND_GEOFENCING) {
       registerGeofencingObserver()
+    }
+  }
+
+  /**
+   * Forwards the compile-time Mapbox agent id (see `-Pmapbox.agent=<id>` and
+   * [BuildConfig.MAPBOX_AGENT]) into Common's process-wide `MapboxAgentContext`, so that
+   * outbound Mapbox requests made during this process' lifetime (e.g. during a
+   * `connectedAndroidTest` run) carry an `agent/<id>` tag on the User-Agent header.
+   *
+   * This is a no-op whenever [BuildConfig.MAPBOX_AGENT] is empty, which is the default when the
+   * `mapbox.agent` Gradle property is not supplied, so regular `assembleRelease` / non-test
+   * builds of this app are unaffected.
+   */
+  private fun forwardMapboxAgentId() {
+    forwardAgentIdIfPresent(BuildConfig.MAPBOX_AGENT) { agentId ->
+      MapboxAgentContextFactory.getInstance().setMapboxAgentId(agentId)
     }
   }
 

--- a/app/src/test/java/com/mapbox/maps/testapp/AgentTelemetryForwardingTest.kt
+++ b/app/src/test/java/com/mapbox/maps/testapp/AgentTelemetryForwardingTest.kt
@@ -1,0 +1,33 @@
+package com.mapbox.maps.testapp
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AgentTelemetryForwardingTest {
+
+  @Test
+  fun `does not forward when agent id is empty`() {
+    var forwardedAgentId: String? = null
+    forwardAgentIdIfPresent("") { forwardedAgentId = it }
+    assertNull(
+      "Setter should not be invoked when BuildConfig.MAPBOX_AGENT is empty (the default when " +
+        "`-Pmapbox.agent` is not supplied)",
+      forwardedAgentId
+    )
+  }
+
+  @Test
+  fun `forwards agent id when non-empty`() {
+    var forwardedAgentId: String? = null
+    forwardAgentIdIfPresent("claude-code") { forwardedAgentId = it }
+    assertEquals("claude-code", forwardedAgentId)
+  }
+
+  @Test
+  fun `forwards agent id exactly once`() {
+    var invocationCount = 0
+    forwardAgentIdIfPresent("codex") { invocationCount++ }
+    assertEquals(1, invocationCount)
+  }
+}


### PR DESCRIPTION
### Summary of changes

Part of a broader effort to measure how much SDK traffic comes from AI coding agents (Claude Code, Codex, Cursor, etc.) rather than human-run apps, the Mapbox Common SDK is adding a way to tag outbound requests with an agent identifier. On Android that identifier has to be resolved at compile time, since there's no OS environment variable to read the way there is on desktop platforms. So it has to come in through a Gradle property and get forwarded into the running process by the app itself.

This PR wires that forwarding path through the sample/test app (`app` module) used for `connectedAndroidTest`:

- `app/build.gradle.kts` reads an optional `-Pmapbox.agent=<id>` Gradle property into `BuildConfig.MAPBOX_AGENT`, following the same `project.hasProperty(...)` pattern already used for `gitVersionCode` and `APP_KEYSTORE_PASSWORD`. Defaults to an empty string when the property isn't supplied, and the value is escaped before being embedded in generated source.
- `MapboxApplication.onCreate()` forwards `BuildConfig.MAPBOX_AGENT` into Common's `MapboxAgentContextFactory.getInstance().setMapboxAgentId(...)` via a small helper, guarded so it only fires when the value is non-empty.
- The forward/no-op logic itself lives in a pure, dependency-free function (`forwardAgentIdIfPresent` in `AgentTelemetryForwarding.kt`) with a unit test covering: empty id -> no-op, non-empty id -> forwarded, forwarded exactly once.

No agent detection or tagging logic lives in this repo, that all happens in Common. This change only forwards an already-resolved id into the running app process.

**Blocked on Common:** this depends on an unreleased Mapbox Common SDK change (mapbox-sdk PR #16363) that adds `com.mapbox.common.MapboxAgentContext` / `MapboxAgentContextFactory`. Until a Common build with those classes is published and this repo's dependency is bumped, `MapboxApplication.kt`'s import of `MapboxAgentContextFactory` won't resolve and the `app` module won't compile. That's why this PR is in draft; it can come out once the dependency lands.

I also wasn't able to verify this end-to-end in my sandbox: building Common from source to work around the above needs the Android NDK and access to Mapbox's private Maven registry, and neither was available there. What I could confirm: the Gradle property to BuildConfig wiring matches this module's existing conventions by inspection, and the forwarding guard has a plain JUnit test with no dependency on the new Common API, so it'll run as soon as the module compiles again.

### Verification once Common's change is available
- `./gradlew :app:testDebugUnitTest --tests "*AgentTelemetryForwardingTest*"` for the guard logic (should already pass once the module compiles).
- `./gradlew connectedAndroidTest -Pmapbox.agent=claude-code` on a device/emulator, confirming outbound Mapbox request User-Agents carry ` agent/claude-code`.
- Running `connectedAndroidTest` without `-Pmapbox.agent` (or a normal `assembleRelease`) should show zero change in behavior.

### User impact (optional)

None. This only affects the sample/test app's instrumentation, not the published SDK's public API or behavior.

## Pull request checklist:
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes. -- N/A, no visual changes.
 - [x] Write tests for all new functionality. If tests were not written, please explain why. -- unit test added for the forwarding guard; instrumented verification is blocked, see above.
 - [ ] Optimize code for java consumption (`@JvmOverloads`, `@file:JvmName`, etc). -- N/A, internal to the sample app only.
 - [ ] Add example if relevant. -- N/A.
 - [ ] Document any changes to public APIs. -- N/A, no public SDK API changes (`app` module is excluded from API validation).
 - [ ] Run `make update-api` -- N/A, no public API changes.
 - [x] Update CHANGELOG.md or use the label 'skip changelog' -- used the `skip changelog` label since this only touches the internal sample/test app.

Fixes: N/A -- implements one piece of a larger cross-SDK agent-traffic-measurement effort tracked internally.
